### PR TITLE
Added withReadStream option to load a file in chunks (useful for large files which don't fit in RAM)

### DIFF
--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -49,6 +49,9 @@ abstract class FilePicker extends PlatformInterface {
   /// If [withData] is set, picked files will have its byte data immediately available on memory as [Uint8List]
   /// which can be useful if you are picking it for server upload or similar.
   ///
+  /// If [withReadStream] is set, picked files will have its byte data available as a [Stream<List<int>>]
+  /// which can be useful for uploading and processing large files.
+  ///
   /// If you want to track picking status, for example, because some files may take some time to be
   /// cached (particularly those picked from cloud providers), you may want to set [onFileLoading] handler
   /// that will give you the current status of picking.
@@ -64,6 +67,7 @@ abstract class FilePicker extends PlatformInterface {
     bool allowCompression,
     bool allowMultiple = false,
     bool withData,
+    bool withReadStream,
   }) async =>
       throw UnimplementedError('pickFiles() has not been implemented.');
 

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -91,17 +91,17 @@ class FilePickerIO extends FilePicker {
         return null;
       }
 
-      final platformFiles = <PlatformFile>[];
+      final List<PlatformFile> platformFiles = <PlatformFile>[];
 
       for (final platformFileMap in result) {
-        if (withReadStream) {
-          platformFiles.add(PlatformFile.fromMap(
+        platformFiles.add(
+          PlatformFile.fromMap(
             platformFileMap,
-            readStream: File(platformFileMap['path']).openRead(),
-          ));
-        } else {
-          platformFiles.add(PlatformFile.fromMap(platformFileMap));
-        }
+            readStream: withReadStream
+                ? File(platformFileMap['path']).openRead()
+                : null,
+          ),
+        );
       }
 
       return FilePickerResult(platformFiles);

--- a/lib/src/file_picker_web.dart
+++ b/lib/src/file_picker_web.dart
@@ -12,7 +12,7 @@ class FilePickerWeb extends FilePicker {
   Element _target;
   final String _kFilePickerInputsDomId = '__file_picker_web-file-input';
 
-  final int readStreamChunkSize = 1000 * 1000; // 1 MB
+  final int _readStreamChunkSize = 1000 * 1000; // 1 MB
 
   static final FilePickerWeb platform = FilePickerWeb._();
 
@@ -149,14 +149,14 @@ class FilePickerWeb extends FilePicker {
 
     int start = 0;
     while (start < file.size) {
-      final end = start + readStreamChunkSize > file.size
+      final end = start + _readStreamChunkSize > file.size
           ? file.size
-          : start + readStreamChunkSize;
+          : start + _readStreamChunkSize;
       final blob = file.slice(start, end);
       reader.readAsArrayBuffer(blob);
       await reader.onLoad.first;
       yield reader.result;
-      start += readStreamChunkSize;
+      start += _readStreamChunkSize;
     }
   }
 }

--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 class PlatformFile {
@@ -5,10 +6,11 @@ class PlatformFile {
     this.path,
     this.name,
     this.bytes,
+    this.readStream,
     this.size,
   });
 
-  PlatformFile.fromMap(Map data)
+  PlatformFile.fromMap(Map data, {this.readStream})
       : this.path = data['path'],
         this.name = data['name'],
         this.bytes = data['bytes'],
@@ -27,6 +29,9 @@ class PlatformFile {
   /// Byte data for this file. Particurlarly useful if you want to manipulate its data
   /// or easily upload to somewhere else.
   final Uint8List bytes;
+
+  /// File content as stream
+  final Stream<List<int>> readStream;
 
   /// The file size in KB.
   final int size;


### PR DESCRIPTION
Should work with Flutter Web and IO. Also see #465
Can for example be used with a multipart file upload.