### PR TITLE
Add the capability of retrieving 'lost' files after activity being de…

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerCache.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerCache.java
@@ -1,0 +1,118 @@
+package com.mr.flutter.plugin.filepicker;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+class FilePickerCache {
+
+    static final String MAP_KEY_PATHS = "paths";
+    static final String MAP_KEY_ERROR_CODE = "errorCode";
+    static final String MAP_KEY_ERROR_MESSAGE = "errorMessage";
+
+    private static final String FLUTTER_FILE_PICKER_FILES_PATH_KEY =
+            "flutter_file_picker_files_path";
+    private static final String SHARED_PREFERENCE_ERROR_CODE_KEY = "flutter_file_picker_error_code";
+    private static final String SHARED_PREFERENCE_ERROR_MESSAGE_KEY =
+            "flutter_file_picker_error_message";
+    private static final String SHARED_PREFERENCE_LOAD_DATA_KEY =
+            "flutter_file_picker_load_data";
+    private static final String SHARED_PREFERENCE_TYPE_KEY =
+            "flutter_file_picker_type";
+
+    static final String SHARED_PREFERENCES_NAME = "flutter_file_picker_shared_preference";
+
+    final private SharedPreferences prefs;
+
+    FilePickerCache(Context context) {
+        prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+    public void saveLoadDataToMemory(boolean loadDataToMemory) {
+        prefs.edit().putBoolean(SHARED_PREFERENCE_LOAD_DATA_KEY, loadDataToMemory).apply();
+    }
+
+    Boolean retrieveLoadDataToMemory() {
+        return prefs.getBoolean(SHARED_PREFERENCE_LOAD_DATA_KEY, false);
+    }
+
+    public void saveType(String type) {
+        prefs.edit().putString(SHARED_PREFERENCE_TYPE_KEY, type).apply();
+    }
+
+    String retrieveType() {
+        return prefs.getString(SHARED_PREFERENCE_TYPE_KEY, "");
+    }
+
+    void saveResult(
+            @Nullable Intent data,
+            @Nullable String errorCode,
+            @Nullable String errorMessage
+    ) {
+        SharedPreferences.Editor editor = prefs.edit();
+        if (data != null) {
+          HashSet<String> uris = new HashSet<String>();
+          if (data.getClipData() != null) {
+                final int count = data.getClipData().getItemCount();
+                int currentItem = 0;
+                while (currentItem < count) {
+                    final Uri currentUri = data.getClipData().getItemAt(currentItem).getUri();
+                    uris.add(currentUri.toString());
+                    currentItem++;
+                }
+            }
+            if (data.getData() != null) {
+                Uri uri = data.getData();
+                uris.add(uri.toString());
+            }
+
+            if (!uris.isEmpty()) {
+              editor.putStringSet(FLUTTER_FILE_PICKER_FILES_PATH_KEY, uris);
+            } else {
+              saveResult(null,"unknown_path", "Failed to retrieve path.");
+            }
+        }
+        if (errorCode != null) {
+            editor.putString(SHARED_PREFERENCE_ERROR_CODE_KEY, errorCode);
+        }
+        if (errorMessage != null) {
+            editor.putString(SHARED_PREFERENCE_ERROR_MESSAGE_KEY, errorMessage);
+        }
+        editor.apply();
+    }
+
+    Map<String, Object> getCacheMap() {
+
+        Map<String, Object> resultMap = new HashMap<>();
+
+        if (prefs.contains(FLUTTER_FILE_PICKER_FILES_PATH_KEY)) {
+            final Set<String> paths = prefs.getStringSet(FLUTTER_FILE_PICKER_FILES_PATH_KEY, new HashSet<String>());
+            resultMap.put(MAP_KEY_PATHS, paths);
+        }
+
+        if (prefs.contains(SHARED_PREFERENCE_ERROR_CODE_KEY)) {
+            final String errorCodeValue = prefs.getString(SHARED_PREFERENCE_ERROR_CODE_KEY, "");
+            resultMap.put(MAP_KEY_ERROR_CODE, errorCodeValue);
+            if (prefs.contains(SHARED_PREFERENCE_ERROR_MESSAGE_KEY)) {
+                final String errorMessageValue = prefs.getString(SHARED_PREFERENCE_ERROR_MESSAGE_KEY, "");
+                resultMap.put(MAP_KEY_ERROR_MESSAGE, errorMessageValue);
+            }
+        }
+
+        return resultMap;
+    }
+
+
+    void clear() {
+        prefs.edit().clear().apply();
+    }
+}

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -97,6 +97,9 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
 
         @Override
         public void onActivityStopped(final Activity activity) {
+            if (thisActivity == activity) {
+                delegate.saveStateBeforeResult();
+            }
         }
     }
 
@@ -151,6 +154,11 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
 
         if (call.method != null && call.method.equals("clear")) {
             result.success(FileUtils.clearCache(activity.getApplicationContext()));
+            return;
+        }
+
+        if (call.method != null && call.method.equals("retrieve")) {
+            this.delegate.retrieveLostFiles(result);
             return;
         }
 

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -22,6 +22,10 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   void initState() {
     super.initState();
     _controller.addListener(() => _extension = _controller.text);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _retrieveLostFiles();
+    });
   }
 
   void _openFileExplorer() async {
@@ -47,6 +51,21 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       _loadingPath = false;
       _fileName =
           _paths != null ? _paths!.map((e) => e.name).toString() : '...';
+    });
+  }
+
+  void _retrieveLostFiles() async {
+    try {
+      final lostData = (await FilePicker.platform.retrieveLostData());
+      _paths = lostData.result?.files;
+    } on PlatformException catch (e) {
+      print("Unsupported operation" + e.toString());
+    } catch (ex) {
+      print(ex);
+    }
+    if (!mounted) return;
+    setState(() {
+      _fileName = _paths != null ? _paths.map((e) => e.name).toString() : '...';
     });
   }
 

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -1,5 +1,7 @@
 library file_picker;
 
