### PR TITLE
[Android][Bug fix]use long instead of int to represent no. of bytes  when parsing file sizes

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
@@ -8,10 +8,10 @@ public class FileInfo {
 
     final String path;
     final String name;
-    final int size;
+    final long size;
     final byte[] bytes;
 
-    public FileInfo(String path, String name, int size, byte[] bytes) {
+    public FileInfo(String path, String name, long size, byte[] bytes) {
         this.path = path;
         this.name = name;
         this.size = size;
@@ -22,7 +22,7 @@ public class FileInfo {
 
         private String path;
         private String name;
-        private int size;
+        private long size;
         private byte[] bytes;
 
         public Builder withPath(String path){
@@ -35,7 +35,7 @@ public class FileInfo {
             return this;
         }
 
-        public Builder withSize(int size){
+        public Builder withSize(long size){
             this.size = size;
             return this;
         }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -173,7 +173,7 @@ public class FileUtils {
         fileInfo
                 .withPath(path)
                 .withName(fileName)
-                .withSize(Integer.parseInt(String.valueOf(file.length())));
+                .withSize(Long.parseLong(String.valueOf(file.length())));
 
         return fileInfo.build();
     }


### PR DESCRIPTION
On Android file_picker would crash if the number of bytes for a file exceeds the JAVA integer limit (2^32 bytes) so with this PR the limit should be at 2^64 bytes or the JAVA long limit.

Minimum steps to reproduce

```dart
Future<void> pick() async {
...
await FilePicker.platform.pickFiles();
...
}
```
Then once the picker launches pick a file with more than 2.1 GB, file_picker will crash with java.lang.NumberFormatException