### PR TITLE
Increase test coverage to utils.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 5.2.2
+
+### General
+- Increased coverage of test cases for functions in the utils file.
+
 ### Android
 - Fix deprecation warning for `getParcelable(String key)` method.
 

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -103,5 +103,33 @@ void main() {
 
       expect(platformFiles.length, equals(filePaths.length));
     });
+
+    test(
+        'should tranform a list of file paths containing a path into a list of PlatformFiles',
+        () async {
+      final filePaths = <String>['test'];
+
+      final platformFiles = await filePathsToPlatformFiles(
+        filePaths,
+        true,
+        false,
+      );
+
+      expect(platformFiles.length, equals(filePaths.length));
+    });
+
+    test(
+        'should transform a list of file paths containing a valid path into a list of PlatformFiles',
+        () async {
+      final filePaths = <String>['test/test_files/test.pdf'];
+
+      final platformFiles = await filePathsToPlatformFiles(
+        filePaths,
+        false,
+        true,
+      );
+
+      expect(platformFiles.length, equals(filePaths.length));
+    });
   });
 }

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -132,4 +132,15 @@ void main() {
       expect(platformFiles.length, equals(filePaths.length));
     });
   });
+
+  group('runExecutableWithArguments()', () {
+    test('should catch an exception when sending an empty filepath', () async {
+      final filepath = '';
+
+      expect(
+        () async => await isExecutableOnPath(filepath),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
### Initial Proposed

* Improve test coverage to utils.dart on macOs.

### My Proposed

* Improve the test suite coverage of `filePathsToPlatformFiles()`.
  * Create two more test cases.
* Create test suite for `runExecutableWithArguments()` function.
  * There are no tests for it in `file_picker_utils_test.dart`.
 
### Objective

* go from 52.2% coverage to 100% coverage for the utils file functions

### Setup

* macOs Ventura 13.0

### Fixes

#### Improve the test suite coverage of `filePathsToPlatformFiles()`.

* Test 1:
   * **Coverage Before:**
    <img width="1664" alt="Screenshot 2022-11-16 at 14 57 48" src="https://user-images.githubusercontent.com/42839818/202257449-887ea2ee-8a1e-4a36-9f41-0bf213122bb3.png">
   * **Added test case**
```dart
test(
    'should tranform a list of file paths containing a path into a list of PlatformFiles',
    () async {
  final filePaths = <String>['test'];

  final platformFiles = await filePathsToPlatformFiles(
    filePaths,
    true,
    false,
  );

  expect(platformFiles.length, equals(filePaths.length));
});
```
   * **Coverage After:**
    <img width="1660" alt="Screenshot 2022-11-16 at 15 00 14" src="https://user-images.githubusercontent.com/42839818/202257725-06429e77-89d9-48e5-a8d4-5d15b4d95d0d.png">

* Test 2: 
   * **Coverage Before:**
    <img width="1660" alt="Screenshot 2022-11-16 at 15 00 14" src="https://user-images.githubusercontent.com/42839818/202257725-06429e77-89d9-48e5-a8d4-5d15b4d95d0d.png">

   * **Added test case**
```dart
test(
    'should transform a list of file paths containing a valid path into a list of PlatformFiles',
    () async {
  final filePaths = <String>['test/test_files/test.pdf'];

  final platformFiles = await filePathsToPlatformFiles(
    filePaths,
    false,
    true,
  );

  expect(platformFiles.length, equals(filePaths.length));
});
```
   * **Coverage After:**
      <img width="1655" alt="Screenshot 2022-11-16 at 15 02 19" src="https://user-images.githubusercontent.com/42839818/202258098-86c55caf-bf96-43c6-a874-0d7375e7f72e.png">

#### Create test suite for `runExecutableWithArguments()` function.

* **Coverage Before:**
<img width="1655" alt="Screenshot 2022-11-16 at 15 02 19" src="https://user-images.githubusercontent.com/42839818/202258098-86c55caf-bf96-43c6-a874-0d7375e7f72e.png">

* **Added test case**
```dart
group('runExecutableWithArguments()', () {
  test('should catch an exception when sending an empty filepath', () async {
    final filepath = '';

    expect(
      () async => await isExecutableOnPath(filepath),
      throwsA(isA<Exception>()),
    );
  });
});
```

* **Coverage After:**
<img width="1659" alt="Screenshot 2022-11-16 at 15 04 01" src="https://user-images.githubusercontent.com/42839818/202258394-5e271620-b330-4048-89a4-c79da4f488cd.png">

### Checking the changes

- [x] Update CHANGELOG.