### PR TITLE
[iOS][Gallery] - Multi image selection fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.3.4
+### iOS
+fix if selecting from gallery multiple files from remote sources (eg GoPro, Drone) imported to the device gallery and uploaded to iCloud they would have the same file name and it shows only one image repeated
+fix returned images are in different onder from the gallery selection
 ## 5.3.3
 fix [#1312](https://github.com/miguelpruivo/flutter_file_picker/issues/1312)
 ## 5.3.2

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -473,7 +473,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
         return;
     }
     
-    NSMutableArray<NSURL *> * urls = [[NSMutableArray alloc] initWithCapacity:results.count];
+    NSMutableArray<NSURL *> * urls = [[NSMutableArray alloc] initWithCapacity: results.count];
     
     self.group = dispatch_group_create();
     
@@ -483,8 +483,13 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
     
     __block NSError * blockError;
     
-    for (PHPickerResult *result in results) {
+    for (NSInteger index = 0; index < results.count; ++index) {
+        [urls addObject:[NSNull null]];
+
         dispatch_group_enter(_group);
+
+        PHPickerResult * result = [results objectAtIndex: index];
+
         [result.itemProvider loadFileRepresentationForTypeIdentifier:@"public.item" completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
             
             if(url == nil) {
@@ -494,7 +499,10 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
                 return;
             }
             
-            NSString * filename = url.lastPathComponent;
+            long timestamp = (long)([[NSDate date] timeIntervalSince1970] * 1000);
+            NSString * filenameWithoutExtension = [url.lastPathComponent stringByDeletingPathExtension];
+            NSString * fileExtension = url.pathExtension;
+            NSString * filename = [NSString stringWithFormat:@"%@-%ld.%@", filenameWithoutExtension, timestamp, fileExtension];
             NSString * extension = [filename pathExtension];
             NSFileManager * fileManager = [[NSFileManager alloc] init];
             NSURL * cachedUrl;
@@ -551,7 +559,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
             }
             
             
-            [urls addObject:cachedUrl];
+            [urls replaceObjectAtIndex:index withObject:cachedUrl];
             dispatch_group_leave(self->_group);
         }];
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.3.3
+version: 5.3.4
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.3.4
+version: 5.5.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR contains fixes for the following:

- When you selected multiple images and for some reason they had the same file name the plugin would not properly handle the situation and would cause the same file to be repeated on all selected files instead of the files itself.
- When you select multiple images the resulting list order would be different than the originally selected order by the user.