### PR TITLE
Fix Issue 1367

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.1
+### iOS
+- fix [1367](https://github.com/miguelpruivo/flutter_file_picker/issues/1367)
+
 ## 8.0.0+1
 Removes linter warnings and fixes CI/CD.
 

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -24,6 +24,7 @@
 @property (nonatomic) BOOL allowCompression;
 @property (nonatomic) dispatch_group_t group;
 @property (nonatomic) BOOL isSaveFile;
+@property (nonatomic) MediaType type;
 @end
 
 @implementation FilePickerPlugin
@@ -221,7 +222,9 @@
 
 #ifdef PICKER_MEDIA
 - (void) resolvePickMedia:(MediaType)type withMultiPick:(BOOL)multiPick withCompressionAllowed:(BOOL)allowCompression  {
-    
+
+    self.type = type;
+
 #ifdef PHPicker
     if (@available(iOS 14, *)) {
         PHPickerConfiguration *config = [[PHPickerConfiguration alloc] init];
@@ -501,7 +504,10 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
     }
     
     __block NSError * blockError;
-    
+
+    bool isImageSelection = self.type == IMAGE;
+    NSString * utiType = isImageSelection ? @"public.image" : @"public.audiovisual-content";
+
     for (NSInteger index = 0; index < results.count; ++index) {
         [urls addObject:[NSURL URLWithString:@""]];
 
@@ -509,8 +515,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
 
         PHPickerResult * result = [results objectAtIndex: index];
 
-        [result.itemProvider loadFileRepresentationForTypeIdentifier:@"public.item" completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
-            
+        [result.itemProvider loadFileRepresentationForTypeIdentifier:utiType completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
             if(url == nil) {
                 blockError = error;
                 Log("Could not load the picked given file: %@", blockError);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.0+1
+version: 8.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
We rebased the PR #1369 fixing the issue [1367](https://github.com/miguelpruivo/flutter_file_picker/issues/1367)

All credits should go to @GabrielAraujo

> On iOS 17 the UTI type public.item is not properly working for live photos that are syncing with iCloud (download or upload).
> Using media specific UTI types seemed to have fixed the problem but still any thoughts on the approach are welcome so we can adjust on how we handle the issue.


