### PR TITLE
#918: buffer for selected file paths too small on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.2.8
+
+##### Desktop (Windows)
+Fixes the issue under Windows that the user could not select more than about 256 files (depending on the length of the file paths) because the buffer size for storing the selected file paths was too small. ([#918](https://github.com/miguelpruivo/flutter_file_picker/issues/918)).
+
+
 ## 4.2.7
 
 ##### Desktop (macOS & Windows)

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -229,7 +229,7 @@ class FilePickerWindows extends FilePicker {
     List<String>? allowedExtensions,
     FileType type = FileType.any,
   }) {
-    final lpstrFileBufferSize = 20 * maximumPathLength;
+    final lpstrFileBufferSize = 8192 * maximumPathLength;
     final Pointer<OPENFILENAMEW> openFileNameW = calloc<OPENFILENAMEW>();
 
     openFileNameW.ref.lStructSize = sizeOf<OPENFILENAMEW>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.2.7
+version: 4.2.8
 
 dependencies:
   flutter:


### PR DESCRIPTION
fixes #918. With this change, it is possible to select at least 2300 files (even files with extra long file paths such as `C:\Users\phil\Downloads\abcdefghijklmnopqrstuvxyz0123456789\zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.txt`. Please see commit message for detailed explanation: 7450ae6