### PR TITLE
Utilize a Gallery-Based picker for Android for Images

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -197,13 +197,17 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         if (type.equals("dir")) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         } else {
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
+            if (type.equals("image/*")) {
+                intent = new Intent(Intent.ACTION_PICK, android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+            } else {
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+            }
             final Uri uri = Uri.parse(Environment.getExternalStorageDirectory().getPath() + File.separator);
             Log.d(TAG, "Selected type " + type);
             intent.setDataAndType(uri, this.type);
             intent.setType(this.type);
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection);
-            intent.addCategory(Intent.CATEGORY_OPENABLE);
 
             if (type.contains(",")) {
                 allowedExtensions = type.split(",");


### PR DESCRIPTION
References #661 where we can use the Gallery picker instead of the file manager to pick images on Android, which makes the process to pick an image more streamlined as a user won't have to navigate through files with a similar gallery presented through the MediaStore API.

I've tested the changes and made sure normal picking as well as image picking, both in single and multiple items work.

Let me know if anything needs to be changed!