### PR TITLE
Add conditional compilation of media, audio and document pickers for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.6.0
+
+#### iOS
+Add conditional compilation of media, audio and document pickers for iOS.
+This prevents error messages for permissions (NSPhotoLibraryUsageDescription, NSAppleMusicUsageDescription, etc.) when publishing to app store connect, in case you don't need either category. This addresses [#783](https://github.com/miguelpruivo/flutter_file_picker/issues/783) in a different way.
+
 ## 4.5.0
 
 #### Desktop (Windows)

--- a/ios/Classes/FilePickerPlugin.h
+++ b/ios/Classes/FilePickerPlugin.h
@@ -4,14 +4,23 @@
 #import <Photos/Photos.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
-#if __has_include(<PhotosUI/PHPicker.h>) || __has_include("PHPicker.h")
+#if PICKER_MEDIA && (__has_include(<PhotosUI/PHPicker.h>) || __has_include("PHPicker.h"))
 #define PHPicker
 #import <PhotosUI/PHPicker.h>
 #endif
 
-@interface FilePickerPlugin : NSObject<FlutterPlugin, FlutterStreamHandler, UIAdaptivePresentationControllerDelegate, UIDocumentPickerDelegate, UITabBarDelegate, UINavigationControllerDelegate, UIImagePickerControllerDelegate, MPMediaPickerControllerDelegate
+@interface FilePickerPlugin : NSObject<FlutterPlugin, FlutterStreamHandler, UITabBarDelegate, UINavigationControllerDelegate, UIAdaptivePresentationControllerDelegate
+#ifdef PICKER_MEDIA
+    , UIImagePickerControllerDelegate
 #ifdef PHPicker
-, PHPickerViewControllerDelegate
+    , PHPickerViewControllerDelegate
 #endif
+#endif // PICKER_MEDIA
+#ifdef PICKER_DOCUMENT
+    , UIDocumentPickerDelegate
+#endif // PICKER_DOCUMENT
+#ifdef PICKER_AUDIO
+    , MPMediaPickerControllerDelegate
+#endif // PICKER_AUDIO
 >
 @end

--- a/ios/file_picker.podspec
+++ b/ios/file_picker.podspec
@@ -8,9 +8,9 @@ Pod::Spec.new do |s|
   s.description           = <<-DESC
 A flutter plugin to show native file picker dialogs.
                        DESC
-  s.homepage              = 'https://github.com/yangyxd/flutter_picker'
+  s.homepage              = 'https://github.com/miguelpruivo/plugins_flutter_file_picker'
   s.license               = { :file => '../LICENSE' }
-  s.author                = { 'yangyxd' => 'yangyxd@126.com' }
+  s.author                = 'Miguel Ruivo'
   s.source                = { :path => '.' }
   s.source_files          = 'Classes/**/*'
   s.public_header_files   = 'Classes/**/*.h'

--- a/ios/file_picker.podspec
+++ b/ios/file_picker.podspec
@@ -2,20 +2,35 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'file_picker'
-  s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
-  s.description      = <<-DESC
-A new flutter plugin project.
+  s.name                  = 'file_picker'
+  s.version               = '0.0.1'
+  s.summary               = 'A flutter plugin to show native file picker dialogs'
+  s.description           = <<-DESC
+A flutter plugin to show native file picker dialogs.
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
-  s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Flutter'
-  s.dependency 'DKImagePickerController/PhotoGallery'
+  s.homepage              = 'https://github.com/yangyxd/flutter_picker'
+  s.license               = { :file => '../LICENSE' }
+  s.author                = { 'yangyxd' => 'yangyxd@126.com' }
+  s.source                = { :path => '.' }
+  s.source_files          = 'Classes/**/*'
+  s.public_header_files   = 'Classes/**/*.h'
+  
   s.ios.deployment_target = '8.0'
+
+  s.dependency 'Flutter'
+
+  preprocess_definitions=[]
+  if !Pod.const_defined?(:PICKER_MEDIA) || PICKER_MEDIA
+    preprocess_definitions << ["PICKER_MEDIA=1"]
+    s.dependency 'DKImagePickerController/PhotoGallery'
+  end
+  if !Pod.const_defined?(:PICKER_AUDIO) || PICKER_AUDIO
+    preprocess_definitions << ["PICKER_AUDIO=1"]
+  end
+  if !Pod.const_defined?(:PICKER_DOCUMENT) || PICKER_DOCUMENT
+    preprocess_definitions << ["PICKER_DOCUMENT=1"]
+  end
+  s.pod_target_xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => preprocess_definitions }
+
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.5.0
+version: 4.6.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
Enable conditional compilation of the media, audio and documents pickers for iOS.
This prevents error messages for permissions (NSPhotoLibraryUsageDescription, NSAppleMusicUsageDescription, etc.) when publishing to app store connect, in case you don't need either category.

This addresses #783 in a different way.

Additional usage instructions that should be added to: https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#ios

---
You can prevent the need for certain permissions by excluding compilation of Media, Audio or Documents picker respectively.
This is achieved by including in the file ```<project root>/ios/Podfile``` the line ```Pod::PICKER_MEDIA = false```, resp. ```Pod::PICKER_AUDIO = false```, resp. ```Pod::PICKER_DOCUMENT = false``` before the line ```target 'Runner' do```.

(If you do use a file picker that is included an error will be logged and no dialog is shown.)

---