### PR TITLE
import fix

### DIFF
--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' if (dart.library.html) 'dart:html';
 
 import 'file_picker_stub.dart' if (dart.library.io) 'file_picker_mobile.dart' if (dart.library.html) 'file_picker_web.dart';
 


### PR DESCRIPTION
when building for web, it fails on import mismatch, because file_picker.dart is taking File object from dart:io but your web implementation is taking it from dart:html. It is correctly declared in file_picker_stub.dart, but not here