### PR TITLE
Remove default cases in switches and fix CI issues

### DIFF
--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -136,8 +136,6 @@ class FilePickerMacOS extends FilePicker {
         return '"avi", "flv", "m4v", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.video:
         return '"avi", "flv", "mkv", "mov", "mp4", "m4v", "mpeg", "webm", "wmv"';
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -65,8 +65,6 @@ class KDialogHandler implements DialogHandler {
         return 'Media File (${DialogHandler.toCaseInsensitive("*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png")})';
       case FileType.video:
         return 'Video File (${DialogHandler.toCaseInsensitive("*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv")})';
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/linux/qarma_and_zenity_handler.dart
+++ b/lib/src/linux/qarma_and_zenity_handler.dart
@@ -57,8 +57,6 @@ class QarmaAndZenityHandler implements DialogHandler {
         return "Media Files | ${DialogHandler.toCaseInsensitive('*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png')}";
       case FileType.video:
         return "Video Files | ${DialogHandler.toCaseInsensitive('*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv')}";
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -5,8 +5,8 @@ import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:file_picker/src/utils.dart';
 import 'package:file_picker/src/exceptions.dart';
+import 'package:file_picker/src/utils.dart';
 import 'package:file_picker/src/windows/file_picker_windows_ffi_types.dart';
 import 'package:path/path.dart';
 import 'package:win32/win32.dart';
@@ -227,8 +227,6 @@ class FilePickerWindows extends FilePicker {
         return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
       case FileType.video:
         return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
-      default:
-        throw Exception('unknown file type');
     }
   }
 


### PR DESCRIPTION
This PR addresses the following changes to improve code quality and maintainability in the `flutter_file_picker` project:

### 1. Remove Default Cases in Switches
- Followed the [no_default_cases](https://dart.dev/tools/linter-rules/no_default_cases) lint rule to ensure exhaustive handling of cases in `switch` statements.
- This prevents unintended behavior when new enum values are added in the future and ensures clarity in the code.

### 2. Fix CI Failures
- Addressed CI issues as per the logs in the GitHub Actions run [#12503559958](https://github.com/miguelpruivo/flutter_file_picker/actions/runs/12503559958/job/34884065614)




