### PR TITLE
Updated dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
-          flutter-version: '2.x'
+          flutter-version: '3.x'
+
+      - run: flutter --version
 
       - name: Install dependencies
         run: flutter pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.0
+
+#### General
+Updated dependecies (most importantly is upgrade from ffi 1.1.2 to 2.0.1).
+Update lints from 1.0.1 to 2.0.0 (with several fixes of code).
+
 ## 4.6.1
 
 #### iOS

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
 
 import 'package:file_picker/_internal/file_picker_web.dart';
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -37,7 +37,7 @@ abstract class FilePicker extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static late FilePicker _instance = FilePicker._setPlatform();
+  static FilePicker _instance = FilePicker._setPlatform();
 
   static FilePicker get platform => _instance;
 

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
-import 'package:file_picker/src/platform_file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -112,7 +112,7 @@ class FilePickerMacOS extends FilePicker {
       case FileType.audio:
         return '"aac", "midi", "mp3", "ogg", "wav"';
       case FileType.custom:
-        return '"", "' + allowedExtensions!.join('", "') + '"';
+        return '"", "${allowedExtensions!.join('", "')}"';
       case FileType.image:
         return '"bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.media:

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -58,9 +58,7 @@ class KDialogHandler implements DialogHandler {
       case FileType.audio:
         return 'Audio File (*.aac *.midi *.mp3 *.ogg *.wav)';
       case FileType.custom:
-        return '${allowedExtensions!
-                .map((ext) => ext.toUpperCase())
-                .join(' File, ')} File (*.${allowedExtensions.join(' *.')})';
+        return '${allowedExtensions!.map((ext) => ext.toUpperCase()).join(' File, ')} File (*.${allowedExtensions.join(' *.')})';
       case FileType.image:
         return 'Image File (*.bmp *.gif *.jpeg *.jpg *.png)';
       case FileType.media:

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -58,12 +58,9 @@ class KDialogHandler implements DialogHandler {
       case FileType.audio:
         return 'Audio File (*.aac *.midi *.mp3 *.ogg *.wav)';
       case FileType.custom:
-        return allowedExtensions!
+        return '${allowedExtensions!
                 .map((ext) => ext.toUpperCase())
-                .join(' File, ') +
-            ' File (*.' +
-            allowedExtensions.join(' *.') +
-            ')';
+                .join(' File, ')} File (*.${allowedExtensions.join(' *.')})';
       case FileType.image:
         return 'Image File (*.bmp *.gif *.jpeg *.jpg *.png)';
       case FileType.media:
@@ -83,7 +80,7 @@ class KDialogHandler implements DialogHandler {
 
     return fileSelectionResult
         .split('\n')
-        .map((String path) => path.startsWith('/') ? path : '/' + path)
+        .map((String path) => path.startsWith('/') ? path : '/$path')
         .toList();
   }
 }

--- a/lib/src/linux/qarma_and_zenity_handler.dart
+++ b/lib/src/linux/qarma_and_zenity_handler.dart
@@ -50,7 +50,7 @@ class QarmaAndZenityHandler implements DialogHandler {
       case FileType.audio:
         return '*.aac *.midi *.mp3 *.ogg *.wav';
       case FileType.custom:
-        return '*.' + allowedExtensions!.join(' *.');
+        return '*.${allowedExtensions!.join(' *.')}';
       case FileType.image:
         return '*.bmp *.gif *.jpeg *.jpg *.png';
       case FileType.media:
@@ -69,7 +69,7 @@ class QarmaAndZenityHandler implements DialogHandler {
     }
     return fileSelectionResult
         .split('|/')
-        .map((String path) => path.startsWith('/') ? path : '/' + path)
+        .map((String path) => path.startsWith('/') ? path : '/$path')
         .toList();
   }
 }

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -297,12 +297,12 @@ class FilePickerWindows extends FilePicker {
   }
 
   Pointer _getWindowHandle() {
-    final _user32 = DynamicLibrary.open('user32.dll');
+    final user32 = DynamicLibrary.open('user32.dll');
 
-    final findWindowA = _user32.lookupFunction<
-        Int32 Function(Pointer<Utf8> _lpClassName, Pointer<Utf8> _lpWindowName),
-        int Function(Pointer<Utf8> _lpClassName,
-            Pointer<Utf8> _lpWindowName)>('FindWindowA');
+    final findWindowA = user32.lookupFunction<
+        Int32 Function(Pointer<Utf8> lpClassName, Pointer<Utf8> lpWindowName),
+        int Function(Pointer<Utf8> lpClassName,
+            Pointer<Utf8> lpWindowName)>('FindWindowA');
 
     int hWnd =
         findWindowA('FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf8(), nullptr);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 4.6.1
+version: 5.0.0
 
 dependencies:
   flutter:
@@ -14,7 +14,7 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.6
   plugin_platform_interface: ^2.1.2
   ffi: ^2.0.1
-  path: ^1.8.1
+  path: ^1.8.0
   win32: ^2.7.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
     
-  flutter_plugin_android_lifecycle: ^2.0.2
-  plugin_platform_interface: ^2.0.0
-  ffi: ^1.1.2
-  path: ^1.8.0
-  win32: ^2.4.1
+  flutter_plugin_android_lifecycle: ^2.0.6
+  plugin_platform_interface: ^2.1.2
+  ffi: ^2.0.1
+  path: ^1.8.1
+  win32: ^2.7.0
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.0.0
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.10.0"
   
 flutter:


### PR DESCRIPTION
I have an issue with library because I want to use `ffi` version >= 2.0.0, but file picker requires `ffi` < 2.0.0

So I updated all the dependencies. Because I changed to `lints` 2.0.0, I fixed problems a bit

Tests are passed:

- file_picker_macos_test.dart
- file_picker_utils_test.dart

Can't process windows and linux tests because I ran it on MacOS machine