### PR TITLE
Picking files without caching 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,12 @@ jobs:
     name: Run unit tests on ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.x'
 
       - run: flutter --version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+#### Desktop (Windows)
+Update Dependencies to latest versions (Win32 2.7.0 to 3.0.0)
+
 ## 5.0.1
 #### Android
 Replaces random number generation with milliseconds timestamp in file name fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 5.1.0
 #### Desktop (Windows)
-Update Dependencies to latest versions (Win32 2.7.0 to 3.0.0)
+- Update Dependencies to latest versions (Win32 2.7.0 to 3.0.0). (Thank you @ishangavidusha)
+- Set default dialog title to empty. (Thank you @whuhewei)
+
+#### iOS
+Fixes an issue when picking live photos. (Thank you @nagibazad)
+
+#### Android
+Removes READ_EXTERNAL_STORAGE on SDKs targeting 33 or above. (Thank you @alexmercerind)
 
 ## 5.0.1
 #### Android

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
  <a href="https://github.com/Solido/awesome-flutter">
     <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square">
   </a>
- <a href="https://codemagic.io/apps/5ce89f4a9b46f5000ca89638/5ce89f4a9b46f5000ca89637/latest_build">
-    <img alt="Build Status" src="https://api.codemagic.io/apps/5ee2d379c2d4737a756cbd00/5ee2d379c2d4737a756cbcff/status_badge.svg">
-  </a>
  <a href="https://www.buymeacoffee.com/gQyz2MR">
     <img alt="Buy me a coffee" src="https://img.shields.io/badge/Donate-Buy%20Me%20A%20Coffee-yellow.svg">
   </a>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.4.2))
 connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=C\:/Program Files/Eclipse Adoptium/jdk-17.0.2.8-hotspot
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -262,12 +262,15 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         this.isMultipleSelection = isMultipleSelection;
         this.loadDataToMemory = withData;
         this.allowedExtensions = allowedExtensions;
-
-        if (!this.permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            this.permissionManager.askForPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_CODE);
-            return;
+        // `READ_EXTERNAL_STORAGE` permission is not needed since SDK 33 (Android 13 or higher).
+        // `READ_EXTERNAL_STORAGE` & `WRITE_EXTERNAL_STORAGE` are no longer meant to be used, but classified into granular types.
+        // Reference: https://developer.android.com/about/versions/13/behavior-changes-13
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (!this.permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                this.permissionManager.askForPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_CODE);
+                return;
+            }
         }
-
         this.startFileExplorer();
     }
 

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -35,7 +35,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     private final PermissionManager permissionManager;
     private MethodChannel.Result pendingResult;
     private boolean isMultipleSelection = false;
-    private boolean loadDataToMemory = false;
+    private  boolean loadDataToMemory = false;
     private String type;
     private String[] allowedExtensions;
     private EventChannel.EventSink eventSink;

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -12,8 +12,10 @@ import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
-
+import android.provider.MediaStore;
+import android.content.ContentUris;
 import androidx.annotation.Nullable;
+import android.text.TextUtils;
 import androidx.annotation.RequiresApi;
 
 import java.io.BufferedInputStream;

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -128,8 +128,8 @@ public class FileUtils {
         FileOutputStream fos = null;
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
-        Log.i(TAG, "abhi1618o testing: " + fileName);
-        final String path = context.getFilesDir().getAbsolutePath() + "/file_picker/" + (fileName != null ? fileName : System.currentTimeMillis());
+       
+        final String path = context.getFilesDir().getAbsolutePath();
         Log.i(TAG, "abhi1618o testing: " + path);
         final File file = new File(path);
 

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -233,8 +233,13 @@ public class FileUtils {
 
         final String path = getPath(uri, context);
         Log.i(TAG, "abhi1618o testing0: " + path);
-
-        final File file = new File(path);
+        File file;
+        try {
+             file = new File(path);
+        } catch (NullPointerException e) {
+            Log.i(TAG, "abhi1618o testing1: " + path);
+        }
+        
 
         // if(!file.exists()) {
         // file.getParentFile().mkdirs();
@@ -390,8 +395,6 @@ public class FileUtils {
         }
     }
 
- 
-
     private static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());
     }
@@ -428,9 +431,11 @@ public class FileUtils {
         }
         return null;
     }
