### PR TITLE
Fixed crashing on windows when picking a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.3.4
+fix [#1317](https://github.com/miguelpruivo/flutter_file_picker/issues/1317)
 ## 5.3.3
 fix [#1312](https://github.com/miguelpruivo/flutter_file_picker/issues/1312)
 ## 5.3.2

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -131,7 +131,6 @@ class FilePickerWindows extends FilePicker {
     final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
     hr = fileDialog.show(hwndOwner);
     if (!SUCCEEDED(hr)) {
-      fileDialog.release();
       CoUninitialize();
 
       if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
@@ -154,7 +153,6 @@ class FilePickerWindows extends FilePicker {
     hr = item.release();
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
-    hr = fileDialog.release();
     CoUninitialize();
 
     return Future.value(path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.3.3
+version: 5.3.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixed crash when picking a directory. [https://github.com/https://github.com/miguelpruivo/flutter_file_picker/issues/1317, https://github.com/https://github.com/miguelpruivo/flutter_file_picker/issues/1297]

"Note that, with v5.0.0, .release() is also called automatically if you wish to upgrade it." https://win32.pub/docs/com-programming/basics#releasing-com-objects