### PR TITLE
Check FlutterResult _result, is not void when picking media in PHPick…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.3
+
+##### iOS
+Fixed an issue that was creating a crash when media in PHPickerViewController in iOs was tapped several times very fast, we check that _result is not empty to avoid the crash. No Github issue created.
+
 ## 4.2.2+1
 
 ##### Android

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -390,6 +390,10 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
 
 -(void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14)){
     
+    if(_result == nil) {
+        return;
+    }
+    
     if(self.group != nil) {
         return;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.2.2+1
+version: 4.2.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
Sometimes when the users select videos very fast, _didFinishPicking:_ is called twice, and in the second time _result is null and the app crashes.