### PR TITLE
feat: set defaultDialogTitle empty

### DIFF
--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -9,7 +9,7 @@ import 'package:file_picker/src/windows/stub.dart'
     if (dart.library.io) 'package:file_picker/src/windows/file_picker_windows.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-const String defaultDialogTitle = 'File Picker';
+const String defaultDialogTitle = '';
 
 enum FileType {
   any,


### PR DESCRIPTION
Leave defaultDialogTitle empty is a more common practice :)