### PR TITLE
feat: pass multiple types of events from channel

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,12 +28,19 @@ android {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
-      dependencies {
+
+    dependencies {
         implementation 'androidx.core:core:1.0.2'
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileEvent.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileEvent.java
@@ -1,0 +1,21 @@
+package com.mr.flutter.plugin.filepicker;
+
+import java.util.HashMap;
+
+public class FileEvent {
+
+    final String type;
+    final Object value;
+
+    public FileEvent(String type, Object value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public HashMap<String, Object> toMap() {
+        final HashMap<String, Object> data = new HashMap<>();
+        data.put("type", type);
+        data.put("value", value);
+        return data;
+    }
+}

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileEventTypes.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileEventTypes.java
@@ -1,0 +1,6 @@
+package com.mr.flutter.plugin.filepicker;
+
+public class FileEventTypes {
+    public static String STATUS = "STATUS";
+    public static String ORIGINAL_CONTENT_URL = "ORIGINAL_CONTENT_URL";
+}

--- a/ios/Classes/FileEvent.h
+++ b/ios/Classes/FileEvent.h
@@ -1,0 +1,10 @@
+@interface FileEvent : NSObject
+
+@property(nonatomic, strong) NSString *type;
+@property(nonatomic, strong) NSObject *value;
+
+- (instancetype)init:(NSString *)type andValue:(NSObject *)value;
+
+- (NSDictionary *)toData;
+
+@end

--- a/ios/Classes/FileEvent.m
+++ b/ios/Classes/FileEvent.m
@@ -1,0 +1,23 @@
+#import "FileEvent.h"
+
+@implementation FileEvent
+
+- (instancetype) init: (NSString *)type andValue: (NSObject*)value {
+
+    self = [super init];
+
+    if (self) {
+        self.type = type;
+        self.value = value;
+    }
+    return self;
+}
+
+- (NSDictionary *)toData {
+    NSMutableDictionary * data = [[NSMutableDictionary alloc] init];
+    [data setValue:self.type forKey:@"type"];
+    [data setValue:self.value forKey:@"value"];
+    return data;
+}
+
+@end

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -61,6 +61,7 @@ abstract class FilePicker extends PlatformInterface {
     FileType type = FileType.any,
     List<String> allowedExtensions,
     Function(FilePickerStatus) onFileLoading,
+    Function(List<String>) onOriginalUrls,
     bool allowCompression,
     bool allowMultiple = false,
     bool withData,

--- a/lib/src/platform_event.dart
+++ b/lib/src/platform_event.dart
@@ -1,0 +1,38 @@
+enum PlatformEventType {
+  STATUS,
+  ORIGINAL_CONTENT_URL,
+  UNKNOWN,
+}
+
+class PlatformEvent {
+  const PlatformEvent({
+    this.type,
+    this.value,
+  });
+
+  PlatformEvent.fromMap(Map data)
+      : this.type = determineEventType(data['type']),
+        this.value = data['value'];
+
+  static PlatformEventType determineEventType(dynamic type) {
+    if (type == null) {
+      return PlatformEventType.UNKNOWN;
+    }
+
+    if (type is String) {
+      switch (type) {
+        case 'STATUS':
+          return PlatformEventType.STATUS;
+        case 'ORIGINAL_CONTENT_URL':
+          return PlatformEventType.ORIGINAL_CONTENT_URL;
+        default:
+          return PlatformEventType.UNKNOWN;
+      }
+    }
+
+    return PlatformEventType.UNKNOWN;
+  }
+
+  final PlatformEventType type;
+  final dynamic value;
+}


### PR DESCRIPTION
Need to use event channel to communicate between native code and dart
but existing implementation expected only a boolean value to be passed.

This creates a file event which translates to a platform event. The
setup allows for future work related to passing more events. This commit
includes the addition of the source paths as soon as they are available
as they may be usable more immediately than the copied files are in the
event of large files.

Signed-off-by: Nick Campbell <nicholas.j.campbell@gmail.com>