### PR TITLE
#1255: update dependency `win32` to latest major v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.11
+### Desktop (Windows)
+Updates dependencies, including win32 bump to 4.1.3 ([#1255](https://github.com/miguelpruivo/flutter_file_picker/issues/1255)).
+
 ## 5.2.10
 ### Desktop (Windows)
 Fixes the bug that the result of the save-file dialog was incorrect when it was invoked with a long default file name but the user selected a file with a much short file name ([#1257](https://github.com/miguelpruivo/flutter_file_picker/issues/1257)).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ For full usage details refer to the **[Wiki](https://github.com/miguelpruivo/flu
 #### Linux
 ![DemoLinux](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_linux.gif)
 
-Android
 #### Windows
 ![DemoWindows](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_windows.gif)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.1.2
   ffi: ^2.0.1
   path: ^1.8.0
-  win32: ^3.0.0
+  win32: ^4.1.1
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.2.10
+version: 5.2.11
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  flutter_plugin_android_lifecycle: ^2.0.6
-  plugin_platform_interface: ^2.1.2
+  flutter_plugin_android_lifecycle: ^2.0.9
+  plugin_platform_interface: ^2.1.4
   ffi: ^2.0.1
-  path: ^1.8.0
-  win32: ^4.1.1
+  path: ^1.8.2
+  win32: ^4.1.3
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^2.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Updates the dependency `win32`, which is used in our Windows `file_picker` implementation, to the latest major v4. See `win32`'s changelog: https://pub.dev/packages/win32/changelog