### PR TITLE
Remove references to v1 embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.4
+### Android
+Removes references to Flutter v1 android embedding classes.
+
 ## 8.0.3
 ### Web
 Fixes a TypeError with `pickFiles()` when using the HTML renderer.

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -23,7 +23,6 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry;
 
 /**
  * FilePickerPlugin
@@ -115,29 +114,6 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
     private static boolean isMultipleSelection = false;
     private static boolean withData = false;
     private static int compressionQuality;
-
-    /**
-     * Plugin registration.
-     */
-    public static void registerWith(final io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-
-        if (registrar.activity() == null) {
-            // If a background flutter view tries to register the plugin, there will be no activity from the registrar,
-            // we stop the registering process immediately because the ImagePicker requires an activity.
-            return;
-        }
-
-        final Activity activity = registrar.activity();
-        Application application = null;
-        if (registrar.context() != null) {
-            application = (Application) (registrar.context().getApplicationContext());
-        }
-
-        final FilePickerPlugin plugin = new FilePickerPlugin();
-        plugin.setup(registrar.messenger(), application, activity, registrar, null);
-
-    }
-
 
     @SuppressWarnings("unchecked")
     @Override
@@ -258,7 +234,6 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
             final BinaryMessenger messenger,
             final Application application,
             final Activity activity,
-            final PluginRegistry.Registrar registrar,
             final ActivityPluginBinding activityBinding) {
 
         this.activity = activity;
@@ -278,18 +253,11 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
             }
         });
         this.observer = new LifeCycleObserver(activity);
-        if (registrar != null) {
-            // V1 embedding setup for activity listeners.
-            application.registerActivityLifecycleCallbacks(this.observer);
-            registrar.addActivityResultListener(this.delegate);
-            registrar.addRequestPermissionsResultListener(this.delegate);
-        } else {
-            // V2 embedding setup for activity listeners.
-            activityBinding.addActivityResultListener(this.delegate);
-            activityBinding.addRequestPermissionsResultListener(this.delegate);
-            this.lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
-            this.lifecycle.addObserver(this.observer);
-        }
+        // V2 embedding setup for activity listeners.
+        activityBinding.addActivityResultListener(this.delegate);
+        activityBinding.addRequestPermissionsResultListener(this.delegate);
+        this.lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
+        this.lifecycle.addObserver(this.observer);
     }
 
     private void tearDown() {
@@ -325,7 +293,6 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
                 this.pluginBinding.getBinaryMessenger(),
                 (Application) this.pluginBinding.getApplicationContext(),
                 this.activityBinding.getActivity(),
-                null,
                 this.activityBinding);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.3
+version: 8.0.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes https://github.com/miguelpruivo/flutter_file_picker/issues/1526.

Tested by building the `flutter_file_picker` example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 