### PR TITLE
Fixes bug #856 that .app files could not be picked on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.6
+##### Desktop (macOS)
+Fixes the issue that users could not pick `.app` files on macOS because FilePicker tried to determine the file size of `.app` files. On macOS, these special kind of files are actually Unix directories in a special format ([read more on StackExchange](https://apple.stackexchange.com/a/112213)). Now, if a file is picked, which is actually a directory, then the file size will be zero. ([#856](https://github.com/miguelpruivo/flutter_file_picker/issues/856))
+
 ## 4.1.5
 ##### Web
 - Fixes an issue that would prevent the call to return when both `withReadStream` and `allowMultiple` were set. ([#843](https://github.com/miguelpruivo/flutter_file_picker/issues/843)).

--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -54,7 +54,8 @@ class PlatformFile {
   /// File content as stream
   final Stream<List<int>>? readStream;
 
-  /// The file size in bytes.
+  /// The file size in bytes. Defaults to `0` if the file size could not be
+  /// determined.
   final int size;
 
   /// File extension for this file.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -39,7 +39,7 @@ Future<PlatformFile> createPlatformFile(
       name: basename(file.path),
       path: file.path,
       readStream: readStream,
-      size: await file.length(),
+      size: file.existsSync() ? file.lengthSync() : 0,
     );
 
 Future<String?> runExecutableWithArguments(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.1.5
+version: 4.1.6
 
 dependencies:
   flutter:

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,27 +1,33 @@
 import 'dart:io';
 
 setUpTestFiles(
-  String imageTestFile,
-  String pdfTestFile,
-  String yamlTestFile,
+  String appTestFilePath,
+  String imageTestFilePath,
+  String pdfTestFilePath,
+  String yamlTestFilePath,
 ) {
+  // .app files on macOS are actually directories but they are treated as files
+  Directory(appTestFilePath).createSync();
+
   File(
     './test/test_files/franz-michael-schneeberger-unsplash.jpg',
-  ).copySync(imageTestFile);
+  ).copySync(imageTestFilePath);
   File(
     './test/test_files/test.pdf',
-  ).copySync(pdfTestFile);
+  ).copySync(pdfTestFilePath);
   File(
     './test/test_files/test.yml',
-  ).copySync(yamlTestFile);
+  ).copySync(yamlTestFilePath);
 }
 
 tearDownTestFiles(
-  String imageTestFile,
-  String pdfTestFile,
-  String yamlTestFile,
+  String appTestFilePath,
+  String imageTestFilePath,
+  String pdfTestFilePath,
+  String yamlTestFilePath,
 ) {
-  File(imageTestFile).deleteSync();
-  File(pdfTestFile).deleteSync();
-  File(yamlTestFile).deleteSync();
+  Directory(appTestFilePath).deleteSync();
+  File(imageTestFilePath).deleteSync();
+  File(pdfTestFilePath).deleteSync();
+  File(yamlTestFilePath).deleteSync();
 }

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -1,22 +1,59 @@
 @TestOn('linux || mac-os')
 
+import 'dart:io';
 import 'package:file_picker/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'common.dart';
 
 void main() {
+  final appTestFilePath = '/tmp/test_utils.app';
   final imageTestFile = '/tmp/test_utils.jpg';
   final pdfTestFile = '/tmp/test_utils.pdf';
   final yamlTestFile = '/tmp/test_utils.yml';
 
   setUpAll(
-    () => setUpTestFiles(imageTestFile, pdfTestFile, yamlTestFile),
+    () => setUpTestFiles(
+        appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile),
   );
 
   tearDownAll(
-    () => tearDownTestFiles(imageTestFile, pdfTestFile, yamlTestFile),
+    () => tearDownTestFiles(
+        appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile),
   );
+
+  group('createPlatformFile()', () {
+    test('should return an instance of PlatformFile', () async {
+      final imageFile = File(imageTestFile);
+      final bytes = imageFile.readAsBytesSync();
+      final readStream = imageFile.openRead();
+
+      final platformFile =
+          await createPlatformFile(imageFile, bytes, readStream);
+
+      expect(platformFile.bytes, equals(bytes));
+      expect(platformFile.name, equals('test_utils.jpg'));
+      expect(platformFile.readStream, equals(readStream));
+      expect(platformFile.size, equals(bytes.length));
+    });
+
+    test(
+        'should not throw an exception when picking .app files on macOS (.app files on macOS are actually directories but they are treated as files, similar to .exe files on Windows)',
+        () async {
+      final appFile = File(appTestFilePath);
+
+      final platformFile = await createPlatformFile(appFile, null, null);
+
+      expect(platformFile.bytes, equals(null));
+      expect(platformFile.name, equals('test_utils.app'));
+      expect(platformFile.readStream, equals(null));
+      expect(
+        platformFile.size,
+        equals(0),
+        reason: 'Expect size to be 0 because .app files are directories.',
+      );
+    });
+  });
 
   group('filePathsToPlatformFiles()', () {
     test('should transform a list of file paths into a list of PlatformFiles',


### PR DESCRIPTION
Fixes #856:

`.app` files on macOS are special files which are actually Unix directories ([read more on StackExchange](https://apple.stackexchange.com/a/112213)). Previously, if an `.app` file was picked, then we would get the following exception because directories don't have an inherent (file) size:

```
FileSystemException: Cannot retrieve length of file, path = '/path/Runner.app' (OS Error: Is a directory, errno = 21)
```

I changed the implementation so that the **file size is only determined**, if the picked file system entity is an **actual file** (and not a directory). If the picked file system entity is **not a file**, then the file size will **default to zero** because it the `size` property is non-nullable.

@miguelpruivo, are you okay with this solution or would you suggest a better solution / improvements? 