### PR TITLE
Fix null PlatformFIle.extension error when called on Web

### DIFF
--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -32,5 +32,5 @@ class PlatformFile {
   final int size;
 
   /// File extension for this file.
-  String get extension => path?.split('.')?.last;
+  String get extension => name?.split('.')?.last;
 }


### PR DESCRIPTION
Multiple people encountered an error where calling PlatformFile.extension returns a null, like issue #491 

I've created a simple fix for this one. Hope it will help other struggling to create a fix for this.
