### PR TITLE
[Web] Release picked file data for Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.5
+### Web
+Release picked file data in memory to avoid memory leak
+
 ## 8.0.4
 ### Android
 Removes references to Flutter v1 android embedding classes.

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -169,6 +169,12 @@ class FilePickerWeb extends FilePicker {
     _target.children.add(uploadInput);
     uploadInput.click();
 
+    firstChild = _target.firstChild;
+    while (firstChild != null) {
+      _target.removeChild(firstChild);
+      firstChild = _target.firstChild;
+    }
+
     final List<PlatformFile>? files = await filesCompleter.future;
 
     return files == null ? null : FilePickerResult(files);

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -94,7 +94,9 @@ class FilePickerWindows extends FilePicker {
     String? initialDirectory,
   }) {
     int hr = CoInitializeEx(
-        nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+      nullptr,
+      COINIT.COINIT_APARTMENTTHREADED | COINIT.COINIT_DISABLE_OLE1DDE,
+    );
 
     if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
@@ -134,7 +136,7 @@ class FilePickerWindows extends FilePicker {
     if (!SUCCEEDED(hr)) {
       CoUninitialize();
 
-      if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+      if (hr == HRESULT_FROM_WIN32(WIN32_ERROR.ERROR_CANCELLED)) {
         return Future.value(null);
       }
       throw WindowsException(hr);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.4
+version: 8.0.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
### Issue
There's a memory leak happening with web version

### Reproducible code
<details>
  <summary>See here</summary>

```Dart
import 'package:file_picker/file_picker.dart';
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Material App',
      home: FirstScreen(),
    );
  }
}

class FirstScreen extends StatelessWidget {
  const FirstScreen({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: TextButton(
          onPressed: () {
            Navigator.push(
              context,
              MaterialPageRoute(builder: (context) => const SecondScreen()),
            );
          },
          child: Text('Go to second screen'),
        ),
      ),
    );
  }
}

class SecondScreen extends StatefulWidget {
  const SecondScreen({super.key});

  @override
  State<SecondScreen> createState() => _SecondScreenState();
}

class _SecondScreenState extends State<SecondScreen> {
  String _name = '';

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: [
            Text("Picked file's name: $_name"),
            TextButton(
              onPressed: () async {
                final picked = await FilePicker.platform.pickFiles(
                  type: FileType.image,
                  withData: true,
                );
                if (mounted && picked != null) {
                  setState(() {
                    _name = picked.files.firstOrNull?.name ?? '';
                  });
                }
              },
              child: Text('Pick image'),
            ),
            TextButton(
              onPressed: () {
                Navigator.pop(context);
              },
              child: Text('Go back'),
            ),
          ],
        ),
      ),
    );
  }
}

```
</details>

### Steps to reproduce

1. Run `flutter run -d chrome --profile`
2. Open Chrome dev tools, Memory tab, trigger garbage collector then snapshot main heap
3. Navigate to second screen by clicking on `Go to second screen` button
4. Pick a heavy file. In the above code, I chose to pick image because I already have a heavy image (16.3mb)
5. Go back to the previous screen either by clicking on `Go back` or any conventional ways for web
6. Trigger garbage collector then snapshot main heap again. Compare two snapshots.

### Expected behavior
The file's data will be deallocated from memory
### Actual behavior
The file's data is still on memory

### Resolved demo
**Before**
<img width="1432" alt="Screenshot 2024-04-09 at 11 51 30" src="https://github.com/miguelpruivo/flutter_file_picker/assets/160106668/218db53e-b5de-4c2c-b1db-f984e1930a3d">
**After**
<img width="1425" alt="Screenshot 2024-04-09 at 11 53 41" src="https://github.com/miguelpruivo/flutter_file_picker/assets/160106668/b1774457-1d86-49f7-8d8c-8345b258f8a4">
