### PR TITLE
Added File Picker Support for Android Q and above

### DIFF
--- a/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -87,9 +87,11 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                             final ArrayList<String> paths = new ArrayList<>();
                             while (currentItem < count) {
                                 final Uri currentUri = data.getClipData().getItemAt(currentItem).getUri();
-                                String path = FileUtils.getPath(currentUri, FilePickerDelegate.this.activity);
-                                if (path == null) {
+                                String path;
+                                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                                     path = FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, currentUri);
+                                }else{
+                                    path = FileUtils.getPath(currentUri, FilePickerDelegate.this.activity);
                                 }
                                 paths.add(path);
                                 Log.i(FilePickerDelegate.TAG, "[MultiFilePick] File #" + currentItem + " - URI: " + currentUri.getPath());
@@ -108,10 +110,11 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                             }
 
                             Log.i(FilePickerDelegate.TAG, "[SingleFilePick] File URI:" + uri.toString());
-                            fullPath = FileUtils.getPath(uri, FilePickerDelegate.this.activity);
 
-                            if (fullPath == null) {
+                            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                                 fullPath = type.equals("dir") ? FileUtils.getFullPathFromTreeUri(uri, activity) : FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, uri);
+                            } else {
+                                fullPath = FileUtils.getPath(uri, FilePickerDelegate.this.activity);
                             }
 
                             if (fullPath != null) {

--- a/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -110,7 +110,7 @@ public class FileUtils {
                     contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
                 }
 
-                final String selection = "_id=?";
+                final String selection = MediaStore.Images.Media._ID + "=?";
                 final String[] selectionArgs = new String[]{
                         split[1]
                 };
@@ -156,7 +156,7 @@ public class FileUtils {
     private static String getDataColumn(final Context context, final Uri uri, final String selection,
                                         final String[] selectionArgs) {
         Cursor cursor = null;
-        final String column = "_data";
+        final String column = MediaStore.Images.Media.DATA;
         final String[] projection = {
                 column
         };


### PR DESCRIPTION
Opening a PR for File Picker Support for devices with Android Q and above.
Implemented OS level check to get file path for the selected file.
Verified this implementation on devices with Android Q and below as well, it is working as expected.
#234 