### PR TITLE
#970 Support setting an initial directory in getDirectoryPath() on Windows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.1
+### Desktop (Windows)
+The `initialDirectory` parameter of `getDirectoryPath()` now works ([#970](https://github.com/miguelpruivo/flutter_file_picker/issues/970)).
+
 ## 6.2.0
 ### Android
 Add ability to compress images on android by specifying a compression quality value ([#735]

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -140,7 +140,7 @@ abstract class FilePicker extends PlatformInterface {
   /// window). This parameter works only on Windows desktop.
   ///
   /// [initialDirectory] can be optionally set to an absolute path to specify
-  /// where the dialog should open. Only supported on Linux and macOS.
+  /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   ///
   /// Returns a [Future<String?>] which resolves to  the absolute path of the selected directory,
   /// if the user selected a directory. Returns `null` if the user aborted the dialog or if the

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -116,19 +116,18 @@ class FilePickerWindows extends FilePicker {
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
     free(title);
 
-    // TODO: figure out how to set the initial directory via SetDefaultFolder / SetFolder
-    // if (initialDirectory != null) {
-    //   final folder = TEXT(initialDirectory);
-    //   final riid = calloc<COMObject>();
-    //   final item = IShellItem(riid);
-    //   final location = item.ptr;
-    //   SHCreateItemFromParsingName(folder, nullptr, riid.cast(), item.ptr.cast());
-    //   hr = fileDialog.AddPlace(item.ptr, FDAP.FDAP_TOP);
-    //   if (!SUCCEEDED(hr)) throw WindowsException(hr);
-    //   hr = fileDialog.SetFolder(location);
-    //   if (!SUCCEEDED(hr)) throw WindowsException(hr);
-    //   free(folder);
-    // }
+    if (initialDirectory != null) {
+      final folder = TEXT(initialDirectory);
+      final riid = convertToIID(IID_IShellItem);
+      final ppv = calloc<Pointer>();
+      hr = SHCreateItemFromParsingName(folder, nullptr, riid, ppv);
+      final item = IShellItem(ppv.cast());
+      free(riid);
+      free(folder);
+      if (!SUCCEEDED(hr)) throw WindowsException(hr);
+      hr = fileDialog.setFolder(item.ptr.cast<Pointer<COMObject>>().value);
+      if (!SUCCEEDED(hr)) throw WindowsException(hr);
+    }
 
     final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
     hr = fileDialog.show(hwndOwner);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 6.2.0
+version: 6.2.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi, thanks for developing and maintaining this plugin!

Here is a fix for issue #970 (getDirectoryPath() would ignore its initialDirectory parameter on Windows). I hope you'll find it helpful.


