### PR TITLE
Bump `package:web` to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.1.0
+### General
+- Updates the minimum Flutter version to 3.22.0, to support Dart 3.4.
+
+### Web
+- Updates the `package:web` dependency to 1.0.0.
+
 ## 8.0.7
 ### General
 - Fixes an issue relating to incorrect registration of platform-specific implementations. [#1555](https://github.com/miguelpruivo/flutter_file_picker/issues/1555).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Web
 - Updates the `package:web` dependency to 1.0.0.
+- Removes a redundant `FilePickerWeb.platform` static field. Use `FilePicker.platform` instead.
 
 ## 8.0.7
 ### General

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -12,14 +12,12 @@ class FilePickerWeb extends FilePicker {
 
   final int _readStreamChunkSize = 1000 * 1000; // 1 MB
 
-  static final FilePickerWeb platform = FilePickerWeb._();
-
   FilePickerWeb._() {
     _target = _ensureInitialized(_kFilePickerInputsDomId);
   }
 
   static void registerWith(Registrar registrar) {
-    FilePicker.platform = platform;
+    FilePicker.platform = FilePickerWeb._();
   }
 
   /// Initializes a DOM container where we can host input elements.
@@ -218,16 +216,15 @@ class FilePickerWeb extends FilePicker {
       if (readerResult == null) {
         continue;
       }
-      // TODO: use `isA<JSArrayBuffer>()` when switching to Dart 3.4
+
       // Handle the ArrayBuffer type. This maps to a `ByteBuffer` in Dart.
-      if (readerResult.instanceOfString('ArrayBuffer')) {
+      if (readerResult.isA<JSArrayBuffer>()) {
         yield (readerResult as JSArrayBuffer).toDart.asUint8List();
         start += _readStreamChunkSize;
         continue;
       }
-      // TODO: use `isA<JSArray>()` when switching to Dart 3.4
-      // Handle the Array type.
-      if (readerResult.instanceOfString('Array')) {
+
+      if (readerResult.isA<JSArray>()) {
         // Assume this is a List<int>.
         yield (readerResult as JSArray).toDart.cast<int>();
         start += _readStreamChunkSize;

--- a/lib/src/windows/file_picker_windows_ffi_types.dart
+++ b/lib/src/windows/file_picker_windows_ffi_types.dart
@@ -71,7 +71,7 @@ typedef GetSaveFileNameWDart = int Function(
 ///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfoa
-class BROWSEINFOA extends Struct {
+final class BROWSEINFOA extends Struct {
   /// A handle to the owner window for the dialog box.
   external Pointer hwndOwner;
 
@@ -112,7 +112,7 @@ class BROWSEINFOA extends Struct {
 ///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamew
-class OPENFILENAMEW extends Struct {
+final class OPENFILENAMEW extends Struct {
   /// The length, in bytes, of the structure. Use sizeof [OPENFILENAMEW] for this parameter.
   @Uint32()
   external int lStructSize;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.0.7
+version: 8.1.0
 
 dependencies:
   flutter:
@@ -17,16 +17,16 @@ dependencies:
   path: ^1.8.2
   win32: ^5.5.1
   cross_file: ^0.3.3+7
-  web: ^0.5.1
+  web: ^1.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0
   flutter_test:
     sdk: flutter
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 flutter:
   plugin:

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -1,4 +1,5 @@
 @TestOn('mac-os')
+library;
 
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/file_picker_macos.dart';

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -1,4 +1,6 @@
 @TestOn('linux || mac-os')
+library;
+
 import 'dart:io';
 import 'package:file_picker/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -1,4 +1,5 @@
 @TestOn('windows')
+library;
 
 import 'dart:ffi';
 

--- a/test/linux/dialog_handler_test.dart
+++ b/test/linux/dialog_handler_test.dart
@@ -1,4 +1,5 @@
 @TestOn('linux')
+library;
 
 import 'package:file_picker/src/linux/dialog_handler.dart';
 import 'package:file_picker/src/linux/kdialog_handler.dart';

--- a/test/linux/kdialog_handler_test.dart
+++ b/test/linux/kdialog_handler_test.dart
@@ -1,4 +1,6 @@
 @TestOn('linux')
+library;
+
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/linux/kdialog_handler.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/linux/qarma_and_zenity_handler_test.dart
+++ b/test/linux/qarma_and_zenity_handler_test.dart
@@ -1,4 +1,6 @@
 @TestOn('linux')
+library;
+
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/linux/qarma_and_zenity_handler.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
This PR bumps the `web` dependency to 1.0.0

It also bumps the minimum Flutter version to 3.22.0, which ships with Dart 3.4.0
That Dart version is the minimum needed for the new package:web version.

It also addresses the following points:
- the structs in the ffi types for windows should be marked base, sealed or final, due to a Dart language change. I made them final.
- the web version of this plugin had two open TODO's that needed Dart 3.4, these have been fixed.
- the web version also had a redundant static variable `platform`, that wasn't used except for setting up the web platform implementation. This has been removed, as users should not rely on `FilePickerWeb.platform`, but rather on `FilePicker.platform`

Fixes #1571 
Closes https://github.com/miguelpruivo/flutter_file_picker/pull/1575
Closes https://github.com/miguelpruivo/flutter_file_picker/pull/1566

For clarification, this is the corporate account of @navaronbracke I'm currently away from my other machine but wanted to land this fix ASAP.