### PR TITLE
Macos directory fix

### DIFF
--- a/file_picker/pubspec.yaml
+++ b/file_picker/pubspec.yaml
@@ -1,7 +1,7 @@
 name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extension filtering support.
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-version: 1.13.2
+version: 1.13.3
 
 dependencies:
   flutter:

--- a/file_picker_platform_interface/lib/method_channel_file_picker.dart
+++ b/file_picker_platform_interface/lib/method_channel_file_picker.dart
@@ -33,7 +33,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
   @override
   Future<String> getDirectoryPath() async {
     try {
-      return await _channel.invokeMethod('dir');
+      return await _channel.invokeMethod('dir', {});
     } on PlatformException catch (ex) {
       if (ex.code == "unknown_path") {
         print(


### PR DESCRIPTION
Getting a directory path was not working on osx for me so I changed the implementation from the go dlgs dependency to applescript like the file implementation that was working. I was able to confirm that with my changes directory picking works on osx, linux, and windows. This addresses issue #324 