### PR TITLE
Check unsupported extensions correctly.

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -165,7 +165,7 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
             allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
         }
 
-        if (fileType == "custom" && (allowedExtensions == null || allowedExtensions.length == 0)) {
+        if (call.method != null && call.method.equals("custom") && (allowedExtensions == null || allowedExtensions.length == 0)) {
             result.error(TAG, "Unsupported filter. Make sure that you are only using the extension without the dot, (ie., jpg instead of .jpg). This could also have happened because you are using an unsupported file extension.  If the problem persists, you may want to consider using FileType.all instead.", null);
         } else {
             this.delegate.startFileExplorer(fileType, isMultipleSelection, withData, allowedExtensions, result);


### PR DESCRIPTION
fileType cannot be "custom" since it always contains file types matched with a passed method name. Thus, the condition is always false.

When the error never happens it's likely to lead to a weird behaviour. For instance, I've stumbled upon a case when the file explorer is opened successfully but there is no possibility to choose any folders except for some default ones (e.g., Recent, Photos or Drive). The problem can be reproduced on Android API < 29 with an unsupported file extension 'json' (it's been included starting from API 29):
![Android 8 0-9 0_Custom](https://user-images.githubusercontent.com/23010028/127323257-73240a11-986b-4398-a14d-30267b075c77.png)
