### PR TITLE
Feature for desktop platforms: initial directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.4.0
+
+#### Desktop (Linux, macOS, and Windows)
+Adds the additional parameter `initialDirectory` to configure the initial directory where the dialog should be opened. This parameter is supported for all three dialogs (pick files, pick directory, and save file). The only exception is that the parameter does not work on Windows for the function `getDirectoryPath()`. Please note that this feature has not been implemented for Android and iOS.
+
 ## 4.3.3
 
 #### Desktop (Linux)

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -37,6 +37,7 @@ class FilePickerWeb extends FilePicker {
   @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     bool allowMultiple = false,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -67,7 +67,7 @@ abstract class FilePicker extends PlatformInterface {
   /// Default [type] set to [FileType.any] with [allowMultiple] set to `false`.
   /// Optionally, [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.).
   ///
-  /// If [withData] is set, picked files will have its byte data immediately available on memory as [Uint8List]
+  /// If [withData] is set, picked files will have its byte data immediately available on memory as `Uint8List`
   /// which can be useful if you are picking it for server upload or similar. However, have in mind that
   /// enabling this on IO (iOS & Android) may result in out of memory issues if you allow multiple picks or
   /// pick huge files. Use [withReadStream] instead. Defaults to `true` on web, `false` otherwise.

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -136,7 +136,7 @@ abstract class FilePicker extends PlatformInterface {
   /// window). This parameter works only on Windows desktop.
   ///
   /// [initialDirectory] can be optionally set to select the directory where the
-  /// dialog is opened.
+  /// dialog is opened. On Windows, [initialDirectory] is not supported.
   /// 
   /// Returns `null` if aborted or if the folder path couldn't be resolved.
   ///

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -67,7 +67,7 @@ abstract class FilePicker extends PlatformInterface {
   /// Default [type] set to [FileType.any] with [allowMultiple] set to `false`.
   /// Optionally, [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.).
   ///
-  /// If [withData] is set, picked files will have its byte data immediately available on memory as `Uint8List`
+  /// If [withData] is set, picked files will have its byte data immediately available on memory as [Uint8List]
   /// which can be useful if you are picking it for server upload or similar. However, have in mind that
   /// enabling this on IO (iOS & Android) may result in out of memory issues if you allow multiple picks or
   /// pick huge files. Use [withReadStream] instead. Defaults to `true` on web, `false` otherwise.
@@ -88,6 +88,9 @@ abstract class FilePicker extends PlatformInterface {
   ///
   /// [dialogTitle] can be optionally set on desktop platforms to set the modal window title. It will be ignored on
   /// other platforms.
+  /// 
+  /// [initialDirectory] can be optionally set to select the directory where the
+  /// dialog is opened.
   ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
@@ -97,6 +100,7 @@ abstract class FilePicker extends PlatformInterface {
   /// Returns `null` if aborted.
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
@@ -126,14 +130,22 @@ abstract class FilePicker extends PlatformInterface {
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms. It will be ignored on Web & IO.
-  ///
+
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
   /// window). This parameter works only on Windows desktop.
   ///
+  /// [initialDirectory] can be optionally set to select the directory where the
+  /// dialog is opened.
+  /// 
   /// Returns `null` if aborted or if the folder path couldn't be resolved.
-  Future<String?> getDirectoryPath(
-          {String? dialogTitle, bool lockParentWindow = false}) async =>
+  ///
+  /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    bool lockParentWindow = false,
+    String? initialDirectory,
+  }) async =>
       throw UnimplementedError('getDirectoryPath() has not been implemented.');
 
   /// Opens a save file dialog which lets the user select a file path and a file
@@ -147,11 +159,14 @@ abstract class FilePicker extends PlatformInterface {
   /// Windows).
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
-  ///
+  /// 
   /// [fileName] can be set to a non-empty string to provide a default file
   /// name. Throws an `IllegalCharacterInFileNameException` under Windows if the
   /// given [fileName] contains forbidden characters.
-  ///
+  /// 
+  /// [initialDirectory] can be optionally set to select the directory where the
+  /// file picker dialog is opened. 
+  /// 
   /// The file type filter [type] defaults to [FileType.any]. Optionally,
   /// [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.). Both
   /// parameters are just a proposal to the user as the save file dialog does
@@ -166,6 +181,7 @@ abstract class FilePicker extends PlatformInterface {
   Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     bool lockParentWindow = false,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -88,9 +88,9 @@ abstract class FilePicker extends PlatformInterface {
   ///
   /// [dialogTitle] can be optionally set on desktop platforms to set the modal window title. It will be ignored on
   /// other platforms.
-  /// 
-  /// [initialDirectory] can be optionally set to select the directory where the
-  /// dialog is opened.
+  ///
+  /// [initialDirectory] can be optionally set to an absolute path to specify
+  /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
@@ -130,14 +130,14 @@ abstract class FilePicker extends PlatformInterface {
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms. It will be ignored on Web & IO.
-
+  ///
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
   /// window). This parameter works only on Windows desktop.
   ///
-  /// [initialDirectory] can be optionally set to select the directory where the
-  /// dialog is opened. On Windows, [initialDirectory] is not supported.
-  /// 
+  /// [initialDirectory] can be optionally set to an absolute path to specify
+  /// where the dialog should open. Only supported on Linux, macOS, and Windows.
+  ///
   /// Returns `null` if aborted or if the folder path couldn't be resolved.
   ///
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
@@ -159,14 +159,14 @@ abstract class FilePicker extends PlatformInterface {
   /// Windows).
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
-  /// 
+  ///
   /// [fileName] can be set to a non-empty string to provide a default file
   /// name. Throws an `IllegalCharacterInFileNameException` under Windows if the
   /// given [fileName] contains forbidden characters.
-  /// 
-  /// [initialDirectory] can be optionally set to select the directory where the
-  /// file picker dialog is opened. 
-  /// 
+  ///
+  /// [initialDirectory] can be optionally set to an absolute path to specify
+  /// where the dialog should open. Only supported on Linux, macOS, and Windows.
+  ///
   /// The file type filter [type] defaults to [FileType.any]. Optionally,
   /// [allowedExtensions] might be provided (e.g. `[pdf, svg, jpg]`.). Both
   /// parameters are just a proposal to the user as the save file dialog does

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -26,6 +26,7 @@ class FilePickerIO extends FilePicker {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     String? dialogTitle,
+    String? initialDirectory,
     Function(FilePickerStatus)? onFileLoading,
     bool? allowCompression = true,
     bool allowMultiple = false,
@@ -48,8 +49,11 @@ class FilePickerIO extends FilePicker {
       _channel.invokeMethod<bool>('clear');
 
   @override
-  Future<String?> getDirectoryPath(
-      {String? dialogTitle, bool lockParentWindow = false}) async {
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    bool lockParentWindow = false,
+    String? initialDirectory,
+  }) async {
     try {
       return await _channel.invokeMethod('dir', {});
     } on PlatformException catch (ex) {

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -5,6 +5,7 @@ class FilePickerMacOS extends FilePicker {
   @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
@@ -22,6 +23,7 @@ class FilePickerMacOS extends FilePicker {
     final List<String> arguments = generateCommandLineArguments(
       escapeDialogTitle(dialogTitle ?? defaultDialogTitle),
       fileFilter: fileFilter,
+      initialDirectory: initialDirectory ?? '',
       multipleFiles: allowMultiple,
       pickDirectory: false,
     );
@@ -50,10 +52,12 @@ class FilePickerMacOS extends FilePicker {
   Future<String?> getDirectoryPath({
     String? dialogTitle,
     bool lockParentWindow = false,
+    String? initialDirectory,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final List<String> arguments = generateCommandLineArguments(
       escapeDialogTitle(dialogTitle ?? defaultDialogTitle),
+      initialDirectory: initialDirectory ?? '',
       pickDirectory: true,
     );
 
@@ -72,6 +76,7 @@ class FilePickerMacOS extends FilePicker {
   Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     bool lockParentWindow = false,
@@ -85,6 +90,7 @@ class FilePickerMacOS extends FilePicker {
       escapeDialogTitle(dialogTitle ?? defaultDialogTitle),
       fileFilter: fileFilter,
       fileName: fileName ?? '',
+      initialDirectory: initialDirectory ?? '',
       saveFile: true,
     );
 
@@ -122,6 +128,7 @@ class FilePickerMacOS extends FilePicker {
     String dialogTitle, {
     String fileFilter = '',
     String fileName = '',
+    String initialDirectory = '',
     bool multipleFiles = false,
     bool pickDirectory = false,
     bool saveFile = false,
@@ -141,12 +148,18 @@ class FilePickerMacOS extends FilePicker {
           argument += 'default name "$fileName" ';
         }
       } else {
-        argument += 'of type {$fileFilter} ';
+        if (fileFilter.isNotEmpty) {
+          argument += 'of type {$fileFilter} ';
+        }
 
         if (multipleFiles) {
           argument += 'with multiple selections allowed ';
         }
       }
+    }
+
+    if (initialDirectory.isNotEmpty) {
+      argument += 'default location "$initialDirectory" ';
     }
 
     argument += 'with prompt "$dialogTitle"';

--- a/lib/src/linux/dialog_handler.dart
+++ b/lib/src/linux/dialog_handler.dart
@@ -23,6 +23,7 @@ abstract class DialogHandler {
     String dialogTitle, {
     String fileFilter = '',
     String fileName = '',
+    String initialDirectory = '',
     bool multipleFiles = false,
     bool pickDirectory = false,
     bool saveFile = false,

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -9,6 +9,7 @@ class FilePickerLinux extends FilePicker {
   @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
@@ -29,6 +30,7 @@ class FilePickerLinux extends FilePicker {
     final List<String> arguments = dialogHandler.generateCommandLineArguments(
       dialogTitle ?? defaultDialogTitle,
       fileFilter: fileFilter,
+      initialDirectory: initialDirectory ?? '',
       multipleFiles: allowMultiple,
       pickDirectory: false,
     );
@@ -57,11 +59,13 @@ class FilePickerLinux extends FilePicker {
   Future<String?> getDirectoryPath({
     String? dialogTitle,
     bool lockParentWindow = false,
+    String? initialDirectory,
   }) async {
     final executable = await _getPathToExecutable();
     final List<String> arguments =
         DialogHandler(executable).generateCommandLineArguments(
       dialogTitle ?? defaultDialogTitle,
+      initialDirectory: initialDirectory ?? '',
       pickDirectory: true,
     );
     return await runExecutableWithArguments(executable, arguments);
@@ -71,6 +75,7 @@ class FilePickerLinux extends FilePicker {
   Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     bool lockParentWindow = false,
@@ -87,6 +92,7 @@ class FilePickerLinux extends FilePicker {
       dialogTitle ?? defaultDialogTitle,
       fileFilter: fileFilter,
       fileName: fileName ?? '',
+      initialDirectory: initialDirectory ?? '',
       saveFile: true,
     );
 

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -7,6 +7,7 @@ class KDialogHandler implements DialogHandler {
     String dialogTitle, {
     String fileFilter = '',
     String fileName = '',
+    String initialDirectory = '',
     bool multipleFiles = false,
     bool pickDirectory = false,
     bool saveFile = false,

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -1,5 +1,6 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:file_picker/src/linux/dialog_handler.dart';
+import 'package:path/path.dart' as p;
 
 class KDialogHandler implements DialogHandler {
   @override
@@ -14,7 +15,6 @@ class KDialogHandler implements DialogHandler {
   }) {
     final arguments = ['--title', dialogTitle];
 
-    // Choose right dialog
     if (saveFile && !pickDirectory) {
       arguments.add('--getsavefilename');
     } else if (!saveFile && !pickDirectory) {
@@ -24,13 +24,17 @@ class KDialogHandler implements DialogHandler {
     }
 
     // Start directory for the dialog
-    if (fileName.isNotEmpty) {
-      arguments.add(fileName);
+    if (fileName.isNotEmpty && initialDirectory.isNotEmpty) {
+      arguments.add(p.join(initialDirectory, fileName));
+    } else if (fileName.isNotEmpty) {
+      arguments.add(p.absolute(fileName));
+    } else if (initialDirectory.isNotEmpty) {
+      arguments.add(initialDirectory);
     }
 
     if (!pickDirectory && fileFilter.isNotEmpty) {
       // In order to specify a filter, a start directory has to be specified
-      if (fileName.isEmpty) {
+      if (fileName.isEmpty && initialDirectory.isEmpty) {
         arguments.add('.');
       }
       arguments.add(fileFilter);

--- a/lib/src/linux/qarma_and_zenity_handler.dart
+++ b/lib/src/linux/qarma_and_zenity_handler.dart
@@ -1,5 +1,6 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:file_picker/src/linux/dialog_handler.dart';
+import 'package:path/path.dart' as p;
 
 class QarmaAndZenityHandler implements DialogHandler {
   @override
@@ -7,6 +8,7 @@ class QarmaAndZenityHandler implements DialogHandler {
     String dialogTitle, {
     String fileFilter = '',
     String fileName = '',
+    String initialDirectory = '',
     bool multipleFiles = false,
     bool pickDirectory = false,
     bool saveFile = false,
@@ -15,9 +17,14 @@ class QarmaAndZenityHandler implements DialogHandler {
 
     if (saveFile) {
       arguments.add('--save');
-      if (fileName.isNotEmpty) {
-        arguments.add('--filename=$fileName');
-      }
+    }
+
+    if (fileName.isNotEmpty && initialDirectory.isNotEmpty) {
+      arguments.add('--filename=${p.join(initialDirectory, fileName)}');
+    } else if (fileName.isNotEmpty) {
+      arguments.add('--filename=$fileName');
+    } else if (initialDirectory.isNotEmpty) {
+      arguments.add('--filename=$initialDirectory');
     }
 
     if (fileFilter.isNotEmpty) {

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -15,6 +15,7 @@ class FilePickerWindows extends FilePicker {
   @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
@@ -34,6 +35,7 @@ class FilePickerWindows extends FilePicker {
       allowMultiple: allowMultiple,
       allowedExtensions: allowedExtensions,
       dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
       type: type,
       lockParentWindow: lockParentWindow,
     );
@@ -61,6 +63,7 @@ class FilePickerWindows extends FilePicker {
   Future<String?> getDirectoryPath({
     String? dialogTitle,
     bool lockParentWindow = false,
+    String? initialDirectory,
   }) {
     final pathIdPointer =
         _pickDirectory(dialogTitle ?? defaultDialogTitle, lockParentWindow);
@@ -76,6 +79,7 @@ class FilePickerWindows extends FilePicker {
   Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
+    String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     bool lockParentWindow = false,
@@ -90,6 +94,7 @@ class FilePickerWindows extends FilePicker {
       allowedExtensions: allowedExtensions,
       defaultFileName: fileName,
       dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
       type: type,
       lockParentWindow: lockParentWindow,
     );
@@ -243,6 +248,7 @@ class FilePickerWindows extends FilePicker {
     bool allowMultiple = false,
     String? dialogTitle,
     String? defaultFileName,
+    String? initialDirectory,
     List<String>? allowedExtensions,
     FileType type = FileType.any,
     bool lockParentWindow = false,
@@ -257,7 +263,8 @@ class FilePickerWindows extends FilePicker {
     openFileNameW.ref.lpstrFilter =
         fileTypeToFileFilter(type, allowedExtensions).toNativeUtf16();
     openFileNameW.ref.nMaxFile = lpstrFileBufferSize;
-    openFileNameW.ref.lpstrInitialDir = ''.toNativeUtf16();
+    openFileNameW.ref.lpstrInitialDir =
+        (initialDirectory ?? '').toNativeUtf16();
     openFileNameW.ref.flags = ofnExplorer | ofnFileMustExist | ofnHideReadOnly;
 
     if (lockParentWindow) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.3.3
+version: 4.4.0
 
 dependencies:
   flutter:

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -335,7 +335,9 @@ void main() {
       );
     });
 
-    test('should generate the arguments for picking a file when an initial directory is given', () {
+    test(
+        'should generate the arguments for picking a file when an initial directory is given',
+        () {
       final picker = FilePickerMacOS();
 
       final cliArguments = picker.generateCommandLineArguments(
@@ -345,11 +347,14 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals('-e choose file default location "/Users/john/Desktop" with prompt "Pick a file:"'),
+        equals(
+            '-e choose file default location "/Users/john/Desktop" with prompt "Pick a file:"'),
       );
     });
 
-    test('should generate the arguments for picking a directory when an initial directory is given', () {
+    test(
+        'should generate the arguments for picking a directory when an initial directory is given',
+        () {
       final picker = FilePickerMacOS();
 
       final cliArguments = picker.generateCommandLineArguments(
@@ -361,11 +366,14 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals('-e choose folder default location "/Users/john/workspace" with prompt "Pick directory:"'),
+        equals(
+            '-e choose folder default location "/Users/john/workspace" with prompt "Pick directory:"'),
       );
     });
 
-    test('should generate the arguments for saving a file when an initial directory is given', () {
+    test(
+        'should generate the arguments for saving a file when an initial directory is given',
+        () {
       final picker = FilePickerMacOS();
 
       final cliArguments = picker.generateCommandLineArguments(
@@ -377,7 +385,8 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals('-e choose file name default name "output.pdf" default location "/Users/john/Downloads" with prompt "Save as:"'),
+        equals(
+            '-e choose file name default name "output.pdf" default location "/Users/john/Downloads" with prompt "Save as:"'),
       );
     });
   });

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -243,7 +243,7 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals('-e choose file of type {} with prompt "Select a file:"'),
+        equals('-e choose file with prompt "Select a file:"'),
       );
     });
 
@@ -277,7 +277,7 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals(
-          '-e choose file of type {} with multiple selections allowed with prompt "Select files:"',
+          '-e choose file with multiple selections allowed with prompt "Select files:"',
         ),
       );
     });
@@ -332,6 +332,52 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals('-e choose folder with prompt "Select a directory:"'),
+      );
+    });
+
+    test('should generate the arguments for picking a file when an initial directory is given', () {
+      final picker = FilePickerMacOS();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Pick a file:',
+        initialDirectory: '/Users/john/Desktop',
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals('-e choose file default location "/Users/john/Desktop" with prompt "Pick a file:"'),
+      );
+    });
+
+    test('should generate the arguments for picking a directory when an initial directory is given', () {
+      final picker = FilePickerMacOS();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Pick directory:',
+        fileName: 'output.pdf',
+        initialDirectory: '/Users/john/workspace',
+        pickDirectory: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals('-e choose folder default location "/Users/john/workspace" with prompt "Pick directory:"'),
+      );
+    });
+
+    test('should generate the arguments for saving a file when an initial directory is given', () {
+      final picker = FilePickerMacOS();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Save as:',
+        fileName: 'output.pdf',
+        initialDirectory: '/Users/john/Downloads',
+        saveFile: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals('-e choose file name default name "output.pdf" default location "/Users/john/Downloads" with prompt "Save as:"'),
       );
     });
   });

--- a/test/linux/kdialog_handler_test.dart
+++ b/test/linux/kdialog_handler_test.dart
@@ -3,6 +3,7 @@
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/linux/kdialog_handler.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   final imageTestFile = '/tmp/test_linux.jpg';
@@ -133,7 +134,8 @@ void main() {
 
       expect(
         cliArguments.join(' '),
-        equals("""--title Select output file: --getsavefilename test.out"""),
+        equals(
+            """--title Select output file: --getsavefilename ${p.absolute('test.out')}"""),
       );
     });
 
@@ -197,6 +199,68 @@ void main() {
       expect(
         cliArguments.join(' '),
         equals("""--title Select a directory: --getexistingdirectory"""),
+      );
+    });
+
+    test(
+        'should generate the arguments for picking a file when an initial directory is given',
+        () {
+      final cliArguments = KDialogHandler().generateCommandLineArguments(
+        'Select a file:',
+        initialDirectory: '/etc/python3.8',
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals("""--title Select a file: --getopenfilename /etc/python3.8"""),
+      );
+    });
+
+    test(
+        'should generate the arguments for saving a file when an initial directory is given',
+        () {
+      final cliArguments = KDialogHandler().generateCommandLineArguments(
+        'Save as:',
+        initialDirectory: '/home/user/Desktop/',
+        saveFile: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals("""--title Save as: --getsavefilename /home/user/Desktop/"""),
+      );
+    });
+
+    test(
+        'should generate the arguments for saving a file when an initial directory and the filename is given',
+        () {
+      final cliArguments = KDialogHandler().generateCommandLineArguments(
+        'Save as:',
+        fileName: 'output.pdf',
+        initialDirectory: '/tmp',
+        saveFile: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals("""--title Save as: --getsavefilename /tmp/output.pdf"""),
+      );
+    });
+
+    test(
+        'should set the KDialog option "startDir" to the current directory if a file filter is given but fileName and initialDir are empty',
+        () {
+      final cliArguments = KDialogHandler().generateCommandLineArguments(
+        'Select a file:',
+        fileFilter: 'HTML File (*.html)',
+        fileName: '',
+        initialDirectory: '',
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals(
+            """--title Select a file: --getopenfilename . HTML File (*.html)"""),
       );
     });
   });

--- a/test/linux/qarma_and_zenity_handler_test.dart
+++ b/test/linux/qarma_and_zenity_handler_test.dart
@@ -195,5 +195,59 @@ void main() {
         equals("""--file-selection --title Select a directory: --directory"""),
       );
     });
+
+    test(
+        'should generate the arguments for picking a file when an initial directory is given',
+        () {
+      final picker = FilePickerLinux();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Select a file:',
+        initialDirectory: '/home/user/Desktop/',
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals(
+            """--file-selection --title Select a file: --filename=/home/user/Desktop/"""),
+      );
+    });
+
+    test(
+        'should generate the arguments for saving a file when an initial directory is given',
+        () {
+      final picker = FilePickerLinux();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Save as:',
+        initialDirectory: '/home/user/Desktop/',
+        saveFile: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals(
+            """--file-selection --title Save as: --save --filename=/home/user/Desktop/"""),
+      );
+    });
+
+    test(
+        'should generate the arguments for saving a file when an initial directory and the filename is given',
+        () {
+      final picker = FilePickerLinux();
+
+      final cliArguments = picker.generateCommandLineArguments(
+        'Save as:',
+        fileName: 'output.pdf',
+        initialDirectory: '/home/user/Desktop/',
+        saveFile: true,
+      );
+
+      expect(
+        cliArguments.join(' '),
+        equals(
+            """--file-selection --title Save as: --save --filename=/home/user/Desktop/output.pdf"""),
+      );
+    });
   });
 }

--- a/test/linux/qarma_and_zenity_handler_test.dart
+++ b/test/linux/qarma_and_zenity_handler_test.dart
@@ -199,9 +199,7 @@ void main() {
     test(
         'should generate the arguments for picking a file when an initial directory is given',
         () {
-      final picker = FilePickerLinux();
-
-      final cliArguments = picker.generateCommandLineArguments(
+      final cliArguments = QarmaAndZenityHandler().generateCommandLineArguments(
         'Select a file:',
         initialDirectory: '/home/user/Desktop/',
       );
@@ -216,9 +214,7 @@ void main() {
     test(
         'should generate the arguments for saving a file when an initial directory is given',
         () {
-      final picker = FilePickerLinux();
-
-      final cliArguments = picker.generateCommandLineArguments(
+      final cliArguments = QarmaAndZenityHandler().generateCommandLineArguments(
         'Save as:',
         initialDirectory: '/home/user/Desktop/',
         saveFile: true,
@@ -234,9 +230,7 @@ void main() {
     test(
         'should generate the arguments for saving a file when an initial directory and the filename is given',
         () {
-      final picker = FilePickerLinux();
-
-      final cliArguments = picker.generateCommandLineArguments(
+      final cliArguments = QarmaAndZenityHandler().generateCommandLineArguments(
         'Save as:',
         fileName: 'output.pdf',
         initialDirectory: '/home/user/Desktop/',


### PR DESCRIPTION
Implements #859 for Linux, macOS, and Windows.

I added the parameter `initialDirectory` to all three methods `pickFiles()`, `getDirectoryPath()`, and `saveFile()`. This optional parameter must contain an **absolute** path to the directory where the dialog should open. 

Example code:

```dart
await FilePicker.platform.pickFiles(
  initialDirectory: '/home/johnDoe/workspace',
);
await FilePicker.platform.getDirectoryPath(
  initialDirectory: '/home/johnDoe/workspace',
);
await FilePicker.platform.saveFile(
  initialDirectory: '/home/johnDoe/workspace',
);
```

I was able to successfully implement and test the Linux and macOS implementations. Only the Windows implementation does not work completely:

* **Linux:**
   - [x] `pickFiles()`
   - [x] `getDirectoryPath()`
   - [x] `saveFile()`
* **macOS:**
   - [x] `pickFiles()`
   - [x] `getDirectoryPath()`
   - [x] `saveFile()`
* **Windows:**
   - [x] `pickFiles()`
   - [ ] `getDirectoryPath()` :x: seems like setting the initial directory is not supported when picking a directory
   - [x] `saveFile()`
