### PR TITLE
fix #1412: Picking a folder in iOS causes the original folder to be deleted.

### DIFF
--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -349,26 +349,32 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
     if(_result == nil) {
         return;
     }
-    NSMutableArray<NSURL *> *newUrls = [NSMutableArray new];
-    for (NSURL *url in urls) {
-        // Create file URL to temporary folder
-        NSURL *tempURL = [NSURL fileURLWithPath:NSTemporaryDirectory()];
-        // Append filename (name+extension) to URL
-        tempURL = [tempURL URLByAppendingPathComponent:url.lastPathComponent];
-        NSError *error;
-        // If file with same name exists remove it (replace file with new one)
-        if ([[NSFileManager defaultManager] fileExistsAtPath:tempURL.path]) {
-            [[NSFileManager defaultManager] removeItemAtPath:tempURL.path error:&error];
+    NSMutableArray<NSURL *> *newUrls;
+    if(controller.documentPickerMode == UIDocumentPickerModeOpen) {
+        newUrls = urls;
+    }
+    if(controller.documentPickerMode == UIDocumentPickerModeImport) {
+        newUrls = [NSMutableArray new];
+        for (NSURL *url in urls) {
+            // Create file URL to temporary folder
+            NSURL *tempURL = [NSURL fileURLWithPath:NSTemporaryDirectory()];
+            // Append filename (name+extension) to URL
+            tempURL = [tempURL URLByAppendingPathComponent:url.lastPathComponent];
+            NSError *error;
+            // If file with same name exists remove it (replace file with new one)
+            if ([[NSFileManager defaultManager] fileExistsAtPath:tempURL.path]) {
+                [[NSFileManager defaultManager] removeItemAtPath:tempURL.path error:&error];
+                if (error) {
+                    NSLog(@"%@", error.localizedDescription);
+                }
+            }
+            // Move file from app_id-Inbox to tmp/filename
+            [[NSFileManager defaultManager] moveItemAtPath:url.path toPath:tempURL.path error:&error];
             if (error) {
                 NSLog(@"%@", error.localizedDescription);
+            } else {
+                [newUrls addObject:tempURL];
             }
-        }
-        // Move file from app_id-Inbox to tmp/filename
-        [[NSFileManager defaultManager] moveItemAtPath:url.path toPath:tempURL.path error:&error];
-        if (error) {
-            NSLog(@"%@", error.localizedDescription);
-        } else {
-            [newUrls addObject:tempURL];
         }
     }
     


### PR DESCRIPTION
If use file_picker version 5.3.3 or higher, when an ios user picks a directory, the original directory will be deleted (actually, moved to the app's sandbox tmp directory, and the user cannot access them), and file_picker returns a path in tmp directory.

This PR fixes this BUG. file_picker will return the absolute path to the folder, just like before v5.3.3.