### PR TITLE
Fix an issue when picking live photos where the key photo was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.3
+### iOS
+- Fixes an issue when picking live photos where the key photo was changed.
+
 ## 5.2.2
 ### Android
 - Fix deprecation warning for `getParcelable(String key)` method.

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -492,8 +492,8 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
                         //Append meta data into jpeg of live photo
                         NSData *data = [ImageUtils imageFromImage:convertedImageData withMetaData:metaData];
                         //Save jpeg
-                        NSString * fileName = [[item.path lastPathComponent] stringByDeletingPathExtension];
-                        NSString * tmpFile = [NSTemporaryDirectory() stringByAppendingPathComponent:[fileName stringByAppendingString:@".jpeg"]];
+                        NSString * filenameWithoutExtension = [filename stringByDeletingPathExtension];
+                        NSString * tmpFile = [NSTemporaryDirectory() stringByAppendingPathComponent:[filenameWithoutExtension stringByAppendingString:@".jpeg"]];
                         cachedUrl = [NSURL fileURLWithPath: tmpFile];
 
                         if([fileManager fileExistsAtPath:tmpFile]) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.2.2
+version: 5.2.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
When picking multiple live photos where the key photo was changed, the same one is returned multiple times.

This is because the filename used when converting the photo from pvt to jpeg is the same for all pictures where the key photo was updated.

For example, here is the content of a regular live photo:
```
IMG_0042.pvt
|- IMG_0042.MOV
|- metadata.plist
|- IMG_0042.HEIC
```

After the key photo is changed, the content changes to:
```
IMG_0042.pvt
|- FullSizeRender.mov
|- metadata.plist
|- FullSizeRender.heic
```

This solves the issue by using the original filename (e.g. `IMG_0042.pvt`) instead of the renamed file (`FullSizeRender.heic`).
