### PR TITLE
Fix error when closing app on Android

### DIFF
--- a/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -283,10 +283,10 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
         this.activityBinding = null;
         this.lifecycle.removeObserver(this.observer);
         this.lifecycle = null;
+        this.delegate.setEventHandler(null);
         this.delegate = null;
         this.channel.setMethodCallHandler(null);
         this.channel = null;
-        this.delegate.setEventHandler(null);
         this.application.unregisterActivityLifecycleCallbacks(this.observer);
         this.application = null;
     }


### PR DESCRIPTION
Fixes error: java.lang.RuntimeException: Unable to destroy activity {package.name/package.name.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mr.flutter.plugin.filepicker.FilePickerDelegate.setEventHandler(io.flutter.plugin.common.EventChannel$EventSink)' on a null object reference