### PR TITLE
fix the input element display value

### DIFF
--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -60,6 +60,7 @@ class FilePickerWeb extends FilePicker {
     uploadInput.draggable = true;
     uploadInput.multiple = allowMultiple;
     uploadInput.accept = accept;
+    uploadInput.style.display = 'none';
 
     bool changeEventTriggered = false;
 


### PR DESCRIPTION
This PR fixes the `<input>` tag's display value. It was not set to none, which results in it showing up in some cases.