### PR TITLE
Fix: TypeError: Instance of 'NativeByteBuffer': type 'NativeByteBuffer' is not a subtype of type 'List'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.0.3
 ### Web
-Fixes a issue of "TypeError" about `_openFileReadStream`[#1322](https://github.com/miguelpruivo/flutter_file_picker/pull/1496).
+Fixes a issue of "TypeError" about `_openFileReadStream`[#1496](https://github.com/miguelpruivo/flutter_file_picker/pull/1496).
 
 ## 8.0.2
 ### iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.0.3
 ### Web
-Fixes a issue of "TypeError" about `_openFileReadStream`[#1496](https://github.com/miguelpruivo/flutter_file_picker/pull/1496).
+Fixes a TypeError with `pickFiles()` when using the HTML renderer.
 
 ## 8.0.2
 ### iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.3
+### Web
+Fixes a issue of "TypeError" about `_openFileReadStream`[#1322](https://github.com/miguelpruivo/flutter_file_picker/pull/1496).
+
 ## 8.0.2
 ### iOS
 Fixes the bug [#1412](https://github.com/miguelpruivo/flutter_file_picker/issues/1412) that picking a folder in iOS causes the original folder to be deleted.

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -208,6 +208,15 @@ class FilePickerWeb extends FilePicker {
       final blob = file.slice(start, end);
       reader.readAsArrayBuffer(blob);
       await EventStreamProviders.loadEvent.forTarget(reader).first;
+      if (reader.result is ByteBuffer){
+        // When built in the html web-renderer, an error may occur:
+        // TypeError: Instance of 'NativeByteBuffer': type 'NativeByteBuffer' is not a subtype of type 'List<int>'.
+        // Therefore, we need to make a type discrimination of the reader.result.
+        yield  (reader.result as ByteBuffer).asUint8List();
+        start += _readStreamChunkSize;
+        continue;
+      }
+      
       yield reader.result as List<int>;
       start += _readStreamChunkSize;
     }

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -212,29 +212,18 @@ class FilePickerWeb extends FilePicker {
       if (readerResult == null) {
         continue;
       }
-      if (readerResult is ByteBuffer) {
-        // An error may occur:
-        // TypeError: Instance of 'NativeByteBuffer': type 'NativeByteBuffer' is not a subtype of type 'List<int>'.
-        // Therefore, we need to make a type discrimination of the reader.result.
-        yield (readerResult as ByteBuffer).asUint8List();
+      // TODO: use `isA<JSArrayBuffer>()` when switching to Dart 3.4
+      // Handle the ArrayBuffer type. This maps to a `ByteBuffer` in Dart.
+      if (readerResult.instanceOfString('ArrayBuffer')) {
+        yield (readerResult as JSArrayBuffer).toDart.asUint8List();
         start += _readStreamChunkSize;
         continue;
       }
-      // Defensive programming: maybe the code can not reach here. ByteBuffer can cover most cases.
-      // Handle byte buffers.
-      if (readerResult.instanceOfString('JSArrayBuffer')) {
-        yield (readerResult as JSArrayBuffer).toDart.asUint8List();
-        start += _readStreamChunkSize;
-      }
-      // Handle JS Array type.
+      // TODO: use `isA<JSArray>()` when switching to Dart 3.4
+      // Handle the Array type.
       if (readerResult.instanceOfString('Array')) {
         // Assume this is a List<int>.
         yield (readerResult as JSArray).toDart.cast<int>();
-        start += _readStreamChunkSize;
-      }
-      // Handle JS ArrayBuffer type.
-      if (readerResult.instanceOfString('ArrayBuffer')) {
-        yield (readerResult as JSArrayBuffer).toDart.asUint8List();
         start += _readStreamChunkSize;
       }
     }

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -216,7 +216,7 @@ class FilePickerWeb extends FilePicker {
         // An error may occur:
         // TypeError: Instance of 'NativeByteBuffer': type 'NativeByteBuffer' is not a subtype of type 'List<int>'.
         // Therefore, we need to make a type discrimination of the reader.result.
-        yield (reader.result as ByteBuffer).asUint8List();
+        yield (readerResult as ByteBuffer).asUint8List();
         start += _readStreamChunkSize;
         continue;
       }

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -220,22 +220,23 @@ class FilePickerWeb extends FilePicker {
         start += _readStreamChunkSize;
         continue;
       }
+      // Defensive programming: maybe the code can not reach here. ByteBuffer can cover most cases.
       // Handle byte buffers.
       if (readerResult.instanceOfString('JSArrayBuffer')) {
         yield (readerResult as JSArrayBuffer).toDart.asUint8List();
         start += _readStreamChunkSize;
-        continue;
       }
       // Handle JS Array type.
       if (readerResult.instanceOfString('Array')) {
         // Assume this is a List<int>.
         yield (readerResult as JSArray).toDart.cast<int>();
         start += _readStreamChunkSize;
-        continue;
       }
-      // Default this is a List<int>
-      yield readerResult as List<int>;
-      start += _readStreamChunkSize;
+      // Handle JS ArrayBuffer type.
+      if (readerResult.instanceOfString('ArrayBuffer')) {
+        yield (readerResult as JSArrayBuffer).toDart.asUint8List();
+        start += _readStreamChunkSize;
+      }
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.2
+version: 8.0.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
 When built in the html web-renderer, an error may occur:
 TypeError: Instance of 'NativeByteBuffer': type 'NativeByteBuffer' is not a subtype of type 'List<int>'.

 Therefore, we need to make a type discrimination of the reader.result.