### PR TITLE
Web support serialize file object

### DIFF
--- a/file_picker_web/README.md
+++ b/file_picker_web/README.md
@@ -26,4 +26,4 @@ dependencies:
 Once you have the `file_picker_web` dependency in your pubspec, you should
 be able to use `package:file_picker` as normal.
 
-[1]: ../file_picker/file_picker
+[1]: ../file_picker

--- a/file_picker_web/example/lib/main.dart
+++ b/file_picker_web/example/lib/main.dart
@@ -1,5 +1,3 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html';
 import 'package:file_picker_web/file_picker_web.dart';
 import 'package:flutter/material.dart';
 
@@ -34,20 +32,41 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               Expanded(
                 child: _files.isNotEmpty
-                    ? ListView.separated(
-                        itemBuilder: (BuildContext context, int index) =>
-                            Text(_files[index].name),
-                        itemCount: _files.length,
-                        separatorBuilder: (_, __) => const Divider(
-                          thickness: 5.0,
-                        ),
-                      )
-                    : Center(
-                        child: Text(
-                          'Pick some files',
-                          textAlign: TextAlign.center,
-                        ),
+                  ? ListView.separated(
+                      itemBuilder: (BuildContext context, int index) {
+                        return Row(
+                            children: [
+                              Text(_files[index].name),
+                              Container(
+                                constraints: BoxConstraints(
+                                  maxWidth: 150,
+                                  maxHeight: 150,
+                                ),
+                                padding: EdgeInsets.all(8.0),
+                                child: _files[index].type.contains('image') 
+                                  ?  FutureBuilder<List<int>>(
+                                      future: _files[index].fileAsBytes(),
+                                      builder: (context, snapshot) => snapshot.hasData 
+                                        ?  Image.memory(snapshot.data) 
+                                        : CircularProgressIndicator()
+                                    )
+                                  : Icon(Icons.insert_drive_file, size: 100,),
+                              )
+                            ],
+                          );
+                      },  
+                      itemCount: _files.length,
+                      separatorBuilder: (_, __) => const Divider(
+                        thickness: 2.0,
                       ),
+                    )
+                  // ? Image.memory(image)
+                  : Center(
+                      child: Text(
+                        'Pick some files',
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
               ),
               Padding(
                 padding: const EdgeInsets.all(15.0),

--- a/file_picker_web/example/lib/main.dart
+++ b/file_picker_web/example/lib/main.dart
@@ -57,10 +57,9 @@ class _MyAppState extends State<MyApp> {
                       },  
                       itemCount: _files.length,
                       separatorBuilder: (_, __) => const Divider(
-                        thickness: 2.0,
+                        thickness: 3.0,
                       ),
                     )
-                  // ? Image.memory(image)
                   : Center(
                       child: Text(
                         'Pick some files',

--- a/file_picker_web/lib/file_picker_web.dart
+++ b/file_picker_web/lib/file_picker_web.dart
@@ -46,9 +46,9 @@ class FilePicker extends FilePickerPlatform {
     html.InputElement uploadInput = html.FileUploadInputElement();
     uploadInput.multiple = allowMultiple;
     uploadInput.accept = _fileType(type, allowedExtensions);
-    uploadInput.click();
     uploadInput.onChange
         .listen((event) => pickedFiles.complete(uploadInput.files));
+    uploadInput.click();
     return await pickedFiles.future;
   }
 

--- a/file_picker_web/lib/file_picker_web.dart
+++ b/file_picker_web/lib/file_picker_web.dart
@@ -3,27 +3,26 @@ import 'package:file_picker_platform_interface/file_picker_platform_interface.da
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'dart:html' as html;
 
-
-/// File Object wrapper 
-/// 
+/// File Object wrapper
+///
 /// [file]  `html.File` object that contains picked file
 class File {
   final html.File file;
 
   File({this.file});
-  
+
   String get name => file.name;
   String get type => file.type;
   int get size => file.size;
   String toString() => file.toString();
 
   /// Serialize `html.File` object
-  /// 
+  ///
   /// Returns a `<List<int>>`
   Future<List<int>> fileAsBytes() async {
     final Completer<List<int>> bytesFile = Completer<List<int>>();
-    final html.FileReader reader =  html.FileReader();
-    reader.onLoad.listen((event) => bytesFile.complete(reader.result) );
+    final html.FileReader reader = html.FileReader();
+    reader.onLoad.listen((event) => bytesFile.complete(reader.result));
     reader.readAsArrayBuffer(file);
     return await bytesFile.future;
   }
@@ -73,7 +72,7 @@ class FilePicker extends FilePickerPlatform {
     uploadInput.accept = _fileType(type, allowedExtensions);
     uploadInput.onChange.listen((event) {
       List<File> _files = [];
-      uploadInput.files.forEach((file) => _files.add(File(file: file)) );
+      uploadInput.files.forEach((file) => _files.add(File(file: file)));
       pickedFiles.complete(_files);
     });
     uploadInput.click();


### PR DESCRIPTION
Hi Miguel, i implemented the function requested in number 326, tested it with Chrome and Firefox with successful results.

Changes:
- Create a class to wrap the `html.File` named `File` with a method named `fileAsBytes` to request the serialized object.
- Change the type object from `html.File` to File in all plugin code.
- Add in the sample code an example of using the new function.

These changes allow to get the file at a low level and decouple it from the platform type, also to avoid importing the `dart: html` package outside the web plugin when the development is cross-platform.

Regards.
