### PR TITLE
fix getDirectoryPath() for window crash

### DIFF
--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -131,7 +131,6 @@ class FilePickerWindows extends FilePicker {
     final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
     hr = fileDialog.show(hwndOwner);
     if (!SUCCEEDED(hr)) {
-      fileDialog.release();
       CoUninitialize();
 
       if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
@@ -150,11 +149,6 @@ class FilePickerWindows extends FilePicker {
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
     final path = pathPtr.value.toDartString();
-
-    hr = item.release();
-    if (!SUCCEEDED(hr)) throw WindowsException(hr);
-
-    hr = fileDialog.release();
     CoUninitialize();
 
     return Future.value(path);


### PR DESCRIPTION
compare to https://github.com/dart-windows/win32/blob/main/example/dialogshow.dart
xxx.release() is useless and causes application crash