### PR TITLE
Fix demo GIFs in README.md on pub.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,19 +160,19 @@ For full usage details refer to the **[Wiki](https://github.com/miguelpruivo/flu
 
 ## Example App
 #### Android
-![DemoAndroid](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_android.gif)
+![DemoAndroid](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_android.gif?raw=true)
 
 #### iOS
-![DemoMultiFilters](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_ios.gif)
+![DemoMultiFilters](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_ios.gif?raw=true)
 
 #### MacOS
-![DemoMacOS](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_macos.png)
+![DemoMacOS](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_macos.png?raw=true)
 
 #### Linux
-![DemoLinux](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_linux.gif)
+![DemoLinux](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_linux.gif?raw=true)
 
 #### Windows
-![DemoWindows](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_windows.gif)
+![DemoWindows](https://github.com/miguelpruivo/flutter_file_picker/blob/master/example/screenshots/example_windows.gif?raw=true)
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

The demo GIFs on pub.dev were not displayed on pub.dev. See #1513 

## How I fixed it?

I copied the image address from GitHub:

![image](https://github.com/miguelpruivo/flutter_file_picker/assets/24459435/9ae0645f-225c-47f4-9dc8-d275e1bbbb7a)

## Demo

https://github.com/miguelpruivo/flutter_file_picker/assets/24459435/c15acbb1-bbc0-4b41-b989-de608293daea

Tested it by replacing the new URLs in Chrome Dev Tools.

Closes #1513 
