### PR TITLE
Fix web example on Flutter 3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.1
+### Web
+- Migrate the web example to use the new web bootstrapping, introduced in Flutter 3.22.
+
 ## 8.1.0
 ### General
 - Updates the minimum Flutter version to 3.22.0, to support Dart 3.4.

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -16,16 +16,8 @@
 
   <title>example</title>
   <link rel="manifest" href="manifest.json">
-  <script src="flutter.js"></script>
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    {{flutter_build_config}}
-    _flutter.loader.load();
-  </script>
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.1.0
+version: 8.1.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR fixes the example for the web, that now needs a different method of bootstrapping in Flutter 3.22

I had forgotten to include this commit in my last PR, after testing the web example.
 
We still hit the CanvasKit undefined module error when running the example a second time, but this was reported upstream in flutter/flutter.