### PR TITLE
saveFile method implemented for android platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.0
+### Android
+- saveFile() method implemented for the android platform
 ## 6.0.0
 Update minimum Flutter version to 3.7.0.
 

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileInfo.java
@@ -20,6 +20,10 @@ public class FileInfo {
         this.uri = uri;
     }
 
+    public String toString() {
+        return "path: " + this.path + ", name: " + this.name;
+    }
+
     public static class Builder {
 
         private String path;

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -37,6 +37,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     private boolean isMultipleSelection = false;
     private boolean loadDataToMemory = false;
     private String type;
+    private String input;
     private String[] allowedExtensions;
     private EventChannel.EventSink eventSink;
 
@@ -121,7 +122,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                 return;
                             } else if (type.equals("save") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                 Log.d(FilePickerDelegate.TAG, "[SaveFile] File URI:" + uri.toString());
-                                final String filePath = FileUtils.getAbsolutePathFromUri(uri, activity);
+                                final String filePath = FileUtils.getAbsolutePathFromUri(uri, input, activity);
                                 if(filePath != null) {
                                     Log.d(FilePickerDelegate.TAG, "[SaveFile] File Path:" + filePath);
                                     finishWithSuccess(filePath);
@@ -279,7 +280,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @SuppressWarnings("deprecation")
-    public void startFileExplorer(final String type, final boolean isMultipleSelection, final boolean withData, final String[] allowedExtensions, final MethodChannel.Result result) {
+    public void startFileExplorer(final String type, final String input, final boolean isMultipleSelection, final boolean withData, final String[] allowedExtensions, final MethodChannel.Result result) {
 
         if (!this.setPendingMethodCallAndResult(result)) {
             finishWithAlreadyActiveError(result);
@@ -287,6 +288,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         }
 
         this.type = type;
+        this.input = input;
         this.isMultipleSelection = isMultipleSelection;
         this.loadDataToMemory = withData;
         this.allowedExtensions = allowedExtensions;

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -119,16 +119,26 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                                     finishWithError("unknown_path", "Failed to retrieve directory path.");
                                 }
                                 return;
+                            } else if (type.equals("save") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                                Log.d(FilePickerDelegate.TAG, "[SaveFile] File URI:" + uri.toString());
+                                final String filePath = FileUtils.getAbsolutePathFromUri(uri, activity);
+                                if(filePath != null) {
+                                    Log.d(FilePickerDelegate.TAG, "[SaveFile] File Path:" + filePath);
+                                    finishWithSuccess(filePath);
+                                } else {
+                                    finishWithError("unknown_path", "Failed to retrieve file path.");
+                                }
+                                return;
                             }
 
                             final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, uri, loadDataToMemory);
 
                             if(file != null) {
+                                Log.d(FilePickerDelegate.TAG, file.toString());
                                 files.add(file);
                             }
 
                             if (!files.isEmpty()) {
-                                Log.d(FilePickerDelegate.TAG, "File path:" + files.toString());
                                 finishWithSuccess(files);
                             } else {
                                 finishWithError("unknown_path", "Failed to retrieve path.");
@@ -229,6 +239,14 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
 
         if (type.equals("dir")) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        } else if (type.equals("save")) {
+            intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            Log.d(TAG, "Selected type " + type);
+            intent.setType("*/*");
+            if (allowedExtensions != null) {
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions);
+            }
         } else {
             if (type.equals("image/*")) {
                 intent = new Intent(Intent.ACTION_PICK, android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -159,6 +159,8 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
 
         if (fileType == null) {
             result.notImplemented();
+        } else if (fileType == "save") {
+            allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
         } else if (fileType != "dir") {
             isMultipleSelection = (boolean) arguments.get("allowMultipleSelection");
             withData = (boolean) arguments.get("withData");
@@ -189,6 +191,9 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
                 return "*/*";
             case "dir":
                 return "dir";
+            case "save":
+                return "save";
+
             default:
                 return null;
         }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -111,6 +111,7 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
     private Activity activity;
     private MethodChannel channel;
     private static String fileType;
+    private static String inputFile;
     private static boolean isMultipleSelection = false;
     private static boolean withData = false;
 
@@ -160,6 +161,7 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
         if (fileType == null) {
             result.notImplemented();
         } else if (fileType == "save") {
+            inputFile         = (String) arguments.get("inputFile");
             allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
         } else if (fileType != "dir") {
             isMultipleSelection = (boolean) arguments.get("allowMultipleSelection");
@@ -170,7 +172,7 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
         if (call.method != null && call.method.equals("custom") && (allowedExtensions == null || allowedExtensions.length == 0)) {
             result.error(TAG, "Unsupported filter. Make sure that you are only using the extension without the dot, (ie., jpg instead of .jpg). This could also have happened because you are using an unsupported file extension.  If the problem persists, you may want to consider using FileType.all instead.", null);
         } else {
-            this.delegate.startFileExplorer(fileType, isMultipleSelection, withData, allowedExtensions, result);
+            this.delegate.startFileExplorer(fileType, inputFile, isMultipleSelection, withData, allowedExtensions, result);
         }
 
     }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -195,13 +195,13 @@ public class FileUtils {
             String path = split[1];
 
             try {
-
-                StorageManager storageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+                StorageManager storageManager =
+                    (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
                 StorageVolume storageVolume = null;
                 List<StorageVolume> storageVolumes = storageManager.getStorageVolumes();
                 for (StorageVolume volume : storageVolumes) {
                     if (
-                        "primary".equalsIgnoreCase(authority) ||
+                        PRIMARY_VOLUME_NAME.equals(authority) ||
                         (volume.getUuid() != null && volume.getUuid().equals(authority))
                         ) {
                         storageVolume = volume;
@@ -213,12 +213,15 @@ public class FileUtils {
                     String rootPath = storageVolume.getDirectory().getAbsolutePath();
                     absolutePath = rootPath + "/" + path;
                     try {
-                        OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
-                        InputStream inputStream = new FileInputStream(input);
-                        byte[] buffer = new byte[1024];
-                        int bytesRead = 0;
-                        while ((bytesRead = inputStream.read(buffer)) != -1) {
-                            outputStream.write(buffer, 0, bytesRead);
+                        File iFile = new File(input);
+                        if (iFile.exists() && iFile.isFile()) {
+                            OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
+                            InputStream inputStream = new FileInputStream(input);
+                            byte[] buffer = new byte[1024];
+                            int bytesRead = 0;
+                            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                                outputStream.write(buffer, 0, bytesRead);
+                            }
                         }
                     } catch (Exception e) {
                         e.printStackTrace();

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -26,6 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -183,9 +184,10 @@ public class FileUtils {
     @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     @Nullable
     @SuppressWarnings("deprecation")
-    public static String getAbsolutePathFromUri(Uri uri, Context context) {
+    public static String getAbsolutePathFromUri(Uri uri, String input, Context context) {
         String absolutePath = null;
         if (DocumentsContract.isDocumentUri(context, uri)) {
+
             // DocumentProvider
             String documentId = DocumentsContract.getDocumentId(uri);
             String[] split = documentId.split(":");
@@ -193,7 +195,6 @@ public class FileUtils {
             String path = split[1];
 
             try {
-                DocumentsContract.deleteDocument(context.getContentResolver(), uri);
 
                 StorageManager storageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
                 StorageVolume storageVolume = null;
@@ -211,8 +212,19 @@ public class FileUtils {
                 if (storageVolume != null) {
                     String rootPath = storageVolume.getDirectory().getAbsolutePath();
                     absolutePath = rootPath + "/" + path;
+                    try {
+                        OutputStream outputStream = context.getContentResolver().openOutputStream(uri);
+                        InputStream inputStream = new FileInputStream(input);
+                        byte[] buffer = new byte[1024];
+                        int bytesRead = 0;
+                        while ((bytesRead = inputStream.read(buffer)) != -1) {
+                            outputStream.write(buffer, 0, bytesRead);
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
                 }
-            } catch (FileNotFoundException e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -52,6 +52,7 @@ class FilePickerIO extends FilePicker {
     bool lockParentWindow = false,
   }) =>
       _getSavePath(
+        fileName!,
         type,
         allowedExtensions,
       );
@@ -138,6 +139,7 @@ class FilePickerIO extends FilePicker {
   }
 
   Future<String?> _getSavePath(
+    String inputFile,
     FileType fileType,
     List<String>? allowedExtensions,
   ) async {
@@ -148,6 +150,7 @@ class FilePickerIO extends FilePicker {
     }
     try {
       return await _channel.invokeMethod('save', {
+        'inputFile': inputFile,
         'allowedExtensions': allowedExtensions,
       });
     } on PlatformException catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 6.0.0
+version: 6.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
I implemented a saveFile method for the android platform because I needed it.
I don't know if it is interesting, I think that you already know how to do it but maybe violates some android security rule and that's the reason why you didn't add it.
If this is the case just ignore it.

The only way I found to implement the method is by removing the file that the saveFile dialog creates because that file cannot be written by the calling thread. By removing the 0 length created file and returning the path, the calling thread is able to open the file, provided that the file is in an accessible folder.