### PR TITLE
Support initialDirectory of getDirectoryPath in Android

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -38,6 +38,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     private boolean loadDataToMemory = false;
     private String type;
     private String[] allowedExtensions;
+    private String initialDirectory;
     private EventChannel.EventSink eventSink;
 
     public FilePickerDelegate(final Activity activity) {
@@ -110,7 +111,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                             if (type.equals("dir") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                 uri = DocumentsContract.buildDocumentUriUsingTree(uri, DocumentsContract.getTreeDocumentId(uri));
 
-                                Log.d(FilePickerDelegate.TAG, "[SingleFilePick] File URI:" + uri.toString());
+                                Log.d(FilePickerDelegate.TAG, "[DirectoryPick] File URI:" + uri.toString());
                                 final String dirPath = FileUtils.getFullPathFromTreeUri(uri, activity);
 
                                 if(dirPath != null) {
@@ -229,6 +230,11 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
 
         if (type.equals("dir")) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+
+            Log.d(TAG, "Initial directory " + initialDirectory);
+            if (initialDirectory != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, DocumentsContract.buildDocumentUri("com.android.externalstorage.documents", initialDirectory));
+            }
         } else {
             if (type.equals("image/*")) {
                 intent = new Intent(Intent.ACTION_PICK, android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
@@ -261,7 +267,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @SuppressWarnings("deprecation")
-    public void startFileExplorer(final String type, final boolean isMultipleSelection, final boolean withData, final String[] allowedExtensions, final MethodChannel.Result result) {
+    public void startFileExplorer(final String type, final boolean isMultipleSelection, final boolean withData, final String[] allowedExtensions, final String initialDirectory, final MethodChannel.Result result) {
 
         if (!this.setPendingMethodCallAndResult(result)) {
             finishWithAlreadyActiveError(result);
@@ -272,6 +278,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         this.isMultipleSelection = isMultipleSelection;
         this.loadDataToMemory = withData;
         this.allowedExtensions = allowedExtensions;
+        this.initialDirectory = FileUtils.getTreeUriFromFullPath(initialDirectory, activity);
         // `READ_EXTERNAL_STORAGE` permission is not needed since SDK 33 (Android 13 or higher).
         // `READ_EXTERNAL_STORAGE` & `WRITE_EXTERNAL_STORAGE` are no longer meant to be used, but classified into granular types.
         // Reference: https://developer.android.com/about/versions/13/behavior-changes-13

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -156,6 +156,7 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
 
         fileType = FilePickerPlugin.resolveType(call.method);
         String[] allowedExtensions = null;
+        String initialDirectory = null;
 
         if (fileType == null) {
             result.notImplemented();
@@ -163,12 +164,14 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
             isMultipleSelection = (boolean) arguments.get("allowMultipleSelection");
             withData = (boolean) arguments.get("withData");
             allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
+        } else if (fileType == "dir") {
+            initialDirectory = (String) arguments.get("initialDirectory");
         }
 
         if (call.method != null && call.method.equals("custom") && (allowedExtensions == null || allowedExtensions.length == 0)) {
             result.error(TAG, "Unsupported filter. Make sure that you are only using the extension without the dot, (ie., jpg instead of .jpg). This could also have happened because you are using an unsupported file extension.  If the problem persists, you may want to consider using FileType.all instead.", null);
         } else {
-            this.delegate.startFileExplorer(fileType, isMultipleSelection, withData, allowedExtensions, result);
+            this.delegate.startFileExplorer(fileType, isMultipleSelection, withData, allowedExtensions, initialDirectory, result);
         }
 
     }

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -54,7 +54,9 @@ class FilePickerIO extends FilePicker {
     String? initialDirectory,
   }) async {
     try {
-      return await _channel.invokeMethod('dir', {});
+      return await _channel.invokeMethod('dir', {
+        'initialDirectory': initialDirectory
+      });
     } on PlatformException catch (ex) {
       if (ex.code == "unknown_path") {
         print(


### PR DESCRIPTION
For example, given `/storage/emulated/0/DCIM` as initialDirectory, it converts path to `primary:/DCIM` internally. Using `EXTRA_INITIAL_URI` and `com.android.externalstorage.documents`, can set initialDirectory of file explorer. It works for android.