### PR TITLE
add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 33
+    
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.mr.flutter.plugin.filepicker'
+    }
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
i added `namespace` to `build.gradle` to support compatibility with AGP <4.2.