### PR TITLE
fix: package not working with Android 13 (SDK 33)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -262,12 +262,15 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         this.isMultipleSelection = isMultipleSelection;
         this.loadDataToMemory = withData;
         this.allowedExtensions = allowedExtensions;
-
-        if (!this.permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            this.permissionManager.askForPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_CODE);
-            return;
+        // `READ_EXTERNAL_STORAGE` permission is not needed since SDK 33 (Android 13 or higher).
+        // `READ_EXTERNAL_STORAGE` & `WRITE_EXTERNAL_STORAGE` are no longer meant to be used, but classified into granular types.
+        // Reference: https://developer.android.com/about/versions/13/behavior-changes-13
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (!this.permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                this.permissionManager.askForPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_CODE);
+                return;
+            }
         }
-
         this.startFileExplorer();
     }
 


### PR DESCRIPTION
## Summary 

- Changed `compileSdkVersion` to 33 in `build.gradle`.
- Android specific platform channel implementation no longer requests `READ_EXTERNAL_STORAGE` on Android 13 or higher
  _i.e._ SDK 33 or above.

## Related Issues

Closes #1099.
Closes #1107.

## References

To be frank, I couldn't find any sources about requirement of `READ_EXTERNAL_STORAGE` for `ACTION_GET_CONTENT`.

However, `READ_EXTERNAL_STORAGE` should no longer be used when targeting Android 13 or higher. It does nothing on newer versions, however you can keep it in `AppManifest.xml`.

The storage access has been split into three permissions:

<html>
<body>

Type of media | Permission to request
-- | --
Images and photos | READ_MEDIA_IMAGES
Videos | READ_MEDIA_VIDEO
Audio files | READ_MEDIA_AUDIO

See: https://developer.android.com/about/versions/13/behavior-changes-13.

## Additional Info

~~I will be pleased, if someone tests the changes.~~ Confirmed by a user at #1099.

Thanks!



