### PR TITLE
Update Dependencies to latest versions (Win32 2.7.0 to 3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+#### Desktop (Windows)
+Update Dependencies to latest versions (Win32 2.7.0 to 3.0.0)
+
 ## 5.0.1
 #### Android
 Replaces random number generation with milliseconds timestamp in file name fallback.

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -8,7 +8,7 @@ import 'package:file_picker/src/utils.dart';
 import 'package:file_picker/src/exceptions.dart';
 import 'package:file_picker/src/windows/file_picker_windows_ffi_types.dart';
 import 'package:path/path.dart';
-import 'package:win32/win32.dart';
+import 'package:win32/winrt.dart';
 
 FilePicker filePickerWithFFI() => FilePickerWindows();
 
@@ -78,17 +78,17 @@ class FilePickerWindows extends FilePicker {
     final fileDialog = FileOpenDialog.createInstance();
 
     final optionsPointer = calloc<Uint32>();
-    hr = fileDialog.GetOptions(optionsPointer);
+    hr = fileDialog.getOptions(optionsPointer);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final options = optionsPointer.value |
         FILEOPENDIALOGOPTIONS.FOS_PICKFOLDERS |
         FILEOPENDIALOGOPTIONS.FOS_FORCEFILESYSTEM;
-    hr = fileDialog.SetOptions(options);
+    hr = fileDialog.setOptions(options);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final title = TEXT(dialogTitle ?? defaultDialogTitle);
-    hr = fileDialog.SetTitle(title);
+    hr = fileDialog.setTitle(title);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
     free(title);
 
@@ -107,9 +107,9 @@ class FilePickerWindows extends FilePicker {
     // }
 
     final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
-    hr = fileDialog.Show(hwndOwner);
+    hr = fileDialog.show(hwndOwner);
     if (!SUCCEEDED(hr)) {
-      fileDialog.Release();
+      fileDialog.release();
       CoUninitialize();
 
       if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
@@ -119,20 +119,20 @@ class FilePickerWindows extends FilePicker {
     }
 
     final ppsi = calloc<COMObject>();
-    hr = fileDialog.GetResult(ppsi.cast());
+    hr = fileDialog.getResult(ppsi.cast());
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final item = IShellItem(ppsi);
     final pathPtr = calloc<Pointer<Utf16>>();
-    hr = item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, pathPtr);
+    hr = item.getDisplayName(SIGDN.SIGDN_FILESYSPATH, pathPtr);
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final path = pathPtr.value.toDartString();
 
-    hr = item.Release();
+    hr = item.release();
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
-    hr = fileDialog.Release();
+    hr = fileDialog.release();
     CoUninitialize();
 
     return Future.value(path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.1.2
   ffi: ^2.0.1
   path: ^1.8.0
-  win32: ^2.7.0
+  win32: ^3.0.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Issue: #1106 

Add necessary dependency API updates, As mentioned in the Win32 Change Log: 

> COM and Windows Runtime methods and properties are now camelCased, not TitleCased. This is inconvenient, but it avoids a whole class of name clashes and aligns COM and WinRT APIs more closely with Dart idioms. As the projections get smarter with more helpers, we think this is the right call for the future and worth a one-time tax to fix.

**Test Passed**: test\file_picker_windows_test.dart