### PR TITLE
Feature: keep picking order on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.0
+Add `readSequential` flag for web. If `readSequential` is true, order of picked files will be preserved. If flag is false, files will be read parallel. 
+
 ## 6.0.0
 Update minimum Flutter version to 3.7.0.
 

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -46,6 +46,7 @@ class FilePickerWeb extends FilePicker {
     bool withData = true,
     bool withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) async {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
       throw Exception(
@@ -68,7 +69,7 @@ class FilePickerWeb extends FilePicker {
       onFileLoading(FilePickerStatus.picking);
     }
 
-    void changeEventListener(e) {
+    void changeEventListener(e) async {
       if (changeEventTriggered) {
         return;
       }
@@ -114,11 +115,16 @@ class FilePickerWeb extends FilePicker {
           continue;
         }
 
+        final syncCompleter = Completer<void>();
         final FileReader reader = FileReader();
         reader.onLoadEnd.listen((e) {
           addPickedFile(file, reader.result as Uint8List?, null, null);
+          syncCompleter.complete();
         });
         reader.readAsArrayBuffer(file);
+        if (readSequential) {
+          await syncCompleter.future;
+        }
       }
     }
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -92,6 +92,8 @@ abstract class FilePicker extends PlatformInterface {
   /// [initialDirectory] can be optionally set to an absolute path to specify
   /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   ///
+  /// [readSequential] can be optionally set on web to keep the import file order during import.
+  ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
   ///
@@ -109,6 +111,7 @@ abstract class FilePicker extends PlatformInterface {
     bool withData = false,
     bool withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) async =>
       throw UnimplementedError('pickFiles() has not been implemented.');
 

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -31,6 +31,7 @@ class FilePickerIO extends FilePicker {
     bool? withData = false,
     bool? withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) =>
       _getPath(
         type,

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -14,6 +14,7 @@ class FilePickerMacOS extends FilePicker {
     bool withData = false,
     bool withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final String fileFilter = fileTypeToFileFilter(

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -18,6 +18,7 @@ class FilePickerLinux extends FilePicker {
     bool withData = false,
     bool withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) async {
     final String executable = await _getPathToExecutable();
     final dialogHandler = DialogHandler(executable);

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -26,6 +26,7 @@ class FilePickerWindows extends FilePicker {
     bool withData = false,
     bool withReadStream = false,
     bool lockParentWindow = false,
+    bool readSequential = false,
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(


### PR DESCRIPTION
Currently the order of the imported files in web is not respected. It seems like files are ordered by filesize. 
To have the feature to keep the picking order, the files are read synchronously.  
With `readSequential` order of files will be kept in web. The default value is false. 