### PR TITLE
Fix/call file dialog in isolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.4
+### Desktop (Windows)
+- Calling pick/save file dialog will no longer freeze ui thread.
+
 ## 5.2.3
 ### iOS
 - Fixes an issue when picking live photos where the key photo was changed.

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:isolate';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -26,11 +27,48 @@ class FilePickerWindows extends FilePicker {
     bool withReadStream = false,
     bool lockParentWindow = false,
   }) async {
+    final port = ReceivePort();
+    await Isolate.spawn(
+        _callPickFiles,
+        _OpenSaveFileArgs(
+            port: port.sendPort,
+            dialogTitle: dialogTitle,
+            initialDirectory: initialDirectory,
+            type: type,
+            allowedExtensions: allowedExtensions,
+            allowCompression: allowCompression,
+            allowMultiple: allowMultiple,
+            lockParentWindow: lockParentWindow));
+    final fileNames = (await port.first) as List<String>?;
+    FilePickerResult? returnValue;
+    if (fileNames != null) {
+      final filePaths = fileNames;
+      final platformFiles = await filePathsToPlatformFiles(
+        filePaths,
+        withReadStream,
+        withData,
+      );
+
+      returnValue = FilePickerResult(platformFiles);
+    }
+
+    return returnValue;
+  }
+
+  List<String>? _pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    bool allowCompression = true,
+    bool allowMultiple = false,
+    bool lockParentWindow = false,
+  }) {
     final comdlg32 = DynamicLibrary.open('comdlg32.dll');
 
     final getOpenFileNameW =
-        comdlg32.lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
-            'GetOpenFileNameW');
+    comdlg32.lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
+        'GetOpenFileNameW');
 
     final Pointer<OPENFILENAMEW> openFileNameW = _instantiateOpenFileNameW(
       allowMultiple: allowMultiple,
@@ -42,22 +80,17 @@ class FilePickerWindows extends FilePicker {
     );
 
     final result = getOpenFileNameW(openFileNameW);
-    FilePickerResult? returnValue;
+    late final List<String>? files;
     if (result == 1) {
       final filePaths = _extractSelectedFilesFromOpenFileNameW(
         openFileNameW.ref,
       );
-      final platformFiles = await filePathsToPlatformFiles(
-        filePaths,
-        withReadStream,
-        withData,
-      );
-
-      returnValue = FilePickerResult(platformFiles);
+      files = filePaths;
+    } else {
+      files = null;
     }
-
     _freeMemory(openFileNameW);
-    return returnValue;
+    return files;
   }
 
   /// See API spec:
@@ -147,11 +180,33 @@ class FilePickerWindows extends FilePicker {
     List<String>? allowedExtensions,
     bool lockParentWindow = false,
   }) async {
+    final port = ReceivePort();
+    await Isolate.spawn(
+        _callSaveFile,
+        _OpenSaveFileArgs(
+            port: port.sendPort,
+            fileName: fileName,
+            dialogTitle: dialogTitle,
+            initialDirectory: initialDirectory,
+            type: type,
+            allowedExtensions: allowedExtensions,
+            lockParentWindow: lockParentWindow));
+    return (await port.first) as String?;
+  }
+
+  String? _saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    bool lockParentWindow = false,
+  }) {
     final comdlg32 = DynamicLibrary.open('comdlg32.dll');
 
     final getSaveFileNameW =
-        comdlg32.lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
-            'GetSaveFileNameW');
+    comdlg32.lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
+        'GetSaveFileNameW');
 
     final Pointer<OPENFILENAMEW> openFileNameW = _instantiateOpenFileNameW(
       allowedExtensions: allowedExtensions,
@@ -317,4 +372,52 @@ class FilePickerWindows extends FilePicker {
     calloc.free(openFileNameW.ref.lpstrInitialDir);
     calloc.free(openFileNameW);
   }
+
+
+  static void _callPickFiles(_OpenSaveFileArgs args) {
+    final impl = FilePickerWindows();
+    args.port.send(impl._pickFiles(
+        dialogTitle: args.dialogTitle,
+        initialDirectory: args.initialDirectory,
+        type: args.type,
+        allowedExtensions: args.allowedExtensions,
+        allowCompression: args.allowCompression,
+        allowMultiple: args.allowMultiple,
+        lockParentWindow: args.lockParentWindow));
+  }
+
+  static void _callSaveFile(_OpenSaveFileArgs args) {
+    final impl = FilePickerWindows();
+    args.port.send(impl._saveFile(
+        dialogTitle: args.dialogTitle,
+        fileName: args.fileName,
+        initialDirectory: args.initialDirectory,
+        type: args.type,
+        allowedExtensions: args.allowedExtensions,
+        lockParentWindow: args.lockParentWindow));
+  }
+
+}
+
+class _OpenSaveFileArgs {
+  final SendPort port;
+  final String? dialogTitle;
+  final String? initialDirectory;
+  final String? fileName;
+  final FileType type;
+  final List<String>? allowedExtensions;
+  final bool allowCompression;
+  final bool allowMultiple;
+  final bool lockParentWindow;
+
+  _OpenSaveFileArgs(
+      {required this.port,
+        this.dialogTitle,
+        this.fileName,
+        this.initialDirectory,
+        this.type = FileType.any,
+        this.allowedExtensions,
+        this.allowCompression = true,
+        this.allowMultiple = false,
+        this.lockParentWindow = false});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.2.3
+version: 5.2.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
GetOpenFileNameW and GetSaveFileNameW are sync methods, so if we call them in UI thread, parent windows will stop responding.
Call them in a separate isolate to match same behaviour to macOS.