### PR TITLE
Fix: Bump min Android SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.6
+### Android
+Updates the minimum SDK version to 21, to match the current Flutter minimum Android SDK version.
+
 ## 8.0.5
 ### Web
 Release picked file data in memory to avoid memory leak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.0.6
 ### Android
-Updates the minimum SDK version to 21, to match the current Flutter minimum Android SDK version.
+Updates the minimum Android SDK version to 21, to match the current Flutter minimum Android SDK version. Fixes [#1522](https://github.com/miguelpruivo/flutter_file_picker/issues/1522), [#1528](https://github.com/miguelpruivo/flutter_file_picker/issues/1528), and [#1531](https://github.com/miguelpruivo/flutter_file_picker/issues/1531). Thanks @navaronbracke.
 
 ## 8.0.5
 ### Web

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,10 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdk 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     lintOptions {
         disable 'InvalidPackage'
@@ -23,8 +23,8 @@ android {
 
     defaultConfig {
         applicationId "com.mr.flutter.plugin.filepicker.example"
-        minSdkVersion flutter.minSdkVersion
-        targetSdk 33
+        minSdk flutter.minSdkVersion
+        targetSdk 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   ffi: ^2.0.1
   path: ^1.8.2
-  win32: ^5.1.1
+  win32: ^5.5.1
   cross_file: ^0.3.3+7
   web: ^0.5.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.5
+version: 8.0.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR updates the minimum Android SDK version to 21, to align with the current minimum on Flutter 3.22.

It also updates the compile & target SDK versions to 34 and fixes a versioning issue for win32.

In a follow-up PR, I will also migrate the plugin to Gradle 8.

Fix was tested by compiling and running the example app on an Android 14 device.

Fixes #1522
Fixes #1528 
Fixes https://github.com/miguelpruivo/flutter_file_picker/issues/1531