### PR TITLE
fixed filereader exception when selecting multiple files

### DIFF
--- a/lib/src/file_picker_web.dart
+++ b/lib/src/file_picker_web.dart
@@ -38,29 +38,29 @@ class FilePickerWeb extends FilePicker {
 
     uploadInput.onChange.listen((e) {
       final files = uploadInput.files;
-      final reader = html.FileReader();
-
       List<PlatformFile> pickedFiles = [];
 
-      reader.onLoadEnd.listen((e) {
-        final Uint8List bytes =
-            Base64Decoder().convert(reader.result.toString().split(",").last);
-
-        pickedFiles.add(
-          PlatformFile(
-            name: uploadInput.value.replaceAll('\\', '/'),
-            path: uploadInput.value,
-            size: bytes.length ~/ 1024,
-            bytes: withData ? bytes : null,
-          ),
-        );
-
-        if (pickedFiles.length >= files.length) {
-          filesCompleter.complete(pickedFiles);
-        }
-      });
-
       files.forEach((element) {
+        final reader = html.FileReader();
+
+        reader.onLoadEnd.listen((e) {
+          final Uint8List bytes =
+              Base64Decoder().convert(reader.result.toString().split(",").last);
+
+          pickedFiles.add(
+            PlatformFile(
+              name: uploadInput.value.replaceAll('\\', '/'),
+              path: uploadInput.value,
+              size: bytes.length ~/ 1024,
+              bytes: withData ? bytes : null,
+            ),
+          );
+
+          if (pickedFiles.length >= files.length) {
+            filesCompleter.complete(pickedFiles);
+          }
+        });
+
         reader.readAsDataUrl(element);
       });
     });


### PR DESCRIPTION
Currently, the web version is not working for multiple selected files.

On Chrome/MacOS the following exception was thrown: "Failed to execute 'readAsDataURL' on 'FileReader': The object is already busy reading Blobs."

My PR fixes the issue by creating a new FileReader for each selected file. 

Also refer to: https://developer.mozilla.org/de/docs/Web/API/FileReader/readAsDataURL#Example_reading_multiple_files

Otherwise thanks for a great package :)