### PR TITLE
Directory access is not available on iOS 12 or lower

### DIFF
--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -71,7 +71,12 @@
     }
     
     if([call.method isEqualToString:@"dir"]) {
-        [self resolvePickDocumentWithMultiPick:NO pickDirectory:YES];
+        if (@available(iOS 13, *)) {
+            [self resolvePickDocumentWithMultiPick:NO pickDirectory:YES];
+        } else {
+            _result([self getDocumentDirectory]);
+            _result = nil;
+        }
         return;
     }
     
@@ -97,7 +102,11 @@
         result(FlutterMethodNotImplemented);
         _result = nil;
     }
-    
+}
+
+- (NSString*)getDocumentDirectory {
+    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    return paths.firstObject;
 }
 
 #pragma mark - Resolvers


### PR DESCRIPTION
The getDirectoryPath() doesn't work when access to the directory is not available.
This PR changes to use NSDocumentDirectory on iOS 12 or lower.

https://developer.apple.com/documentation/uikit/view_controllers/providing_access_to_directories