### PR TITLE
#871: file extensions not enforced on Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,11 @@ Also, sometimes a simple `flutter clean` and `flutter build` again with latest f
 A clear and concise description of what the bug is. If the issue happens to be on Android, please make sure that it also happens with a different device/simulator and/or version.
 
 **Platform**
-- [] Android
-- [] iOS
-- [] Web
-- [] Desktop (Go)
+
+- [ ] Android
+- [ ] iOS
+- [ ] Web
+- [ ] Desktop
 
 **Platform OS version**
 What version did it happen?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.7
+
+##### Desktop (Windows)
+Fixes the issue under Windows that the user could select all file types even though a file type filter was enabled. This error existed because the user could select the entry `All Files (*.*)` in the file type filter dropdown ([#871](https://github.com/miguelpruivo/flutter_file_picker/issues/871)).
+
 ## 4.2.6
 
 ##### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.2.7
 
-##### Desktop (Windows)
-Fixes the issue under Windows that the user could select all file types even though a file type filter was enabled. This error existed because the user could select the entry `All Files (*.*)` in the file type filter dropdown ([#871](https://github.com/miguelpruivo/flutter_file_picker/issues/871)).
+##### Desktop (macOS & Windows)
+Fixes the issue under Windows that the user could select all file types even though a file type filter was enabled. This error existed because the user could select the entry `All Files (*.*)` in the file type filter dropdown. Also, fixes the bug under macOS that users could select files without file extension even when one of the pre-defined file type filters (audio, image, video, or media) was enabled. ([#871](https://github.com/miguelpruivo/flutter_file_picker/issues/871)).
 
 ## 4.2.6
 

--- a/lib/src/file_picker_linux.dart
+++ b/lib/src/file_picker_linux.dart
@@ -101,15 +101,15 @@ class FilePickerLinux extends FilePicker {
       case FileType.any:
         return '';
       case FileType.audio:
-        return '*.mp3 *.wav *.midi *.ogg *.aac';
+        return '*.aac *.midi *.mp3 *.ogg *.wav';
       case FileType.custom:
         return '*.' + allowedExtensions!.join(' *.');
       case FileType.image:
-        return '*.bmp *.gif *.jpg *.jpeg *.png';
+        return '*.bmp *.gif *.jpeg *.jpg *.png';
       case FileType.media:
-        return '*.webm *.mpeg *.mkv *.mp4 *.avi *.mov *.flv *.jpg *.jpeg *.bmp *.gif *.png';
+        return '*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png';
       case FileType.video:
-        return '*.webm *.mpeg *.mkv *.mp4 *.avi *.mov *.flv';
+        return '*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv';
       default:
         throw Exception('unknown file type');
     }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -101,15 +101,15 @@ class FilePickerMacOS extends FilePicker {
       case FileType.any:
         return '';
       case FileType.audio:
-        return '"", "aac", "midi", "mp3", "ogg", "wav"';
+        return '"aac", "midi", "mp3", "ogg", "wav"';
       case FileType.custom:
         return '"", "' + allowedExtensions!.join('", "') + '"';
       case FileType.image:
-        return '"", "bmp", "gif", "jpeg", "jpg", "png"';
+        return '"bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.media:
-        return '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"';
+        return '"avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.video:
-        return '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"';
+        return '"avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"';
       default:
         throw Exception('unknown file type');
     }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -101,15 +101,15 @@ class FilePickerMacOS extends FilePicker {
       case FileType.any:
         return '';
       case FileType.audio:
-        return '"", "mp3", "wav", "midi", "ogg", "aac"';
+        return '"", "aac", "midi", "mp3", "ogg", "wav"';
       case FileType.custom:
         return '"", "' + allowedExtensions!.join('", "') + '"';
       case FileType.image:
-        return '"", "jpg", "jpeg", "bmp", "gif", "png"';
+        return '"", "bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.media:
-        return '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"';
+        return '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.video:
-        return '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"';
+        return '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"';
       default:
         throw Exception('unknown file type');
     }

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -103,17 +103,17 @@ class FilePickerWindows extends FilePicker {
   String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
     switch (type) {
       case FileType.any:
-        return '*.*\x00\x00';
+        return 'All Files (*.*)\x00*.*\x00\x00';
       case FileType.audio:
-        return 'Audios (*.mp3)\x00*.mp3\x00All Files (*.*)\x00*.*\x00\x00';
+        return 'Audios (*.mp3)\x00*.mp3\x00\x00';
       case FileType.custom:
         return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
       case FileType.image:
-        return 'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00All Files (*.*)\x00*.*\x00\x00';
+        return 'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00';
       case FileType.media:
-        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00All Files (*.*)\x00*.*\x00\x00';
+        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00';
       case FileType.video:
-        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00All Files (*.*)\x00*.*\x00\x00';
+        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00\x00';
       default:
         throw Exception('unknown file type');
     }

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -105,15 +105,15 @@ class FilePickerWindows extends FilePicker {
       case FileType.any:
         return 'All Files (*.*)\x00*.*\x00\x00';
       case FileType.audio:
-        return 'Audios (*.mp3)\x00*.mp3\x00\x00';
+        return 'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav\x00\x00';
       case FileType.custom:
         return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
       case FileType.image:
-        return 'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00';
+        return 'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
       case FileType.media:
-        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00';
+        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
       case FileType.video:
-        return 'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00\x00';
+        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
       default:
         throw Exception('unknown file type');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.2.6
+version: 4.2.7
 
 dependencies:
   flutter:

--- a/test/file_picker_linux_test.dart
+++ b/test/file_picker_linux_test.dart
@@ -20,24 +20,24 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('*.mp3 *.wav *.midi *.ogg *.aac'),
+        equals('*.aac *.midi *.mp3 *.ogg *.wav'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
-        equals('*.bmp *.gif *.jpg *.jpeg *.png'),
+        equals('*.bmp *.gif *.jpeg *.jpg *.png'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          '*.webm *.mpeg *.mkv *.mp4 *.avi *.mov *.flv *.jpg *.jpeg *.bmp *.gif *.png',
+          '*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
-        equals('*.webm *.mpeg *.mkv *.mp4 *.avi *.mov *.flv'),
+        equals('*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv'),
       );
     });
 

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -16,24 +16,24 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('"", "mp3", "wav", "midi", "ogg", "aac"'),
+        equals('"", "aac", "midi", "mp3", "ogg", "wav"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
-        equals('"", "jpg", "jpeg", "bmp", "gif", "png"'),
+        equals('"", "bmp", "gif", "jpeg", "jpg", "png"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          '"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv", "jpg", "jpeg", "bmp", "gif", "png"',
+          '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
-        equals('"", "webm", "mpeg", "mkv", "mp4", "avi", "mov", "flv"'),
+        equals('"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"'),
       );
     });
 

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -16,24 +16,24 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('"", "aac", "midi", "mp3", "ogg", "wav"'),
+        equals('"aac", "midi", "mp3", "ogg", "wav"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
-        equals('"", "bmp", "gif", "jpeg", "jpg", "png"'),
+        equals('"bmp", "gif", "jpeg", "jpg", "png"'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          '"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"',
+          '"avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
-        equals('"", "avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"'),
+        equals('"avi", "flv", "mkv", "mov", "mp4", "mpeg", "webm", "wmv"'),
       );
     });
 
@@ -42,6 +42,12 @@ void main() {
         () {
       final picker = FilePickerMacOS();
 
+      // TODO: the first empty file type ("", ) is required in some cases, e.g.
+      // when filtering for *.dart and other special file types. Unfortunately,
+      // the empty file type enables the selection of files without extension.
+      // In other cases, e.g. when filtering for *.png files, it isn't required
+      // to provide the empty file type. We need to find a solution to make the
+      // filter work without having to provide an empty file type first.
       expect(
         picker.fileTypeToFileFilter(FileType.custom, ['dart']),
         equals('"", "dart"'),

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -11,32 +11,32 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.any, null),
-        equals('*.*\x00\x00'),
+        equals('All Files (*.*)\x00*.*\x00\x00'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('Audios (*.mp3)\x00*.mp3\x00All Files (*.*)\x00*.*\x00\x00'),
+        equals('Audios (*.mp3)\x00*.mp3\x00\x00'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
         equals(
-          'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00All Files (*.*)\x00*.*\x00\x00',
+          'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00All Files (*.*)\x00*.*\x00\x00',
+          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
         equals(
-          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00All Files (*.*)\x00*.*\x00\x00',
+          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00\x00',
         ),
       );
     });

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -16,7 +16,8 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav\x00\x00'),
+        equals(
+            'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav\x00\x00'),
       );
 
       expect(

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -16,27 +16,27 @@ void main() {
 
       expect(
         picker.fileTypeToFileFilter(FileType.audio, null),
-        equals('Audios (*.mp3)\x00*.mp3\x00\x00'),
+        equals('Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav\x00\x00'),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.image, null),
         equals(
-          'Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00',
+          'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.media, null),
         equals(
-          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00Images (*.jpeg,*.png,*.gif)\x00*.jpg;*.jpeg;*.png;*.gif\x00\x00',
+          'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00',
         ),
       );
 
       expect(
         picker.fileTypeToFileFilter(FileType.video, null),
         equals(
-          'Videos (*.webm,*.wmv,*.mpeg,*.mkv,*.mp4,*.avi,*.mov,*.flv)\x00*.webm;*.wmv;*.mpeg;*.mkv;*mp4;*.avi;*.mov;*.flv\x00\x00',
+          'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00',
         ),
       );
     });


### PR DESCRIPTION
Fixes #871 

## Previously

Users could click on `All Files(*.*)` in the bottom right dropdown even though a file filter was enabled:
![before](https://user-images.githubusercontent.com/9049899/144321338-0ea1e98c-7ffb-4d28-b71a-6a143496c414.gif)

## Now
![after](https://user-images.githubusercontent.com/9049899/144321389-75916b83-762a-456a-997c-eec94ffd0ef1.gif)


## Additional fixes

* I improved the bug report template so that the checkboxes are always correctly rendered like this:
   ![grafik](https://user-images.githubusercontent.com/9049899/144321631-34dcc7ed-f63e-443c-a6e1-bfea169092ee.png).

* Previously, the default file type filters (`FileType.audio`, `FileType.image`, etc.) weren't aligned on all three desktop platforms. I fixed it so that for example `FileType.Audio` filters for `*.aac`, `*.midi`, `*.mp3`, `*.ogg`, and `*.wav` **on all three platforms**.

There's one more bug under macOS which I wasn't able to fix (see TODO in `test/file_picker_macos_test.dart`).