### PR TITLE
Fix bug for directory picking on Linux: drop file type filter

### DIFF
--- a/go/file_linux.go
+++ b/go/file_linux.go
@@ -39,7 +39,7 @@ func fileDialog(title string, filter string) (string, error) {
 }
 
 func dirDialog(title string) (string, error) {
-	dirPath, _, err := dlgs.File(title, `*.*`, true)
+	dirPath, _, err := dlgs.File(title, "", true)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open dialog picker")
 	}


### PR DESCRIPTION
This pull request fixes a bug which I came across on Linux (this bug existed already before the new major release 2.0.0).

Previously, the file filter argument was set to `*.*` which somehow led to the effect that all directories are displayed as not clickable / selectable in the directory picker dialog on Linux (Ubuntu 19). This effect can be observed on the screenshot below. All directories are greyed-out and cannot be selected (except the bookmarks / default directories on the left side):

![previously](https://user-images.githubusercontent.com/9049899/93002228-cb3bff00-f535-11ea-802f-cfddffb5e54c.png)


As stated in the docs of [gen2brain/dlgs](https://github.com/gen2brain/dlgs/blob/master/file_linux.go), setting the file filter to a blank string will display all file types:

```go
// File displays a file dialog, returning the selected file or directory, a bool for success, and an
// error if it was unable to display the dialog. Filter is a string that determines 
// which extensions should be displayed for the dialog. Separate multiple file 
// extensions by spaces and use "*.extension" format for cross-platform compatibility, e.g. "*.png *.jpg".
// A blank string for the filter will display all file types.
func File(title, filter string, directory bool) (string, bool, error) {
   ...
}
```

I tested it on Ubuntu 19 and it works. Now, the directory picker dialog allows to select / click on directories. Also, the filter on the bottom right vanished:
![updated](https://user-images.githubusercontent.com/9049899/93002239-f45c8f80-f535-11ea-9502-9501df2f4e64.png)
