### PR TITLE
Fix Go module declaration

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/miguelpruivo/plugins_flutter_file_picker/go
+module github.com/miguelpruivo/flutter_file_picker/go
 
 go 1.13
 


### PR DESCRIPTION
The rename of this repository broke `go get` when the developer uses Go Modules to import this plugin (which is the default when using hover to setup a go-flutter project).

```
	github.com/miguelpruivo/flutter_file_picker/go: github.com/miguelpruivo/flutter_file_picker/go@v0.0.0-20191120004853-c99e22e95874: parsing go.mod:
	module declares its path as: github.com/miguelpruivo/plugins_flutter_file_picker/go
	        but was required as: github.com/miguelpruivo/flutter_file_picker/go
```

This PR fixes that by aligning the `module` declaration with the repo path.