### PR TITLE
Add custom equality and toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.0+1
+Overrides equality and toString for `platform_file` and `file_picker_result` for better comparison different results.
+
 ## 4.0.0
 ### Desktop support added for all platforms (MacOS, Linux & Windows) ([#271](https://github.com/miguelpruivo/flutter_file_picker/issues/271)) 🎉
 From now on, you'll be able to use file_picker with all your platforms, a big thanks to @philenius, which made this possible and allowed the [flutter_file_picker_desktop](https://github.com/philenius/flutter_file_picker_desktop) to be merged with this one.

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -2,6 +2,7 @@
 // Generated file. Do not edit.
 //
 
+// ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
 
 import 'package:file_picker/src/file_picker_web.dart';

--- a/lib/src/file_picker_result.dart
+++ b/lib/src/file_picker_result.dart
@@ -28,4 +28,17 @@ class FilePickerResult {
 
   /// A `List<String>` containing all names from picked files with its extensions.
   List<String?> get names => files.map((file) => file.name).toList();
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is FilePickerResult && listEquals(other.files, files);
+  }
+
+  @override
+  int get hashCode => files.hashCode;
+
+  @override
+  String toString() => 'FilePickerResult(files: $files)';
 }

--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -41,4 +41,30 @@ class PlatformFile {
 
   /// File extension for this file.
   String? get extension => name.split('.').last;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PlatformFile &&
+        other.path == path &&
+        other.name == name &&
+        other.bytes == bytes &&
+        other.readStream == readStream &&
+        other.size == size;
+  }
+
+  @override
+  int get hashCode {
+    return path.hashCode ^
+        name.hashCode ^
+        bytes.hashCode ^
+        readStream.hashCode ^
+        size.hashCode;
+  }
+
+  @override
+  String toString() {
+    return 'PlatformFile(path: $path, name: $name, bytes: $bytes, readStream: $readStream, size: $size)';
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.0.0
+version: 4.0.0+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi ! I was recently trying to compare platformFiles but realized they weren't really comparing that well.

This is a small PR that adds `==`, `hashCode` and `toString` to `FilePickerResult` and `PlatformFile`.