### PR TITLE
Use flutter extension to avoid force the user update the android sdk …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,10 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion flutter.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.2.2
+version: 5.2.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adding the flutter extension flutter.compileSdkVersion to avoid hardcode the SDK version here, so the user is not forced to update the compileSdkVersion to 33.