### PR TITLE
Move web implementation out of src/ directory

### DIFF
--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: lines_longer_than_80_chars
 
-import 'package:file_picker/src/file_picker_web.dart';
+import 'package:file_picker/file_picker_web.dart';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 

--- a/lib/file_picker_web.dart
+++ b/lib/file_picker_web.dart
@@ -1,0 +1,1 @@
+export 'src/file_picker_web.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,4 +26,4 @@ flutter:
         pluginClass: FilePickerPlugin
       web:
         pluginClass: FilePickerWeb
-        fileName: src/file_picker_web.dart
+        fileName: file_picker_web.dart


### PR DESCRIPTION
The lint [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html) triggers on generated_plugin_registrant if the web implementation is under the src/ directory

Fixes #746