### PR TITLE
Urgent Bug Fix for null path for file selection in Downloads folder for OS below Android Q

### DIFF
--- a/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/file_picker/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -92,6 +92,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                     path = FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, currentUri);
                                 } else {
                                     path = FileUtils.getPath(currentUri, FilePickerDelegate.this.activity);
+                                    if (path == null) {
+                                        path = FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, currentUri);
+                                    }
                                 }
                                 paths.add(path);
                                 Log.i(FilePickerDelegate.TAG, "[MultiFilePick] File #" + currentItem + " - URI: " + currentUri.getPath());
@@ -115,6 +118,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                 fullPath = type.equals("dir") ? FileUtils.getFullPathFromTreeUri(uri, activity) : FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, uri);
                             } else {
                                 fullPath = FileUtils.getPath(uri, FilePickerDelegate.this.activity);
+                                if (fullPath == null) {
+                                    fullPath = type.equals("dir") ? FileUtils.getFullPathFromTreeUri(uri, activity) : FileUtils.getUriFromRemote(FilePickerDelegate.this.activity, uri);
+                                }
                             }
 
                             if (fullPath != null) {


### PR DESCRIPTION
@miguelpruivo , please merge this PR which resolves the issue when the user selects a file from **Downloads** folder and the content uri is not able to resolve to a file path so in turn the file path is returned as null. (happens on devices below Android Q)

This PR resolves this issue, when the file path is null then it will create a file from uri and save it in app cache dir so the file will be accessible within the app.

Thanks!