### PR TITLE
Bump Dart to 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.3.1
+
+Bump Dart SDK lower bound to <4.0.0 to support Dart 3
+
 ## 5.3.0
 ### Android
 Updates Gradle to version 7.5

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example of how to use the file_picker plugin.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.3.0
+version: 5.3.1
 
 dependencies:
   flutter:
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=1.10.0"
 
 flutter:


### PR DESCRIPTION
This PR updates file_picker to support Dart 3.

Any null-safe applications (Dart 2.12+) are Dart 3 compatible.

@miguelpruivo This unblocks people using Dart 3

Fixes #1288 