### PR TITLE
Compile out broken references if PICKER_DOCUMENT is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.1
+### iOS
+Fixes an issue preventing compilation on iOS when using Pod::PICKER_DOCUMENT = false.
+
 ## 8.0.0+1
 Removes linter warnings and fixes CI/CD.
 

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -149,11 +149,17 @@
                                     details:nil]);
 #endif      
     } else if([call.method isEqualToString:@"save"]) {
+#ifdef PICKER_DOCUMENT
         NSString *fileName = [arguments valueForKey:@"fileName"];
         NSString *fileType = [arguments valueForKey:@"fileType"];
         NSString *initialDirectory = [arguments valueForKey:@"initialDirectory"];
         FlutterStandardTypedData *bytes = [arguments valueForKey:@"bytes"];
         [self saveFileWithName:fileName fileType:fileType initialDirectory:initialDirectory bytes: bytes];
+#else
+        _result([FlutterError errorWithCode:@"Unsupported function"
+                                    message:@"The save function requires the document picker to be compiled in. Remove the Pod::PICKER_DOCUMENT=false statement from your Podfile."
+                                    details:nil]);
+#endif
     } else {
         result(FlutterMethodNotImplemented);
         _result = nil;
@@ -167,6 +173,7 @@
 
 #pragma mark - Resolvers
 
+#ifdef PICKER_DOCUMENT
 - (void)saveFileWithName:(NSString*)fileName fileType:(NSString *)fileType initialDirectory:(NSString*)initialDirectory bytes:(FlutterStandardTypedData*)bytes{
     self.isSaveFile = YES;
     NSFileManager* fm = [NSFileManager defaultManager];
@@ -197,6 +204,7 @@
     }
     [[self viewControllerWithWindow:nil] presentViewController:self.documentPickerController animated:YES completion:nil];
 }
+#endif // PICKER_DOCUMENT
 
 #ifdef PICKER_DOCUMENT
 - (void)resolvePickDocumentWithMultiPick:(BOOL)allowsMultipleSelection pickDirectory:(BOOL)isDirectory {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.0+1
+version: 8.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes the issue where compilation fails with Pod::PICKER_DOCUMENT = false 
See issue https://github.com/miguelpruivo/flutter_file_picker/issues/1486 