### PR TITLE
Added option to lock the parent window(flutter window) when file picker is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.0
+
+##### Desktop (Windows)
+Adds the parameter `lockParentWindow` for Windows desktop. This parameter makes the file picker dialog behave like a modal window. That is, the file picker always stays in front of the Flutter window until it is closed. Thank you @vinicios-cervantes.
+
 ## 4.2.8
 
 ##### Desktop (Windows)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,8 @@ analyzer:
 #   strong-mode:
 #     implicit-casts: false
 
-# linter:
-#   rules:
-#     - cancel_subscriptions
+linter:
+  rules:
+    # - cancel_subscriptions
+    - comment_references
+    - slash_for_doc_comments

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -44,6 +44,7 @@ class FilePickerWeb extends FilePicker {
     bool allowCompression = true,
     bool withData = true,
     bool withReadStream = false,
+    bool lockParentWindow = false,
   }) async {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
       throw Exception(

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -83,6 +83,9 @@ abstract class FilePicker extends PlatformInterface {
   /// If `allowCompression` is set, it will allow media to apply the default OS compression.
   /// Defaults to `true`.
   ///
+  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
+  /// of the flutter window until it get closed. (Only Windows)
+  ///
   /// `dialogTitle` can be optionally set on desktop platforms to set the modal window title. It will be ignored on
   /// other platforms.
   ///
@@ -101,6 +104,7 @@ abstract class FilePicker extends PlatformInterface {
     bool allowMultiple = false,
     bool withData = false,
     bool withReadStream = false,
+    bool lockParentWindow = false,
   }) async =>
       throw UnimplementedError('pickFiles() has not been implemented.');
 
@@ -145,6 +149,9 @@ abstract class FilePicker extends PlatformInterface {
   /// parameters are just a proposal to the user as the save file dialog does
   /// not enforce these restrictions.
   ///
+  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
+  /// of the flutter window until it get closed. (Only Windows)
+  ///
   /// Returns [null] if aborted. Returns a [Future<String?>] which resolves to
   /// the absolute path of the selected file, if the user selected a file.
   Future<String?> saveFile({
@@ -152,6 +159,7 @@ abstract class FilePicker extends PlatformInterface {
     String? fileName,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool lockParentWindow = false,
   }) async =>
       throw UnimplementedError('saveFile() has not been implemented.');
 }

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -148,10 +148,10 @@ abstract class FilePicker extends PlatformInterface {
   /// Windows).
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
-  /// 
+  ///
   /// [fileName] can be set to a non-empty string to provide a default file
   /// name.
-  /// 
+  ///
   /// The file type filter [type] defaults to [FileType.any]. Optionally,
   /// [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.). Both
   /// parameters are just a proposal to the user as the save file dialog does

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -65,32 +65,33 @@ abstract class FilePicker extends PlatformInterface {
 
   /// Retrieves the file(s) from the underlying platform
   ///
-  /// Default `type` set to [FileType.any] with `allowMultiple` set to `false`.
-  /// Optionally, `allowedExtensions` might be provided (e.g. `[pdf, svg, jpg]`.).
+  /// Default [type] set to [FileType.any] with [allowMultiple] set to `false`.
+  /// Optionally, [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.).
   ///
-  /// If `withData` is set, picked files will have its byte data immediately available on memory as `Uint8List`
+  /// If [withData] is set, picked files will have its byte data immediately available on memory as `Uint8List`
   /// which can be useful if you are picking it for server upload or similar. However, have in mind that
   /// enabling this on IO (iOS & Android) may result in out of memory issues if you allow multiple picks or
-  /// pick huge files. Use `withReadStream` instead. Defaults to `true` on web, `false` otherwise.
+  /// pick huge files. Use [withReadStream] instead. Defaults to `true` on web, `false` otherwise.
   ///
-  /// If `withReadStream` is set, picked files will have its byte data available as a `Stream<List<int>>`
+  /// If [withReadStream] is set, picked files will have its byte data available as a [Stream<List<int>>]
   /// which can be useful for uploading and processing large files. Defaults to `false`.
   ///
   /// If you want to track picking status, for example, because some files may take some time to be
   /// cached (particularly those picked from cloud providers), you may want to set [onFileLoading] handler
   /// that will give you the current status of picking.
   ///
-  /// If `allowCompression` is set, it will allow media to apply the default OS compression.
+  /// If [allowCompression] is set, it will allow media to apply the default OS compression.
   /// Defaults to `true`.
   ///
-  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
-  /// of the flutter window until it get closed. (Only Windows)
+  /// If [lockParentWindow] is set, the child window (file picker window) will
+  /// stay in front of the Flutter window until it is closed (like a modal
+  /// window). This parameter works only on Windows desktop.
   ///
-  /// `dialogTitle` can be optionally set on desktop platforms to set the modal window title. It will be ignored on
+  /// [dialogTitle] can be optionally set on desktop platforms to set the modal window title. It will be ignored on
   /// other platforms.
   ///
-  /// The result is wrapped in a `FilePickerResult` which contains helper getters
-  /// with useful information regarding the picked `List<PlatformFile>`.
+  /// The result is wrapped in a [FilePickerResult] which contains helper getters
+  /// with useful information regarding the picked [List<PlatformFile>].
   ///
   /// For more information, check the [API documentation](https://github.com/miguelpruivo/flutter_file_picker/wiki/api).
   ///
@@ -123,15 +124,17 @@ abstract class FilePicker extends PlatformInterface {
   /// Selects a directory and returns its absolute path.
   ///
   /// On Android, this requires to be running on SDK 21 or above, else won't work.
-  /// Returns `null` if folder path couldn't be resolved.
-  ///
-  /// `dialogTitle` can be set to display a custom title on desktop platforms. It will be ignored on Web & IO.
-  ///
-  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
-  /// of the flutter window until it get closed. (Only Windows)
-  ///
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
-  Future<String?> getDirectoryPath({String? dialogTitle, bool lockParentWindow = false}) async =>
+  ///
+  /// [dialogTitle] can be set to display a custom title on desktop platforms. It will be ignored on Web & IO.
+  ///
+  /// If [lockParentWindow] is set, the child window (file picker window) will
+  /// stay in front of the Flutter window until it is closed (like a modal
+  /// window). This parameter works only on Windows desktop.
+  ///
+  /// Returns `null` if aborted or if the folder path couldn't be resolved.
+  Future<String?> getDirectoryPath(
+          {String? dialogTitle, bool lockParentWindow = false}) async =>
       throw UnimplementedError('getDirectoryPath() has not been implemented.');
 
   /// Opens a save file dialog which lets the user select a file path and a file
@@ -145,17 +148,20 @@ abstract class FilePicker extends PlatformInterface {
   /// Windows).
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
+  /// 
   /// [fileName] can be set to a non-empty string to provide a default file
   /// name.
+  /// 
   /// The file type filter [type] defaults to [FileType.any]. Optionally,
   /// [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.). Both
   /// parameters are just a proposal to the user as the save file dialog does
   /// not enforce these restrictions.
   ///
-  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
-  /// of the flutter window until it get closed. (Only Windows)
+  /// If [lockParentWindow] is set, the child window (file picker window) will
+  /// stay in front of the Flutter window until it is closed (like a modal
+  /// window). This parameter works only on Windows desktop.
   ///
-  /// Returns [null] if aborted. Returns a [Future<String?>] which resolves to
+  /// Returns `null` if aborted. Returns a [Future<String?>] which resolves to
   /// the absolute path of the selected file, if the user selected a file.
   Future<String?> saveFile({
     String? dialogTitle,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -127,8 +127,11 @@ abstract class FilePicker extends PlatformInterface {
   ///
   /// `dialogTitle` can be set to display a custom title on desktop platforms. It will be ignored on Web & IO.
   ///
+  /// If `lockParentWindow` is set, the child window(File Picker) will stay in front
+  /// of the flutter window until it get closed. (Only Windows)
+  ///
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
-  Future<String?> getDirectoryPath({String? dialogTitle}) async =>
+  Future<String?> getDirectoryPath({String? dialogTitle, bool lockParentWindow = false}) async =>
       throw UnimplementedError('getDirectoryPath() has not been implemented.');
 
   /// Opens a save file dialog which lets the user select a file path and a file

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -48,7 +48,7 @@ class FilePickerIO extends FilePicker {
       _channel.invokeMethod<bool>('clear');
 
   @override
-  Future<String?> getDirectoryPath({String? dialogTitle}) async {
+  Future<String?> getDirectoryPath({String? dialogTitle, bool lockParentWindow = false}) async {
     try {
       return await _channel.invokeMethod('dir', {});
     } on PlatformException catch (ex) {

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -31,6 +31,7 @@ class FilePickerIO extends FilePicker {
     bool allowMultiple = false,
     bool? withData = false,
     bool? withReadStream = false,
+    bool lockParentWindow = false,
   }) =>
       _getPath(
         type,

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -48,7 +48,8 @@ class FilePickerIO extends FilePicker {
       _channel.invokeMethod<bool>('clear');
 
   @override
-  Future<String?> getDirectoryPath({String? dialogTitle, bool lockParentWindow = false}) async {
+  Future<String?> getDirectoryPath(
+      {String? dialogTitle, bool lockParentWindow = false}) async {
     try {
       return await _channel.invokeMethod('dir', {});
     } on PlatformException catch (ex) {

--- a/lib/src/file_picker_linux.dart
+++ b/lib/src/file_picker_linux.dart
@@ -15,6 +15,7 @@ class FilePickerLinux extends FilePicker {
     bool allowMultiple = false,
     bool withData = false,
     bool withReadStream = false,
+    bool lockParentWindow = false,
   }) async {
     final String executable = await _getPathToExecutable();
     final String fileFilter = fileTypeToFileFilter(
@@ -66,6 +67,7 @@ class FilePickerLinux extends FilePicker {
     String? fileName,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool lockParentWindow = false,
   }) async {
     final executable = await _getPathToExecutable();
     final String fileFilter = fileTypeToFileFilter(

--- a/lib/src/file_picker_linux.dart
+++ b/lib/src/file_picker_linux.dart
@@ -52,6 +52,7 @@ class FilePickerLinux extends FilePicker {
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
+    bool lockParentWindow = false,
   }) async {
     final executable = await _getPathToExecutable();
     final arguments = generateCommandLineArguments(

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -12,6 +12,7 @@ class FilePickerMacOS extends FilePicker {
     bool allowMultiple = false,
     bool withData = false,
     bool withReadStream = false,
+    bool lockParentWindow = false,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final String fileFilter = fileTypeToFileFilter(
@@ -72,6 +73,7 @@ class FilePickerMacOS extends FilePicker {
     String? fileName,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool lockParentWindow = false,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final String fileFilter = fileTypeToFileFilter(

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -49,6 +49,7 @@ class FilePickerMacOS extends FilePicker {
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
+    bool lockParentWindow = false,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final List<String> arguments = generateCommandLineArguments(

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -61,7 +61,8 @@ class FilePickerWindows extends FilePicker {
     String? dialogTitle,
     bool lockParentWindow = false,
   }) {
-    final pathIdPointer = _pickDirectory(dialogTitle ?? defaultDialogTitle, lockParentWindow);
+    final pathIdPointer =
+        _pickDirectory(dialogTitle ?? defaultDialogTitle, lockParentWindow);
     if (pathIdPointer == null) {
       return Future.value(null);
     }
@@ -187,12 +188,12 @@ class FilePickerWindows extends FilePicker {
   /// Extracts the list of selected files from the Win32 API struct [OPENFILENAMEW].
   ///
   /// After the user has closed the file picker dialog, Win32 API sets the property
-  /// [lpstrFile] of [OPENFILENAMEW] to the user's selection. This property contains
-  /// a string terminated by two [null] characters. If the user has selected only one
+  /// `lpstrFile` of [OPENFILENAMEW] to the user's selection. This property contains
+  /// a string terminated by two `null` characters. If the user has selected only one
   /// file, then the returned string contains the absolute file path, e. g.
   /// `C:\Users\John\file1.jpg\x00\x00`. If the user has selected more than one file,
   /// then the returned string contains the directory of the selected files, followed
-  /// by a [null] character, followed by the file names each separated by a [null]
+  /// by a `null` character, followed by the file names each separated by a `null`
   /// character, e.g. `C:\Users\John\x00file1.jpg\x00file2.jpg\x00file3.jpg\x00\x00`.
   List<String> _extractSelectedFilesFromOpenFileNameW(
     OPENFILENAMEW openFileNameW,
@@ -274,7 +275,7 @@ class FilePickerWindows extends FilePicker {
     return openFileNameW;
   }
 
-  Pointer _getWindowHandle(){
+  Pointer _getWindowHandle() {
     final _user32 = DynamicLibrary.open('user32.dll');
 
     final findWindowA = _user32.lookupFunction<
@@ -282,7 +283,8 @@ class FilePickerWindows extends FilePicker {
         int Function(Pointer<Utf8> _lpClassName,
             Pointer<Utf8> _lpWindowName)>('FindWindowA');
 
-    int hWnd = findWindowA('FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf8(), nullptr);
+    int hWnd =
+        findWindowA('FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf8(), nullptr);
 
     return Pointer.fromAddress(hWnd);
   }

--- a/lib/src/windows/file_picker_windows_ffi_types.dart
+++ b/lib/src/windows/file_picker_windows_ffi_types.dart
@@ -29,7 +29,7 @@ typedef GetOpenFileNameWDart = int Function(
 
 /// Function from Win32 API to convert an item identifier list to a file system path.
 ///
-/// Returns [true] if successful; otherwise, [false].
+/// Returns `true` if successful; otherwise, `false`.
 ///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetpathfromidlistw
@@ -77,7 +77,7 @@ class BROWSEINFOA extends Struct {
 
   /// A PIDL that specifies the location of the root folder from which to start browsing. Only the
   /// specified folder and its subfolders in the namespace hierarchy appear in the dialog box. This
-  /// member can be [null]; in that case, a default location is used.
+  /// member can be `null`; in that case, a default location is used.
   external Pointer pidlRoot;
 
   /// Pointer to a buffer to receive the display name of the folder selected by the user. The size
@@ -94,7 +94,7 @@ class BROWSEINFOA extends Struct {
   external int ulFlags;
 
   /// Pointer to an application-defined function that the dialog box calls when an event occurs. For
-  /// more information, see the BrowseCallbackProc function. This member can be [null].
+  /// more information, see the BrowseCallbackProc function. This member can be `null`.
   external Pointer lpfn;
 
   /// An application-defined value that the dialog box passes to the callback function, if one is
@@ -117,19 +117,19 @@ class OPENFILENAMEW extends Struct {
   @Uint32()
   external int lStructSize;
 
-  /// A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be [null] if the dialog box has no owner.
+  /// A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be `null` if the dialog box has no owner.
   external Pointer hwndOwner;
 
   /// If the OFN_ENABLETEMPLATEHANDLE flag is set in the Flags member, hInstance is a handle to a memory object containing a dialog box template. If the OFN_ENABLETEMPLATE flag is set, hInstance is a handle to a module that contains a dialog box template named by the lpTemplateName member. If neither flag is set, this member is ignored. If the OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the system uses the template to create an old-style dialog box that replaces the default dialog box.
   external Pointer hInstance;
 
-  /// A buffer containing pairs of null-terminated filter strings. The last string in the buffer must be terminated by two [null] characters.
+  /// A buffer containing pairs of null-terminated filter strings. The last string in the buffer must be terminated by two `null` characters.
   external Pointer<Utf16> lpstrFilter;
 
   /// A static buffer that contains a pair of null-terminated filter strings for preserving the filter pattern chosen by the user.
   external Pointer<Utf16> lpstrCustomFilter;
 
-  /// The size, in characters, of the buffer identified by [lpstrCustomFilter]. This buffer should be at least 40 characters long. This member is ignored if [lpstrCustomFilter] is [null] or points to a [null] string.
+  /// The size, in characters, of the buffer identified by [lpstrCustomFilter]. This buffer should be at least 40 characters long. This member is ignored if [lpstrCustomFilter] is `null` or points to a `null` string.
   @Uint32()
   external int nMaxCustFilter;
 
@@ -137,24 +137,24 @@ class OPENFILENAMEW extends Struct {
   @Uint32()
   external int nFilterIndex;
 
-  /// The file name used to initialize the File Name edit control. The first character of this buffer must be [null] if initialization is not necessary.
+  /// The file name used to initialize the File Name edit control. The first character of this buffer must be `null` if initialization is not necessary.
   external Pointer<Utf16> lpstrFile;
 
-  /// The size, in characters, of the buffer pointed to by lpstrFile. The buffer must be large enough to store the path and file name string or strings, including the terminating [null] character. The GetOpenFileName and GetSaveFileName functions return [false] if the buffer is too small to contain the file information. The buffer should be at least 256 characters long.
+  /// The size, in characters, of the buffer pointed to by lpstrFile. The buffer must be large enough to store the path and file name string or strings, including the terminating `null` character. The GetOpenFileName and GetSaveFileName functions return `false` if the buffer is too small to contain the file information. The buffer should be at least 256 characters long.
   @Uint32()
   external int nMaxFile;
 
-  /// The file name and extension (without path information) of the selected file. This member can be [null].
+  /// The file name and extension (without path information) of the selected file. This member can be `null`.
   external Pointer<Utf16> lpstrFileTitle;
 
-  /// The size, in characters, of the buffer pointed to by [lpstrFileTitle]. This member is ignored if [lpstrFileTitle] is [null].
+  /// The size, in characters, of the buffer pointed to by [lpstrFileTitle]. This member is ignored if [lpstrFileTitle] is `null`.
   @Uint32()
   external int nMaxFileTitle;
 
   /// The initial directory. The algorithm for selecting the initial directory varies on different platforms.
   external Pointer<Utf16> lpstrInitialDir;
 
-  /// A string to be placed in the title bar of the dialog box. If this member is [null], the system uses the default title (that is, Save As or Open).
+  /// A string to be placed in the title bar of the dialog box. If this member is `null`, the system uses the default title (that is, Save As or Open).
   external Pointer<Utf16> lpstrTitle;
 
   /// A set of bit flags you can use to initialize the dialog box. When the dialog box returns, it sets these flags to indicate the user's input.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.2.8
+version: 4.3.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
 - Added implementation lock the main flutter window  behind the file picker window when `lockParentWindow` is set to `true`
 
without lock(default, how it is today):
![without_parent_handler](https://user-images.githubusercontent.com/67704004/146450516-23cf1a82-593b-47e1-9cc5-063c0a4c94db.gif)

with lock(when set):
![with_parent_handler](https://user-images.githubusercontent.com/67704004/146450549-8bf170b8-e959-40fe-8b73-5f1adc5b619a.gif)

