### PR TITLE
type 'String' is not a subtype of type 'List<dynamic>' in desktop 

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/miguelpruivo/flutter_file_picker/go
+module github.com/FakenMaster/flutter_file_picker/go
 
 go 1.13
 

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -90,8 +90,11 @@ class FilePickerIO extends FilePicker {
       if (result is String) {
         return FilePickerResult([PlatformFile(path: result)]);
       }
-      return FilePickerResult(
-          result.map((file) => PlatformFile.fromMap(file)).toList());
+      if (result is List) {
+        return FilePickerResult(
+            result.map((file) => PlatformFile.fromMap(file)).toList());
+      }
+      return null;
     } on PlatformException catch (e) {
       print('[$_tag] Platform exception: $e');
       rethrow;

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -76,7 +76,7 @@ class FilePickerIO extends FilePicker {
             );
       }
 
-      final result = await _channel.invokeListMethod(type, {
+      final result = await _channel.invokeMethod(type, {
         'allowMultipleSelection': allowMultipleSelection,
         'allowedExtensions': allowedExtensions,
         'allowCompression': allowCompression,
@@ -87,8 +87,9 @@ class FilePickerIO extends FilePicker {
         return null;
       }
 
-      print('result类型:${result.runtimeType},result:$result');
-      
+      if (result is String) {
+        return FilePickerResult([PlatformFile(path: result)]);
+      }
       return FilePickerResult(
           result.map((file) => PlatformFile.fromMap(file)).toList());
     } on PlatformException catch (e) {

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -76,7 +76,7 @@ class FilePickerIO extends FilePicker {
             );
       }
 
-      final List<Map> result = await _channel.invokeListMethod(type, {
+      final result = await _channel.invokeListMethod(type, {
         'allowMultipleSelection': allowMultipleSelection,
         'allowedExtensions': allowedExtensions,
         'allowCompression': allowCompression,
@@ -87,6 +87,8 @@ class FilePickerIO extends FilePicker {
         return null;
       }
 
+      print('result类型:${result.runtimeType},result:$result');
+      
       return FilePickerResult(
           result.map((file) => PlatformFile.fromMap(file)).toList());
     } on PlatformException catch (e) {


### PR DESCRIPTION
# Describe the bug
when using file_picker in mac or windows desktop with go_flutter_desktop, choosing a file causes the error: type 'String' is not a subtype of type 'List' in type cast.

# Issue details
Platform: Mac, Windows

# Error Log
flutter: [MethodChannelFilePicker] Unsupported operation. Method not found. The exception thrown was: type 'String' is not a subtype of type 'List' in type cast
[ERROR:flutter/lib/ui/ui_dart_state.cc(166)] Unhandled Exception: type 'String' is not a subtype of type 'List' in type cast
#0 MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:161:41)

#1 MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:334:12)
#2 MethodChannel.invokeListMethod (package:flutter/src/services/platform_channel.dart:347:40)
#3 FilePickerIO._getPath (package:file_picker/src/file_picker_io.dart:79:47)
#4 FilePickerIO.pickFiles (package:file_picker/src/file_picker_io.dart:29:7)
#5 _HomePageState.filePicker (package:rename_lanhu/home_page.dart:230:57)
#6 _HomePageState.build... (package:rename_lanhu/home_page.dart:107:59)
#7 _InkResponseState._handleTap (package:flutter/src/material/ink_well.dart:992:19)
#8 _InkResponseState.build. (package:flutter/src/material/ink_well.dart:1098:38)
#9 GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:184:24)
#10 TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:524:11)
#11 BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:284:5)
#12 BaseTapGestureRecognizer.handlePrimaryPointer (package:flutter/src/gestures/tap.dart:219:7)
#13 PrimaryPointerGestureRecognizer.handleEvent (package:flutter/src/gestures/recognizer.dart:477:9)
#14 PointerRouter._dispatch (package:flutter/src/gestures/pointer_router.dart:78:12)
#15 PointerRouter._dispatchEventToRoutes. (package:flutter/src/gestures/pointer_router.dart:124:9)
#16 _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:377:8)
#17 PointerRouter._dispatchEventToRoutes (package:flutter/src/gestures/pointer_router.dart:122:18)
#18 PointerRouter.route (package:flutter/src/gestures/pointer_router.dart:108:7)
#19 GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:220:19)
#20 GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:200:22)
#21 GestureBinding._handlePointerEvent (package:flutter/src/gestures/binding.dart:158:7)
#22 GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:104:7)
#23 GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:88:7)
#24 _rootRunUnary (dart:async/zone.dart:1206:13)
#25 _CustomZone.runUnary (dart:async/zone.dart:1100:19)
#26 _CustomZone.runUnaryGuarded (dart:async/zone.dart:1005:7)
#27 _invoke1 (dart:ui/hooks.dart:267:10)
#28 _dispatchPointerDataPacket (dart:ui/hooks.dart:176:5)

# Flutter Version details
[✓] Flutter (Channel stable, 1.22.2, on Mac OS X 10.15.3 19D76, locale zh-Hans-CN)
[✓] Xcode - develop for iOS and macOS (Xcode 11.3.1)
[!] Android Studio (version 4.1)
✗ Flutter plugin not installed; this adds Flutter specific functionality.
✗ Dart plugin not installed; this adds Dart specific functionality.
[✓] VS Code (version 1.50.1)
[!] Connected device
! No devices available

# Solutions:
The problem only occurs in desktop like mac or windows(haven't tested in linux).
In library file file_picker_io.dart [line79](https://github.com/miguelpruivo/flutter_file_picker/blob/master/lib/src/file_picker_io.dart), 
```
final List<Map> result = await _channel.invokeListMethod(type, {
        'allowMultipleSelection': allowMultipleSelection,
        'allowedExtensions': allowedExtensions,
        'allowCompression': allowCompression,
        'withData': withData,
      });
```
when running in desktop, _channel.invokeListMethod returns the path of file(String type instead of List<Map>).

So my solution is changing the method to invokeMethod then check what type result is.
```
// ... other contents including in file_picker_io.dart
final result = await _channel.invokeMethod(type, {
        'allowMultipleSelection': allowMultipleSelection,
        'allowedExtensions': allowedExtensions,
        'allowCompression': allowCompression,
        'withData': withData,
      });

      if (result == null) {
        return null;
      }

      if (result is String) {
        return FilePickerResult([PlatformFile(path: result)]);
      }
      if (result is List) {
        return FilePickerResult(
            result.map((file) => PlatformFile.fromMap(file)).toList());
      }
      return null;
```