### PR TITLE
fixes windows support

### DIFF
--- a/go/file_windows.go
+++ b/go/file_windows.go
@@ -1,8 +1,6 @@
 package file_picker
 
 import (
-	"strings"
-
 	"github.com/gen2brain/dlgs"
 	"github.com/pkg/errors"
 )
@@ -23,7 +21,7 @@ func fileFilter(method string, extensions []string, size int, isMulti bool) (str
 		for i = 0 ; i<size ; i++ {
 			  filters += `*.` + extensions[i] + `,`
 		}
-		filters += ")\x00*." + resolveType[1] + "\x00All Files (*.*)\x00*.*\x00\x00"
+		filters += ")"
 		return filters, nil
 	default:
 		return "", errors.New("unknown method")

--- a/go/file_windows.go
+++ b/go/file_windows.go
@@ -21,7 +21,7 @@ func fileFilter(method string, extensions []string, size int, isMulti bool) (str
 		var i int
 		var filters = "Files ("
 		for i = 0 ; i<size ; i++ {
-			  filters += `*.` extensions[i] + `,`
+			  filters += `*.` + extensions[i] + `,`
 		}
 		filters += ")\x00*." + resolveType[1] + "\x00All Files (*.*)\x00*.*\x00\x00"
 		return filters, nil

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/miguelpruivo/flutter_file_picker/go
+module github.com/marchellodev/flutter_file_picker/go
 
 go 1.13
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/marchellodev/flutter_file_picker/go
+module github.com/miguelpruivo/flutter_file_picker/go
 
 go 1.13
 


### PR DESCRIPTION
fixes

```
github.com/miguelpruivo/flutter_file_picker/go
# github.com/miguelpruivo/flutter_file_picker/go
/go/pkg/mod/github.com/miguelpruivo/flutter_file_picker/go@v0.0.0-20200417122615-c13124f9bb41/file_windows.go:24:22: syntax error: unexpected extensions at end of statement

```

and

```
github.com/marchellodev/flutter_file_picker/go
# github.com/marchellodev/flutter_file_picker/go
/go/pkg/mod/github.com/marchellodev/flutter_file_picker/go@v0.0.0-20200418121646-69eca38c82b7/file_windows.go:4:2: imported and not used: "strings"
/go/pkg/mod/github.com/marchellodev/flutter_file_picker/go@v0.0.0-20200418121646-69eca38c82b7/file_windows.go:26:26: undefined: resolveType
```
