### PR TITLE
#915 modern directory picker on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.0
+
+#### Desktop (Windows)
+Changes the implementation of `getDirectoryPath()` on Windows to provide a modern dialog that looks the same as a file picker dialog ([#915](https://github.com/miguelpruivo/flutter_file_picker/issues/915)).
+
 ## 4.4.0
 
 #### Desktop (Linux, macOS, and Windows)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ A package that allows you to use the native file explorer to pick single or mult
 
 If you have any feature that you want to see in this package, please feel free to issue a suggestion. 🎉
 
+## Compatibility Chart
+
+| API                   | Android            | iOS                | Linux              | macOS              | Windows            | Web                |
+| --------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| clearTemporaryFiles() | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| getDirectoryPath()    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| pickFiles()           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| saveFile()            | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+
+See the [API section of the File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api) or the [official API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html) for further details.
+
+
 ## Documentation
 See the **[File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki)** for every detail on about how to install, setup and use it.
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -136,10 +136,14 @@ abstract class FilePicker extends PlatformInterface {
   /// window). This parameter works only on Windows desktop.
   ///
   /// [initialDirectory] can be optionally set to an absolute path to specify
-  /// where the dialog should open. Only supported on Linux, macOS, and Windows.
+  /// where the dialog should open. Only supported on Linux and macOS.
   ///
-  /// Returns `null` if aborted or if the folder path couldn't be resolved.
+  /// Returns a [Future<String?>] which resolves to  the absolute path of the selected directory,
+  /// if the user selected a directory. Returns `null` if the user aborted the dialog or if the
+  /// folder path couldn't be resolved.
   ///
+  /// Note: on Windows, throws a `WindowsException` with a detailed error message, if the dialog
+  /// could not be instantiated or the dialog result could not be interpreted.
   /// Note: Some Android paths are protected, hence can't be accessed and will return `/` instead.
   Future<String?> getDirectoryPath({
     String? dialogTitle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.0.0
   ffi: ^1.1.2
   path: ^1.8.0
+  win32: ^2.4.1
 
 dev_dependencies:
   lints: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.4.0
+version: 4.5.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
Changes the implementation of `getDirectoryPath` on Windows so that the dialog looks like other, modern Windows dialogs as requested in #915.

| Previously, the folder picker dialog looked like this: | With this PR |
| ---------- | ------------ |
| ![grafik](https://user-images.githubusercontent.com/9049899/154863194-9e723c54-c591-405b-9d28-a134ef9cac2d.png) | ![grafik](https://user-images.githubusercontent.com/9049899/154863262-0dba5b96-c4f7-414f-b709-dd4f2df6d1ab.png)              |

**Win32:**
For this PR, I switched from `SHBrowseForFolderW` to [Microsoft's `IFileDialog`](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ifiledialog) and therefore added `win32` as a dependency. `win32` is written by Flutter's product manager (Tim Sneath) and simplifies access to the Windows APIs. In the long run, I'm planning to refactor the two remaining Windows implementations of `pickFiles()` and `saveFile()` so that they are based on `win32`, too.

**Initial directory:**
The previous implementation based on `SHBrowseForFolderW` did not allow to set the folder where the dialog should open (parameter `initialDirectory`). The new API of `IFileDialog` provides two methods `SetFolder()` and `SetDefaultFolder()` for this purpose. However, I couldn't figure out how to use any of these two methods. We could definitely need some help here.
I fixed the Dart docs of `getDirectoryPath()` because they mentioned that `initialDirectory` was supported on Linux, macOS, and Windows which is wrong. My mistake. Thank you, @julianklose, for noticing that (#970).

**Compatibility chart:**
As requested in #943 by @feinstein, I added a compatibility chart to the README.