### PR TITLE
Allow not load files into memory but get file by Stream.

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
@@ -7,12 +7,14 @@ import java.util.HashMap;
 public class FileInfo {
 
     final String path;
+    final Uri uri;
     final String name;
     final long size;
     final byte[] bytes;
 
-    public FileInfo(String path, String name, long size, byte[] bytes) {
+    public FileInfo(String path, Uri uri, String name, long size, byte[] bytes) {
         this.path = path;
+        this.uri = uri;
         this.name = name;
         this.size = size;
         this.bytes = bytes;
@@ -22,31 +24,37 @@ public class FileInfo {
 
         private String path;
         private String name;
+        private Uri uri;
         private long size;
         private byte[] bytes;
 
-        public Builder withPath(String path){
+        public Builder withPath(String path) {
             this.path = path;
             return this;
         }
 
-        public Builder withName(String name){
+        public Builder withUri(Uri uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder withName(String name) {
             this.name = name;
             return this;
         }
 
-        public Builder withSize(long size){
+        public Builder withSize(long size) {
             this.size = size;
             return this;
         }
 
-        public Builder withData(byte[] bytes){
+        public Builder withData(byte[] bytes) {
             this.bytes = bytes;
             return this;
         }
 
         public FileInfo build() {
-            return new FileInfo(this.path, this.name, this.size, this.bytes);
+            return new FileInfo(this.path, uri, this.name, this.size, this.bytes);
         }
     }
 
@@ -56,6 +64,7 @@ public class FileInfo {
         data.put("path", path);
         data.put("name", name);
         data.put("size", size);
+        data.put("uri", uri.toString());
         data.put("bytes", bytes);
         return data;
     }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -34,6 +34,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     private MethodChannel.Result pendingResult;
     private boolean isMultipleSelection = false;
     private boolean loadDataToMemory = false;
+    private static boolean cachedFile = true;
     private String type;
     private String[] allowedExtensions;
     private EventChannel.EventSink eventSink;
@@ -94,9 +95,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                             int currentItem = 0;
                             while (currentItem < count) {
                                 final Uri currentUri = data.getClipData().getItemAt(currentItem).getUri();
-                                final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, currentUri, loadDataToMemory);
+                                final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, currentUri, loadDataToMemory, cachedFile);
 
-                                if(file != null) {
+                                if (file != null) {
                                     files.add(file);
                                     Log.d(FilePickerDelegate.TAG, "[MultiFilePick] File #" + currentItem + " - URI: " + currentUri.getPath());
                                 }
@@ -113,7 +114,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                 Log.d(FilePickerDelegate.TAG, "[SingleFilePick] File URI:" + uri.toString());
                                 final String dirPath = FileUtils.getFullPathFromTreeUri(uri, activity);
 
-                                if(dirPath != null) {
+                                if (dirPath != null) {
                                     finishWithSuccess(dirPath);
                                 } else {
                                     finishWithError("unknown_path", "Failed to retrieve directory path.");
@@ -121,9 +122,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                 return;
                             }
 
-                            final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, uri, loadDataToMemory);
+                            final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, uri, loadDataToMemory, cachedFile);
 
-                            if(file != null) {
+                            if (file != null) {
                                 files.add(file);
                             }
 
@@ -227,7 +228,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @SuppressWarnings("deprecation")
-    public void startFileExplorer(final String type, final boolean isMultipleSelection, final boolean withData, final String[] allowedExtensions, final MethodChannel.Result result) {
+    public void startFileExplorer(final String type, final boolean isMultipleSelection, final boolean withData, final boolean cachedFile, final String[] allowedExtensions, final MethodChannel.Result result) {
 
         if (!this.setPendingMethodCallAndResult(result)) {
             finishWithAlreadyActiveError(result);
@@ -237,6 +238,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         this.type = type;
         this.isMultipleSelection = isMultipleSelection;
         this.loadDataToMemory = withData;
+        this.cachedFile = cachedFile;
         this.allowedExtensions = allowedExtensions;
 
         if (!this.permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
@@ -256,10 +258,10 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         // Temporary fix, remove this null-check after Flutter Engine 1.14 has landed on stable
         if (this.pendingResult != null) {
 
-            if(data != null && !(data instanceof String)) {
+            if (data != null && !(data instanceof String)) {
                 final ArrayList<HashMap<String, Object>> files = new ArrayList<>();
 
-                for (FileInfo file : (ArrayList<FileInfo>)data) {
+                for (FileInfo file : (ArrayList<FileInfo>) data) {
                     files.add(file.toMap());
                 }
                 data = files;

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -61,21 +62,25 @@ abstract class FilePicker extends PlatformInterface {
   /// If [allowCompression] is set, it will allow media to apply the default OS compression.
   /// Defaults to `true`.
   ///
+  /// If [cachedFile] is set, it will not load bytes into memory, you can use [getBytesByUri] to get the Bytes
+  /// when you need.
+  /// Defaults to `false`.
+  ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
   ///
   /// For more information, check the [API documentation](https://github.com/miguelpruivo/flutter_file_picker/wiki/api).
   ///
   /// Returns [null] if aborted.
-  Future<FilePickerResult?> pickFiles({
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Function(FilePickerStatus)? onFileLoading,
-    bool allowCompression = true,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-  }) async =>
+  Future<FilePickerResult?> pickFiles(
+          {FileType type = FileType.any,
+          List<String>? allowedExtensions,
+          Function(FilePickerStatus)? onFileLoading,
+          bool allowCompression = true,
+          bool allowMultiple = false,
+          bool withData = false,
+          bool withReadStream = false,
+          bool cachedFile = false}) async =>
       throw UnimplementedError('pickFiles() has not been implemented.');
 
   /// Asks the underlying platform to remove any temporary files created by this plugin.
@@ -87,6 +92,16 @@ abstract class FilePicker extends PlatformInterface {
   /// Returns [true] if the files were removed with success, [false] otherwise.
   Future<bool?> clearTemporaryFiles() async => throw UnimplementedError(
       'clearTemporaryFiles() has not been implemented.');
+
+  Future<Uint8List?> getBytesByUri(Uri uri, int offset, int size) async =>
+      throw UnimplementedError('getBytesByUri() has not been implemented.');
+
+  Future<void> closeFileInputStreamByUri(Uri uri) async =>
+      throw UnimplementedError(
+          'closeFileInputStreamByUri() has not been implemented.');
+
+  Future<void> openInputStreamByUri(Uri uri) async => throw UnimplementedError(
+      'openInputStreamByUri() has not been implemented.');
 
   /// Selects a directory and returns its absolute path.
   ///

--- a/lib/src/file_picker_web.dart
+++ b/lib/src/file_picker_web.dart
@@ -38,15 +38,15 @@ class FilePickerWeb extends FilePicker {
   }
 
   @override
-  Future<FilePickerResult?> pickFiles({
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    bool allowMultiple = false,
-    Function(FilePickerStatus)? onFileLoading,
-    bool? allowCompression,
-    bool? withData = true,
-    bool? withReadStream = false,
-  }) async {
+  Future<FilePickerResult?> pickFiles(
+      {FileType type = FileType.any,
+      List<String>? allowedExtensions,
+      bool allowMultiple = false,
+      Function(FilePickerStatus)? onFileLoading,
+      bool? allowCompression,
+      bool? withData = true,
+      bool? withReadStream = false,
+      bool? cachedFile = true}) async {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
       throw Exception(
           'You are setting a type [$type]. Custom extension filters are only allowed with FileType.custom, please change it or remove filters.');

--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -6,6 +6,7 @@ class PlatformFile {
     required this.name,
     required this.size,
     this.path,
+    this.uri,
     this.bytes,
     this.readStream,
   });
@@ -14,6 +15,7 @@ class PlatformFile {
       : this.path = data['path'],
         this.name = data['name'],
         this.bytes = data['bytes'],
+        this.uri = data['uri'] != null ? Uri.parse(data['uri']) : null,
         this.size = data['size'];
 
   /// The absolute path for a cached copy of this file. It can be used to create a
@@ -27,6 +29,8 @@ class PlatformFile {
 
   /// File name including its extension.
   final String name;
+
+  final Uri? uri;
 
   /// Byte data for this file. Particurlarly useful if you want to manipulate its data
   /// or easily upload to somewhere else.


### PR DESCRIPTION
Sometimes we dont need to load bytes into memory,for example there is large files to upload，the file might be too big to fit device memory.
So we just need a stream,and then through this stream we can just read byte[size] on demand.

I add a boolean argument [cachedFile] to [pickFiles],If [cachedFile] is set, it will not load bytes into memory, you can use [getBytesByUri] to get the Bytes
 when you need.

And add a menber [uri] in FileInfo so that we can use this uri to run [getBytesByUri], everytime we run [pickFiles] we will get a uri in FileInfo.

The [getBytesByUri] function allows you get bytes by uri which from [pickFiles]'s uri.

There is also [closeFileInputStreamByUri] and [openInputStreamByUri] to operate the stream by uri.