### PR TITLE
Add initialDirectory for iOS

### DIFF
--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -41,6 +41,7 @@ class FilePickerIO extends FilePicker {
         onFileLoading,
         withData,
         withReadStream,
+        initialDirectory,
       );
 
   @override
@@ -72,6 +73,7 @@ class FilePickerIO extends FilePicker {
     Function(FilePickerStatus)? onFileLoading,
     bool? withData,
     bool? withReadStream,
+    String? initialDirectory,
   ) async {
     final String type = describeEnum(fileType);
     if (type != 'custom' && (allowedExtensions?.isNotEmpty ?? false)) {
@@ -94,6 +96,7 @@ class FilePickerIO extends FilePicker {
         'allowedExtensions': allowedExtensions,
         'allowCompression': allowCompression,
         'withData': withData,
+        'initialDirectory': initialDirectory,
       });
 
       if (result == null) {


### PR DESCRIPTION
Hello @miguelpruivo,

I'm reaching out about a feature that has been requested for a while – the ability to pass an initialDirectory to the platform code. I've been working on a pull request for this feature for iOS, but I've hit a roadblock. Even though the initialDirectory is being passed correctly, the picker isn't opening at the specified location. I've tried a few different approaches without success.

I was wondering if you could take a look at my changes, give me your thoughts, and perhaps collaborate to get this feature working for iOS. Your expertise would be very valuable.

Thanks for your time.

Best,
Adrian