### PR TITLE
Feature/validate filename for savefile dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.3.2
+
+#### Desktop (Windows)
+Fixes the issue under Windows that the save-file dialog did not open if the specified file name contained an illegal character. Windows prohibits the usage of [reserved characters in file names](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions). Now the exception `IllegalCharacterInFileNameException` is thrown if the specified file name contains forbidden characters
+([#926](https://github.com/miguelpruivo/flutter_file_picker/issues/926)).
+
 ## 4.3.1
 
 #### Desktop (Linux)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,7 +28,7 @@ linter:
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_types_as_parameter_names
-    # - avoid_web_libraries_in_flutter
+    - avoid_web_libraries_in_flutter
     - cancel_subscriptions
     - close_sinks
     - control_flow_in_finally

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,3 +15,31 @@ linter:
     # - cancel_subscriptions
     - comment_references
     - slash_for_doc_comments
+    - use_key_in_widget_constructors
+    - unsafe_html
+    - unnecessary_statements
+    - throw_in_finally
+    - always_use_package_imports
+    - avoid_dynamic_calls
+    - avoid_empty_else
+    # - avoid_print
+    - avoid_relative_lib_imports
+    - avoid_returning_null_for_future
+    - avoid_slow_async_io
+    - avoid_type_to_string
+    - avoid_types_as_parameter_names
+    # - avoid_web_libraries_in_flutter
+    - cancel_subscriptions
+    - close_sinks
+    - control_flow_in_finally
+    - diagnostic_describe_all_properties
+    - empty_statements
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - no_logic_in_create_state
+    - prefer_void_to_null
+    - test_types_in_equals

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,6 @@
+class IllegalCharacterInFileNameException implements Exception {
+  final String message;
+  IllegalCharacterInFileNameException(this.message);
+  @override
+  String toString() => 'IllegalCharacterInFileNameException: $message';
+}

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -4,11 +4,10 @@ import 'dart:io';
 import 'package:file_picker/src/file_picker_io.dart';
 import 'package:file_picker/src/file_picker_linux.dart';
 import 'package:file_picker/src/file_picker_macos.dart';
+import 'package:file_picker/src/file_picker_result.dart';
 import 'package:file_picker/src/windows/stub.dart'
     if (dart.library.io) 'package:file_picker/src/windows/file_picker_windows.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-
-import 'file_picker_result.dart';
 
 const String defaultDialogTitle = 'File Picker';
 
@@ -150,7 +149,8 @@ abstract class FilePicker extends PlatformInterface {
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
   ///
   /// [fileName] can be set to a non-empty string to provide a default file
-  /// name.
+  /// name. Throws an `IllegalCharacterInFileNameException` under Windows if the
+  /// given [fileName] contains forbidden characters.
   ///
   /// The file type filter [type] defaults to [FileType.any]. Optionally,
   /// [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.). Both

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -211,6 +211,7 @@ class FilePickerWindows extends FilePicker {
     int i = 0;
     bool lastCharWasNull = false;
 
+    // ignore: literal_only_boolean_expressions
     while (true) {
       final char = openFileNameW.lpstrFile.cast<Uint16>().elementAt(i).value;
       if (char == 0) {

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:file_picker/src/utils.dart';
+import 'package:file_picker/src/exceptions.dart';
 import 'package:file_picker/src/windows/file_picker_windows_ffi_types.dart';
 import 'package:path/path.dart';
 
@@ -122,6 +123,13 @@ class FilePickerWindows extends FilePicker {
         return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
       default:
         throw Exception('unknown file type');
+    }
+  }
+
+  validateFileName(String fileName) {
+    if (fileName.contains(RegExp(r'[<>:\/\\|?*"]'))) {
+      throw IllegalCharacterInFileNameException(
+          'Reserved characters may not be used in file names. See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions');
     }
   }
 
@@ -260,6 +268,8 @@ class FilePickerWindows extends FilePicker {
     }
 
     if (defaultFileName != null) {
+      validateFileName(defaultFileName);
+
       final Uint16List nativeString = openFileNameW.ref.lpstrFile
           .cast<Uint16>()
           .asTypedList(maximumPathLength);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.3.1
+version: 4.3.2
 
 dependencies:
   flutter:

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -1,5 +1,6 @@
 @TestOn('windows')
 
+import 'package:file_picker/src/exceptions.dart';
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/windows/file_picker_windows.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -56,6 +57,64 @@ void main() {
         picker.fileTypeToFileFilter(FileType.custom, ['dart', 'html']),
         equals('Files (*.dart,*.html)\x00*.dart;*.html\x00\x00'),
       );
+    });
+  });
+
+  group('validateFileName()', () {
+    test('should throw an exception if the file name contains a < (less than)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('file with < .txt'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test(
+        'should throw an exception if the file name contains a > (greater than)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('file>.csv'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test('should throw an exception if the file name contains a : (colon)', () {
+      expect(() => FilePickerWindows().validateFileName('fi:le.csv'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test(
+        'should throw an exception if the file name contains a " (double quote)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('"output.csv'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test(
+        'should throw an exception if the file name contains a / (forward slash)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('my-output/-file.csv'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test('should throw an exception if the file name contains a \\ (backslash)',
+        () {
+      expect(
+          () =>
+              FilePickerWindows().validateFileName('invalid-\\-file-name.csv'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test('should throw an exception if the file name contains a | (pipe)', () {
+      expect(() => FilePickerWindows().validateFileName('download|.pdf'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test(
+        'should throw an exception if the file name contains a ? (question mark)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('bill?-2021-12-18.pdf'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test('should throw an exception if the file name contains a * (asterisk)',
+        () {
+      expect(() => FilePickerWindows().validateFileName('*.txt'),
+          throwsA(TypeMatcher<IllegalCharacterInFileNameException>()));
+    });
+    test('should return normally given a valid file name', () {
+      expect(
+          () => FilePickerWindows()
+              .validateFileName('0123456789,;.-_+#\'äöüß!§\$%&(){}[]=`´.txt'),
+          returnsNormally);
     });
   });
 }


### PR DESCRIPTION
Fixes #926.

Under Windows the save-file dialog did not open if the specified file name contained an illegal character. Windows prohibits the usage of [reserved characters in file names](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions). Now the exception `IllegalCharacterInFileNameException` is thrown if the specified file name contains forbidden characters.

I also activated many more linter rules, but I had to disable [avoid_print](https://dart-lang.github.io/linter/lints/avoid_print.html) because `file_picker_io.dart` contains print statements.


@miguelpruivo are you okay with my approach of throwing this custom exception? I'm open to suggestions for improvement.