+export './src/file_picker_result.dart';
 export './src/file_picker.dart';
 export './src/platform_file.dart';
 export './src/file_picker_result.dart';
+export './src/lost_data.dart';

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:file_picker/src/file_picker_io.dart';
 import 'package:file_picker/src/file_picker_linux.dart';
 import 'package:file_picker/src/file_picker_macos.dart';
+import 'package:file_picker/src/lost_data.dart';
 import 'package:file_picker/src/windows/stub.dart'
     if (dart.library.io) 'package:file_picker/src/windows/file_picker_windows.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -92,6 +93,8 @@ abstract class FilePicker extends PlatformInterface {
   /// For more information, check the [API documentation](https://github.com/miguelpruivo/flutter_file_picker/wiki/api).
   ///
   /// Returns `null` if aborted.
+  /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
+  /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
     FileType type = FileType.any,
@@ -126,4 +129,21 @@ abstract class FilePicker extends PlatformInterface {
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
   Future<String?> getDirectoryPath({String? dialogTitle}) async =>
       throw UnimplementedError('getDirectoryPath() has not been implemented.');
+
+  /// Retrieve the lost files when [pickFiles] failed because the  MainActivity is destroyed. (Android only)
+  ///
+  /// Files can be lost if the MainActivity is destroyed. And there is no guarantee that the MainActivity is always alive.
+  /// Call this method to retrieve the lost data and process the data according to your APP's business logic.
+  ///
+  /// Returns a [LostData] if successfully retrieved the lost data. The [LostData] can represent either a
+  /// successful file selection, or a failure.
+  ///
+  /// Calling this on a non-Android platform will throw [UnimplementedError] exception.
+  ///
+  /// See also:
+  /// * [LostData], for what's included in the response.
+  /// * [Android Activity Lifecycle](https://developer.android.com/reference/android/app/Activity.html), for more information on MainActivity destruction.
+  Future<LostData> retrieveLostData() {
+    throw UnimplementedError('retrieveLostData() has not been implemented.');
+  }
 }

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -118,4 +118,49 @@ class FilePickerIO extends FilePicker {
       rethrow;
     }
   }
+
+  @override
+  Future<LostData> retrieveLostData() async {
+    try {
+      final Map<String, dynamic>? result =
+          await _channel.invokeMapMethod<String, dynamic>('retrieve');
+
+      if (result == null) {
+        return LostData.empty();
+      }
+
+      assert(result.containsKey('filePickerResult') ^
+          result.containsKey('errorCode'));
+
+      PlatformException? exception;
+      if (result.containsKey('errorCode')) {
+        exception = PlatformException(
+          code: result['errorCode'],
+          message: result['errorMessage'],
+        );
+      }
+
+      FilePickerResult? filePickerResult;
+      if (result.containsKey('filePickerResult')) {
+        final list = result['filePickerResult'];
+        filePickerResult = FilePickerResult(
+          list
+              ?.map(
+                  (file) => PlatformFile.fromMap(file.cast<String, dynamic>()))
+              ?.toList()
+              ?.cast<PlatformFile>(),
+        );
+      }
+      return LostData(
+        result: filePickerResult,
+        exception: exception,
+      );
+    } on PlatformException catch (e) {
+      print('[$_tag] Platform exception: $e');
+      rethrow;
+    } catch (e) {
+      print('[$_tag] Unsupported operation. The exception thrown was: $e');
+      rethrow;
+    }
+  }
 }

--- a/lib/src/lost_data.dart
+++ b/lib/src/lost_data.dart
@@ -1,0 +1,41 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
+
+/// The response object of [FilePicker.retrieveLostData].
+///
+/// Only applies to Android.
+/// See also:
+/// * [FilePicker.retrieveLostData] for more details on retrieving lost data.
+class LostData {
+  /// Creates an instance with the given [result] and [exception]. Any of
+  /// the params may be null, but this is never considered to be empty.
+  LostData({this.result, this.exception});
+
+  /// Initializes an instance with all member params set to null and considered
+  /// to be empty.
+  LostData.empty()
+      : result = null,
+        exception = null,
+        _empty = true;
+
+  /// Whether it is an empty response.
+  ///
+  /// An empty response should have [file], [exception] and [type] to be null.
+  bool get isEmpty => _empty;
+
+  /// The file that was lost in a previous [pickFiles] call due to MainActivity being destroyed.
+  ///
+  /// Can be null if [exception] exists.
+  final FilePickerResult? result;
+
+  /// The exception of the last [pickFiles].
+  ///
+  /// If the last [pickFiles] threw some exception before the MainActivity destruction, this variable keeps that
+  /// exception.
+  /// You should handle this exception as if the [pickFiles] got an exception when the MainActivity was not destroyed.
+  ///
+  /// Note that it is not the exception that caused the destruction of the MainActivity.
+  final PlatformException? exception;
+
+  bool _empty = false;
+}


### PR DESCRIPTION
Based on [image_picker](https://pub.dev/packages/image_picker) plugin, I've added the same logic to retrieve 'lost' files selection after activity destruction on Android, This can occur by different reasons and I've seen it happening a lot on huawei and xiaomi devices.

After calling `pickFiles` if the app `Activity` is destroyed, the user can retrieve the "lost selection" by calling `retrieveLostData'. I'm using this functionality in some apps and maybe it can be useful to others as well.