+
     private static boolean isMediaDocument(Uri uri) {
         return "com.android.providers.media.documents".equals(uri.getAuthority());
     }
+
     private static boolean isDropBoxUri(Uri uri) {
         return "com.dropbox.android.FileCache".equals(uri.getAuthority());
     }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -240,6 +240,7 @@ public class FileUtils {
             Log.i(TAG, "abhi1618o testing1: " + path);
         }
         
+        file= File(path);
 
         // if(!file.exists()) {
         // file.getParentFile().mkdirs();

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -129,8 +129,9 @@ public class FileUtils {
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
        
-        final String path = context.getFilesDir().getAbsolutePath();
-        Log.i(TAG, "abhi1618o testing: " + path);
+        final String path = context.getFilesDir();
+        Log.i(TAG, "abhi1618o testing0: " + path);
+   
         final File file = new File(path);
 
         // if(!file.exists()) {

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -63,7 +63,8 @@ public class FileUtils {
         try {
 
             if (uri.getScheme().equals("content")) {
-                Cursor cursor = context.getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
+                Cursor cursor = context.getContentResolver().query(uri, new String[] { OpenableColumns.DISPLAY_NAME },
+                        null, null, null);
                 try {
                     if (cursor != null && cursor.moveToFirst()) {
                         result = cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME));
@@ -79,7 +80,7 @@ public class FileUtils {
                     result = result.substring(cut + 1);
                 }
             }
-        } catch (Exception ex){
+        } catch (Exception ex) {
             Log.e(TAG, "Failed to handle file name: " + ex.toString());
         }
 
@@ -119,8 +120,9 @@ public class FileUtils {
             }
             fileInfo.withData(bytes);
 
-        }  catch (Exception e) {
-            Log.e(TAG, "Failed to load bytes into memory with error " + e.toString() + ". Probably the file is too big to fit device memory. Bytes won't be added to the file this time.");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to load bytes into memory with error " + e.toString()
+                    + ". Probably the file is too big to fit device memory. Bytes won't be added to the file this time.");
         }
     }
 
@@ -138,7 +140,7 @@ public class FileUtils {
         }
         return null;
     }
