### PR TITLE
Fix 1357

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.4
+### iOS
+- Fixes the bug [#1357](https://github.com/miguelpruivo/flutter_file_picker/issues/1357) that File Picker sometimes crashes when you swipe the modal down and call it again
+
 ## 8.1.3
 ### Android
 - Fixes a null object reference error [#1604](https://github.com/miguelpruivo/flutter_file_picker/issues/1604)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.1.3
+version: 8.1.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fix https://github.com/miguelpruivo/flutter_file_picker/issues/1357
Added `CustomDocumentPickerViewController`, a subclass of `UIDocumentPickerViewController` that overrides the `viewDidDisappear` method, making sure that `documentPickerWasCancelled` is called when no file is selected, even when the bottom sheet is suddenly swiped down.
In `documentPickerWasCancelled` added additional checks, but the root cause is that `documentPickerWasCancelled` was not called before.