### PR TITLE
Fix flutter web warning in generated_plugin_registrant.dart

### DIFF
--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -3,3 +3,4 @@ library file_picker;
 export './src/file_picker.dart';
 export './src/platform_file.dart';
 export './src/file_picker_result.dart';
+export './src/file_picker_web.dart';


### PR DESCRIPTION
#493 Fix flutter web warning "Don't import implementation files from another package."