-    
+
     @TargetApi(19)
     private static String getForApi19(Context context, Uri uri) {
         Log.e(TAG, "Getting for API 19 or above" + uri);
@@ -161,27 +163,27 @@ public class FileUtils {
                     if (id.startsWith("raw:")) {
                         return id.replaceFirst("raw:", "");
                     }
-                        String[] contentUriPrefixesToTry = new String[]{
-                                "content://downloads/public_downloads",
-                                "content://downloads/my_downloads",
-                                "content://downloads/all_downloads"
-                        };
-                    if(id.contains(":")){
+                    String[] contentUriPrefixesToTry = new String[] {
+                            "content://downloads/public_downloads",
+                            "content://downloads/my_downloads",
+                            "content://downloads/all_downloads"
+                    };
+                    if (id.contains(":")) {
                         id = id.split(":")[1];
                     }
-                        for (String contentUriPrefix : contentUriPrefixesToTry) {
-                            Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
-                            try {
-                                String path = getDataColumn(context, contentUri, null, null);
-                                if (path != null) {
-                                    return path;
-                                }
-                            } catch (Exception e) {
-                                Log.e(TAG, "Something went wrong while retrieving document path: " + e.toString());
+                    for (String contentUriPrefix : contentUriPrefixesToTry) {
+                        Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
+                        try {
+                            String path = getDataColumn(context, contentUri, null, null);
+                            if (path != null) {
+                                return path;
                             }
+                        } catch (Exception e) {
+                            Log.e(TAG, "Something went wrong while retrieving document path: " + e.toString());
                         }
-
                     }
+
+                }
             } else if (isMediaDocument(uri)) {
                 Log.e(TAG, "Media Document URI");
                 final String docId = DocumentsContract.getDocumentId(uri);
@@ -201,7 +203,7 @@ public class FileUtils {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[]{
+                final String[] selectionArgs = new String[] {
                         split[1]
                 };
 
@@ -221,52 +223,53 @@ public class FileUtils {
         }
         return null;
     }
+
     public static FileInfo openFileStream(final Context context, final Uri uri, boolean withData) {
 
         Log.i(TAG, "Caching from URI: " + uri.toString());
         FileOutputStream fos = null;
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
-       
+
         final String path = getPath(uri, context);
         Log.i(TAG, "abhi1618o testing0: " + path);
-   
+
         final File file = new File(path);
 
         // if(!file.exists()) {
-        //     file.getParentFile().mkdirs();
-        //     try {
-        //         fos = new FileOutputStream(path);
-        //         try {
-        //             final BufferedOutputStream out = new BufferedOutputStream(fos);
-        //             final InputStream in = context.getContentResolver().openInputStream(uri);
+        // file.getParentFile().mkdirs();
+        // try {
+        // fos = new FileOutputStream(path);
+        // try {
+        // final BufferedOutputStream out = new BufferedOutputStream(fos);
+        // final InputStream in = context.getContentResolver().openInputStream(uri);
 
-        //             final byte[] buffer = new byte[8192];
-        //             int len = 0;
+        // final byte[] buffer = new byte[8192];
+        // int len = 0;
 
-        //             while ((len = in.read(buffer)) >= 0) {
-        //                 out.write(buffer, 0, len);
-        //             }
+        // while ((len = in.read(buffer)) >= 0) {
+        // out.write(buffer, 0, len);
+        // }
 
-        //             out.flush();
-        //         } finally {
-        //             fos.getFD().sync();
-        //         }
-        //     } catch (final Exception e) {
-        //         try {
-        //             fos.close();
-        //         } catch (final IOException | NullPointerException ex) {
-        //             Log.e(TAG, "Failed to close file streams: " + e.getMessage(), null);
-        //             return null;
-        //         }
-        //         Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
-        //         return null;
-        //     }
+        // out.flush();
+        // } finally {
+        // fos.getFD().sync();
+        // }
+        // } catch (final Exception e) {
+        // try {
+        // fos.close();
+        // } catch (final IOException | NullPointerException ex) {
+        // Log.e(TAG, "Failed to close file streams: " + e.getMessage(), null);
+        // return null;
+        // }
+        // Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
+        // return null;
+        // }
         // }
 
         Log.d(TAG, "File loaded and cached at:" + path);
 
-        if(withData) {
+        if (withData) {
             loadData(file, fileInfo);
         }
 
@@ -290,7 +293,8 @@ public class FileUtils {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             if (isDownloadsDocument(treeUri)) {
                 String docId = DocumentsContract.getDocumentId(treeUri);
-                String extPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
+                String extPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                        .getPath();
                 if (docId.equals("downloads")) {
                     return extPath;
                 } else if (docId.matches("^ms[df]\\:.*")) {
@@ -322,8 +326,7 @@ public class FileUtils {
         if (documentPath.length() > 0) {
             if (documentPath.startsWith(File.separator)) {
                 return volumePath + documentPath;
-            }
-            else {
+            } else {
                 return volumePath + File.separator + documentPath;
             }
         } else {
@@ -352,10 +355,10 @@ public class FileUtils {
 
     @SuppressLint("ObsoleteSdkInt")
     private static String getVolumePath(final String volumeId, Context context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+            return null;
         try {
-            StorageManager mStorageManager =
-                    (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+            StorageManager mStorageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
             Class<?> storageVolumeClazz = Class.forName("android.os.storage.StorageVolume");
             Method getVolumeList = mStorageManager.getClass().getMethod("getVolumeList");
             Method getUuid = storageVolumeClazz.getMethod("getUuid");
@@ -387,29 +390,93 @@ public class FileUtils {
         }
     }
 
+    private static String getDataColumn(Context context, Uri uri, String selection,
+            String[] selectionArgs) {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } catch (Exception ex) {
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
     private static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    public static String getExternalPath(Context context) {
+        if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
+            return context.getExternalFilesDir(null).getAbsolutePath();
+        }
+        return context.getFilesDir().getAbsolutePath();
+    }
+
+    private static String getDataColumn(Context context, Uri uri, String selection,
+            String[] selectionArgs) {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } catch (Exception ex) {
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+    private static boolean isDropBoxUri(Uri uri) {
+        return "com.dropbox.android.FileCache".equals(uri.getAuthority());
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static String getVolumeIdFromTreeUri(final Uri treeUri) {
         final String docId = DocumentsContract.getTreeDocumentId(treeUri);
         final String[] split = docId.split(":");
-        if (split.length > 0) return split[0];
-        else return null;
+        if (split.length > 0)
+            return split[0];
+        else
+            return null;
     }
-
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static String getDocumentPathFromTreeUri(final Uri treeUri) {
         final String docId = DocumentsContract.getTreeDocumentId(treeUri);
         final String[] split = docId.split(":");
-        if ((split.length >= 2) && (split[1] != null)) return split[1];
-        else return File.separator;
+        if ((split.length >= 2) && (split[1] != null))
+            return split[1];
+        else
+            return File.separator;
     }
+
     private static boolean isGooglePhotosUri(Uri uri) {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
     }
-
 
 }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -129,40 +129,40 @@ public class FileUtils {
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
         Log.i(TAG, "abhi1618o testing: " + fileName);
-        final String path = context.getCacheDir().getAbsolutePath() + "/file_picker/" + (fileName != null ? fileName : System.currentTimeMillis());
-
+        final String path = context.getFilesDir().getAbsolutePath() + "/file_picker/" + (fileName != null ? fileName : System.currentTimeMillis());
+        Log.i(TAG, "abhi1618o testing: " + path);
         final File file = new File(path);
 
-        if(!file.exists()) {
-            file.getParentFile().mkdirs();
-            try {
-                fos = new FileOutputStream(path);
-                try {
-                    final BufferedOutputStream out = new BufferedOutputStream(fos);
-                    final InputStream in = context.getContentResolver().openInputStream(uri);
+        // if(!file.exists()) {
+        //     file.getParentFile().mkdirs();
+        //     try {
+        //         fos = new FileOutputStream(path);
+        //         try {
+        //             final BufferedOutputStream out = new BufferedOutputStream(fos);
+        //             final InputStream in = context.getContentResolver().openInputStream(uri);
 
-                    final byte[] buffer = new byte[8192];
-                    int len = 0;
+        //             final byte[] buffer = new byte[8192];
+        //             int len = 0;
 
-                    while ((len = in.read(buffer)) >= 0) {
-                        out.write(buffer, 0, len);
-                    }
+        //             while ((len = in.read(buffer)) >= 0) {
+        //                 out.write(buffer, 0, len);
+        //             }
 
-                    out.flush();
-                } finally {
-                    fos.getFD().sync();
-                }
-            } catch (final Exception e) {
-                try {
-                    fos.close();
-                } catch (final IOException | NullPointerException ex) {
-                    Log.e(TAG, "Failed to close file streams: " + e.getMessage(), null);
-                    return null;
-                }
-                Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
-                return null;
-            }
-        }
+        //             out.flush();
+        //         } finally {
+        //             fos.getFD().sync();
+        //         }
+        //     } catch (final Exception e) {
+        //         try {
+        //             fos.close();
+        //         } catch (final IOException | NullPointerException ex) {
+        //             Log.e(TAG, "Failed to close file streams: " + e.getMessage(), null);
+        //             return null;
+        //         }
+        //         Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
+        //         return null;
+        //     }
+        // }
 
         Log.d(TAG, "File loaded and cached at:" + path);
 

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -240,7 +240,7 @@ public class FileUtils {
             Log.i(TAG, "abhi1618o testing1: " + path);
         }
         
-        file= File(path);
+
 
         // if(!file.exists()) {
         // file.getParentFile().mkdirs();
@@ -283,7 +283,7 @@ public class FileUtils {
                 .withPath(path)
                 .withName(fileName)
                 .withUri(uri)
-                .withSize(Long.parseLong(String.valueOf(file.length())));
+                .withSize(10.0);
 
         return fileInfo.build();
     }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -122,6 +122,20 @@ public class FileUtils {
         }
     }
 
+    public static String getPath(final Uri uri, Context context) {
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+        if (isKitKat) {
+            return getForApi19(context, uri);
+        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            if (isGooglePhotosUri(uri)) {
+                return uri.getLastPathSegment();
+            }
+            return getDataColumn(context, uri, null, null);
+        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+        return null;
+    }
     public static FileInfo openFileStream(final Context context, final Uri uri, boolean withData) {
 
         Log.i(TAG, "Caching from URI: " + uri.toString());
@@ -129,7 +143,7 @@ public class FileUtils {
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
        
-        final String path = context.getFilesDir();
+        final String path = getPath(uri, context);
         Log.i(TAG, "abhi1618o testing0: " + path);
    
         final File file = new File(path);

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -390,27 +390,7 @@ public class FileUtils {
         }
     }
 
-    private static String getDataColumn(Context context, Uri uri, String selection,
-            String[] selectionArgs) {
-        Cursor cursor = null;
-        final String column = "_data";
-        final String[] projection = {
-                column
-        };
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                    null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int index = cursor.getColumnIndexOrThrow(column);
-                return cursor.getString(index);
-            }
-        } catch (Exception ex) {
-        } finally {
-            if (cursor != null)
-                cursor.close();
-        }
-        return null;
-    }
+ 
 
     private static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -128,6 +128,7 @@ public class FileUtils {
         FileOutputStream fos = null;
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
+        Log.i(TAG, "abhi1618o testing: " + fileName);
         final String path = context.getCacheDir().getAbsolutePath() + "/file_picker/" + (fileName != null ? fileName : System.currentTimeMillis());
 
         final File file = new File(path);

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -277,7 +277,7 @@ public class FileUtils {
 
         }
 
-        Log.d(TAG, "File loaded and cached at:" + path);
+   
 
         if (withData) {
             loadData(file, fileInfo);

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.4.2))
 connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=C\:/Program Files/Eclipse Adoptium/jdk-17.0.2.8-hotspot
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -482,11 +482,17 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
                 NSArray * files = [fileManager contentsOfDirectoryAtURL:url includingPropertiesForKeys:@[] options:NSDirectoryEnumerationSkipsHiddenFiles error:nil];
                 
                 for (NSURL * item in files) {
+                    
                     if (UTTypeConformsTo(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, CFBridgingRetain([item pathExtension]), NULL), kUTTypeImage)) {
-                        
-                        UIImage * img = [UIImage imageWithContentsOfFile:item.path];
+                        NSData *assetData = [NSData dataWithContentsOfURL:item];
+                        //Convert any type of image to jpeg
+                        NSData *convertedImageData = UIImageJPEGRepresentation([UIImage imageWithData:assetData], 1.0);
+                        //Get meta data from asset
+                        NSDictionary *metaData = [ImageUtils getMetaDataFromImageData:assetData];
+                        //Append meta data into jpeg of live photo
+                        NSData *data = [ImageUtils imageFromImage:convertedImageData withMetaData:metaData];
+                        //Save jpeg
                         NSString * fileName = [[item.path lastPathComponent] stringByDeletingPathExtension];
-                        NSData * data = UIImageJPEGRepresentation(img, 1);
                         NSString * tmpFile = [NSTemporaryDirectory() stringByAppendingPathComponent:[fileName stringByAppendingString:@".jpeg"]];
                         cachedUrl = [NSURL fileURLWithPath: tmpFile];
 

--- a/ios/Classes/ImageUtils.h
+++ b/ios/Classes/ImageUtils.h
@@ -8,4 +8,6 @@
 @interface ImageUtils : NSObject
 + (BOOL)hasAlpha:(UIImage *)image;
 + (NSURL*)saveTmpImage:(UIImage *)image;
++ (NSDictionary *)getMetaDataFromImageData:(NSData *)imageData;
++ (NSData *)imageFromImage:(NSData *)imageData withMetaData:(NSDictionary *)metadata;
 @end

--- a/ios/Classes/ImageUtils.m
+++ b/ios/Classes/ImageUtils.m
@@ -32,4 +32,35 @@
     return nil;
 }
 
++ (NSDictionary *)getMetaDataFromImageData:(NSData *)imageData {
+  CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
+  NSDictionary *metadata =
+      (NSDictionary *)CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, NULL));
+  CFRelease(source);
+  return metadata;
+}
+
++ (NSData *)imageFromImage:(NSData *)imageData withMetaData:(NSDictionary *)metadata {
+  NSMutableData *targetData = [NSMutableData data];
+  CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
+  if (source == NULL) {
+    return nil;
+  }
+  CGImageDestinationRef destination = NULL;
+  CFStringRef sourceType = CGImageSourceGetType(source);
+  if (sourceType != NULL) {
+    destination =
+        CGImageDestinationCreateWithData((__bridge CFMutableDataRef)targetData, sourceType, 1, nil);
+  }
+  if (destination == NULL) {
+    CFRelease(source);
+    return nil;
+  }
+  CGImageDestinationAddImageFromSource(destination, source, 0, (__bridge CFDictionaryRef)metadata);
+  CGImageDestinationFinalize(destination);
+  CFRelease(source);
+  CFRelease(destination);
+  return targetData;
+}
+
 @end

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -9,7 +9,7 @@ import 'package:file_picker/src/windows/stub.dart'
     if (dart.library.io) 'package:file_picker/src/windows/file_picker_windows.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-const String defaultDialogTitle = 'File Picker';
+const String defaultDialogTitle = '';
 
 enum FileType {
   any,

--- a/lib/src/platform_file.dart
+++ b/lib/src/platform_file.dart
@@ -48,7 +48,7 @@ class PlatformFile {
   /// File name including its extension.
   final String name;
 
-  /// Byte data for this file. Particurlarly useful if you want to manipulate its data
+  /// Byte data for this file. Particularly useful if you want to manipulate its data
   /// or easily upload to somewhere else.
   /// [Check here in the FAQ](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ) an example on how to use it to upload on web.
   final Uint8List? bytes;

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -8,7 +8,7 @@ import 'package:file_picker/src/utils.dart';
 import 'package:file_picker/src/exceptions.dart';
 import 'package:file_picker/src/windows/file_picker_windows_ffi_types.dart';
 import 'package:path/path.dart';
-import 'package:win32/win32.dart';
+import 'package:win32/winrt.dart';
 
 FilePicker filePickerWithFFI() => FilePickerWindows();
 
@@ -78,17 +78,17 @@ class FilePickerWindows extends FilePicker {
     final fileDialog = FileOpenDialog.createInstance();
 
     final optionsPointer = calloc<Uint32>();
-    hr = fileDialog.GetOptions(optionsPointer);
+    hr = fileDialog.getOptions(optionsPointer);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final options = optionsPointer.value |
         FILEOPENDIALOGOPTIONS.FOS_PICKFOLDERS |
         FILEOPENDIALOGOPTIONS.FOS_FORCEFILESYSTEM;
-    hr = fileDialog.SetOptions(options);
+    hr = fileDialog.setOptions(options);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final title = TEXT(dialogTitle ?? defaultDialogTitle);
-    hr = fileDialog.SetTitle(title);
+    hr = fileDialog.setTitle(title);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
     free(title);
 
@@ -107,9 +107,9 @@ class FilePickerWindows extends FilePicker {
     // }
 
     final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
-    hr = fileDialog.Show(hwndOwner);
+    hr = fileDialog.show(hwndOwner);
     if (!SUCCEEDED(hr)) {
-      fileDialog.Release();
+      fileDialog.release();
       CoUninitialize();
 
       if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
@@ -119,20 +119,20 @@ class FilePickerWindows extends FilePicker {
     }
 
     final ppsi = calloc<COMObject>();
-    hr = fileDialog.GetResult(ppsi.cast());
+    hr = fileDialog.getResult(ppsi.cast());
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final item = IShellItem(ppsi);
     final pathPtr = calloc<Pointer<Utf16>>();
-    hr = item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, pathPtr);
+    hr = item.getDisplayName(SIGDN.SIGDN_FILESYSPATH, pathPtr);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final path = pathPtr.value.toDartString();
 
-    hr = item.Release();
+    hr = item.release();
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
-    hr = fileDialog.Release();
+    hr = fileDialog.release();
     CoUninitialize();
 
     return Future.value(path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.1.2
   ffi: ^2.0.1
   path: ^1.8.0
-  win32: ^2.7.0
+  win32: ^3.0.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.0.1
+version: 5.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
The current version of file_picker caches all the files regardless of type of file. This is very inefficient and cause a lot of delay in fetching the filepath. If caching is completely removed like before ( versions <2. 0. 0) it may not be able to fetch some files. So  I have made changes in way that it will caches the files only if it cannot retrieve the files' paths directly. This will save a lot of time.
 
https://github.com/abhi16180/flutter_file_picker/blob/2c95ee84010b06499330abf206fa0df353e4508b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java#L227-L293