### PR TITLE
Fix #1455 NPE when compressing images from gallery on Android 14

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.Parcelable;
 import android.os.Message;
+import android.os.Parcelable;
 import android.provider.DocumentsContract;
 import android.util.Log;
 
@@ -19,10 +19,9 @@ import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Objects;
 
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
@@ -77,13 +76,11 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
 
     @Override
     public boolean onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-
-        if(type == null) {
+        if (type == null) {
             return false;
         }
 
         if (requestCode == REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-
             this.dispatchEventStatus(true);
 
             new Thread(new Runnable() {
@@ -92,16 +89,14 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                     if (data != null) {
                         final ArrayList<FileInfo> files = new ArrayList<>();
 
-
                         if (data.getClipData() != null) {
                             final int count = data.getClipData().getItemCount();
                             int currentItem = 0;
                             while (currentItem < count) {
                                  Uri currentUri = data.getClipData().getItemAt(currentItem).getUri();
 
-                                if(type=="image/*" && compressionQuality>0) {
-
-                                    currentUri=FileUtils.compressImage(currentUri,compressionQuality,activity.getApplicationContext());
+                                if (Objects.equals(type, "image/*") && compressionQuality > 0) {
+                                    currentUri = FileUtils.compressImage(currentUri, compressionQuality, activity.getApplicationContext());
                                 }
                                 final FileInfo file = FileUtils.openFileStream(FilePickerDelegate.this.activity, currentUri, loadDataToMemory);
                                 if(file != null) {
@@ -115,8 +110,8 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
                         } else if (data.getData() != null) {
                             Uri uri = data.getData();
 
-                            if(type=="image/*" && compressionQuality>0) {
-                                uri=FileUtils.compressImage(uri,compressionQuality,activity.getApplicationContext());
+                            if (Objects.equals(type, "image/*") && compressionQuality > 0) {
+                                uri = FileUtils.compressImage(uri, compressionQuality, activity.getApplicationContext());
                             }
 
                             if (type.equals("dir") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -230,7 +225,6 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         return bundle.getParcelableArrayList("selectedItems");
     }
 
-    @SuppressWarnings("deprecation")
     private void startFileExplorer() {
         final Intent intent;
 
@@ -265,7 +259,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
         }
 
         if (intent.resolveActivity(this.activity.getPackageManager()) != null) {
-            this.activity.startActivityForResult(intent, REQUEST_CODE);
+            this.activity.startActivityForResult(Intent.createChooser(intent, null), REQUEST_CODE);
         } else {
             Log.e(TAG, "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.");
             finishWithError("invalid_format_type", "Can't handle the provided file type.");

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -94,9 +94,9 @@ public class FileUtils {
 
     public static Uri compressImage(Uri originalImageUri, int compressionQuality, Context context) {
         Uri compressedUri;
-        try {
+        try (InputStream imageStream = context.getContentResolver().openInputStream(originalImageUri)) {
             File compressedFile = createImageFile();
-            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(originalImageUri));
+            Bitmap originalBitmap = BitmapFactory.decodeStream(imageStream);
             // Compress and save the image
             FileOutputStream fos = new FileOutputStream(compressedFile);
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, compressionQuality, fos);

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -92,28 +92,27 @@ public class FileUtils {
     }
 
 
-    public static Uri compressImage(Uri originalImageUri, int compressionQuality,Context context) {
-        String originalImagePath = getRealPathFromURI(context,originalImageUri);
-       Uri compressedUri=null;
-       File compressedFile=null;
+    public static Uri compressImage(Uri originalImageUri, int compressionQuality, Context context) {
+        Uri compressedUri;
         try {
-             compressedFile=createImageFile();
-            Bitmap originalBitmap = BitmapFactory.decodeFile(originalImagePath);
-            String file_path = Environment.getExternalStorageDirectory().getAbsolutePath() +
-                    "/FilePicker";
+            File compressedFile = createImageFile();
+            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(originalImageUri));
             // Compress and save the image
             FileOutputStream fos = new FileOutputStream(compressedFile);
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, compressionQuality, fos);
             fos.flush();
             fos.close();
-            compressedUri=Uri.fromFile(compressedFile);
-        }catch (FileNotFoundException e) {
+            compressedUri = Uri.fromFile(compressedFile);
+        }
+        catch (FileNotFoundException e) {
             throw new RuntimeException(e);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException(e);
         }
         return compressedUri;
     }
+
     private static File createImageFile() throws IOException {
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     lintOptions {
         disable 'InvalidPackage'
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.mr.flutter.plugin.filepicker.example"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 33
+        targetSdk 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Compression is done by reading the file on disk, which is not allowed on Android 14+. 
The correct way is opening the content Uri with openInputStream().
