### PR TITLE
fix conflict with flutter_image_cropper

### DIFF
--- a/ios/file_picker.podspec
+++ b/ios/file_picker.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'DKImagePickerController'
+  s.dependency 'DKImagePickerController/PhotoGallery'
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
This resolves the [issue](https://github.com/miguelpruivo/flutter_file_picker/issues/233#issuecomment-620264779) we discussed regarding [flutter_image_cropper](https://pub.dev/packages/image_cropper) and [DKImagePicker](https://github.com/zhangao0086/DKImagePickerController) both importing [TOCropViewController](https://github.com/TimOliver/TOCropViewController) and causing a conflict.

`DKImagePicker` exposes subspecs -- from those, I was able to select this package to only import the `PhotoGallery` subspec, which excludes `TOCropViewController`.

I'm new to this world of Pods, etc so if I messed anything up, be gentle 🤣 