### PR TITLE
web split cancel and focus event, increase focus time

### DIFF
--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -140,12 +140,17 @@ class FilePickerWeb extends FilePicker {
     }
 
     void cancelledEventListener(Event _) {
-      window.removeEventListener('focus', cancelledEventListener.toJS);
+      changeEventTriggered = true;
+      filesCompleter.complete(null);
+    }
+
+    void focusedEventListener(Event _) {
+      window.removeEventListener('focus', focusedEventListener.toJS);
 
       // This listener is called before the input changed event,
       // and the `uploadInput.files` value is still null
       // Wait for results from js to dart
-      Future.delayed(Duration(seconds: 1)).then((value) {
+      Future.delayed(Duration(seconds: 3)).then((value) {
         if (!changeEventTriggered) {
           changeEventTriggered = true;
           filesCompleter.complete(null);
@@ -158,7 +163,7 @@ class FilePickerWeb extends FilePicker {
     uploadInput.addEventListener('cancel', cancelledEventListener.toJS);
 
     // Listen focus event for cancelled
-    window.addEventListener('focus', cancelledEventListener.toJS);
+    window.addEventListener('focus', focusedEventListener.toJS);
 
     //Add input element to the page body
     Node? firstChild = _target.firstChild;


### PR DESCRIPTION
[c5b01e072ffa24a7500a38c0e0b927f2e371b4a5](https://github.com/miguelpruivo/flutter_file_picker/commit/c5b01e072ffa24a7500a38c0e0b927f2e371b4a5)


I have two computer tests here I found that one second is still not enough time. So changeEventTriggered is always true. Is there any other way to determine whether to cancel?

One is Win7+Chrome109, and the other is Win10+Chrome122