### PR TITLE
add ofnNoChangeDir to make desktop consistent for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.2
+#### Desktop (Windows)
+Adds the flag `OFN_NOCHANGEDIR` to prevent current directory from changing on Windows. That makes all platform consistent.
+
 ## 4.5.1
 
 #### Web

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -268,7 +268,8 @@ class FilePickerWindows extends FilePicker {
     openFileNameW.ref.nMaxFile = lpstrFileBufferSize;
     openFileNameW.ref.lpstrInitialDir =
         (initialDirectory ?? '').toNativeUtf16();
-    openFileNameW.ref.flags = ofnExplorer | ofnFileMustExist | ofnHideReadOnly;
+    openFileNameW.ref.flags =
+        ofnExplorer | ofnFileMustExist | ofnNoChangeDir | ofnHideReadOnly;
 
     if (lockParentWindow) {
       openFileNameW.ref.hwndOwner = _getWindowHandle();

--- a/lib/src/windows/file_picker_windows_ffi_types.dart
+++ b/lib/src/windows/file_picker_windows_ffi_types.dart
@@ -217,5 +217,8 @@ const ofnExplorer = 0x00080000;
 /// The user can type only names of existing files in the File Name entry field.
 const ofnFileMustExist = 0x00001000;
 
+/// Keeps current directory
+const ofnNoChangeDir = 0x00000008;
+
 /// Hides the Read Only check box.
 const ofnHideReadOnly = 0x00000004;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,14 +3,14 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.5.1
+version: 4.5.2
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-    
+
   flutter_plugin_android_lifecycle: ^2.0.2
   plugin_platform_interface: ^2.0.0
   ffi: ^1.1.2
@@ -25,7 +25,7 @@ dev_dependencies:
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"
-  
+
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
Before this changes, If we used `pickFiles` on Windows, the current directory would be changed. And the behavior is inconsistent with Linux and Macos, that those never modify current directory. Issue: https://github.com/miguelpruivo/flutter_file_picker/issues/804

For example (from example):
```
void _pickFiles() async {
    _resetState();
    try {
      _directoryPath = null;
      print(Directory.current.path);
      _paths = (await FilePicker.platform.pickFiles(
        type: _pickingType,
        allowMultiple: _multiPick,
        onFileLoading: (FilePickerStatus status) => print(status),
        allowedExtensions: (_extension?.isNotEmpty ?? false)
            ? _extension?.replaceAll(' ', '').split(',')
            : null,
      ))
          ?.files;
      print(Directory.current.path);
    } on PlatformException catch (e) {
      _logException('Unsupported operation' + e.toString());
    } catch (e) {
      _logException(e.toString());
    }
    if (!mounted) return;
    setState(() {
      _isLoading = false;
      _fileName =
          _paths != null ? _paths!.map((e) => e.name).toString() : '...';
      _userAborted = _paths == null;
    });
  }
```
Will output: (If I select file from C)
```
C:\flutter_picker_file\example
C:\
```

So I add the `OFN_NOCHANGEDIR` flag to prevent current directory from changing by default on Windows. Reference [here](https://stackoverflow.com/questions/41244561/why-the-current-directory-changes).

Then using the sample code will output:
```
C:\flutter_picker_file\example
C:\flutter_picker_file\example
```

This make the same logic as MacOS and Linux.