### PR TITLE
feat-add-mime-type

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -290,7 +290,7 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @RequiresApi(api = Build.VERSION_CODES.KITKAT)
-    public void saveFile(String fileName, String type, String initialDirectory, String[] allowedExtensions, byte[] bytes, MethodChannel.Result result) {
+    public void saveFile(String fileName, String type, String mimeType, String initialDirectory, String[] allowedExtensions, byte[] bytes, MethodChannel.Result result) {
         if (!this.setPendingMethodCallAndResult(result)) {
             finishWithAlreadyActiveError(result);
             return;
@@ -301,7 +301,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
             intent.putExtra(Intent.EXTRA_TITLE, fileName);
         }
         this.bytes = bytes;
-        if (type != null && !"dir".equals(type) && type.split(",").length == 1) {
+        if (mimeType != null) {
+            intent.setType(mimeType);
+        } else if (type != null && !"dir".equals(type) && type.split(",").length == 1) {
             intent.setType(type);
         } else {
             intent.setType("*/*");

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -135,10 +135,11 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
         if (call.method != null && call.method.equals("save")) {
             String fileName = (String) arguments.get("fileName");
             String type = resolveType((String) arguments.get("fileType"));
+            String mimeType = (String) arguments.get("mimeType");
             String initialDirectory = (String) arguments.get("initialDirectory");
             String[] allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
             byte[] bytes = (byte[]) arguments.get("bytes");
-            this.delegate.saveFile(fileName, type, initialDirectory, allowedExtensions, bytes,result);
+            this.delegate.saveFile(fileName, type, mimeType, initialDirectory, allowedExtensions, bytes,result);
             return;
         }
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -162,6 +162,9 @@ abstract class FilePicker extends PlatformInterface {
   /// stay in front of the Flutter window until it is closed (like a modal
   /// window). This parameter works only on Windows desktop.
   ///
+  /// [mimeType] can be optionally set to provide a mime type for the file.
+  /// It only work for iOS and Android.
+  ///
   /// Returns `null` if aborted. Returns a [Future<String?>] which resolves to
   /// the absolute path of the selected file, if the user selected a file.
   Future<String?> saveFile({
@@ -172,6 +175,7 @@ abstract class FilePicker extends PlatformInterface {
     List<String>? allowedExtensions,
     Uint8List? bytes,
     bool lockParentWindow = false,
+    String? mimeType,
   }) async =>
       throw UnimplementedError('saveFile() has not been implemented.');
 }

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -137,17 +137,20 @@ class FilePickerIO extends FilePicker {
   }
 
   @override
-  Future<String?> saveFile(
-      {String? dialogTitle,
-      String? fileName,
-      String? initialDirectory,
-      FileType type = FileType.any,
-      List<String>? allowedExtensions,
-      Uint8List? bytes,
-      bool lockParentWindow = false}) {
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+    String? mimeType,
+  }) {
     if (Platform.isIOS || Platform.isAndroid) {
       return _channel.invokeMethod("save", {
         "fileName": fileName,
+        "mimeType": mimeType,
         "fileType": type.name,
         "initialDirectory": initialDirectory,
         "allowedExtensions": allowedExtensions,
@@ -162,6 +165,7 @@ class FilePickerIO extends FilePicker {
       allowedExtensions: allowedExtensions,
       bytes: bytes,
       lockParentWindow: lockParentWindow,
+      mimeType: mimeType,
     );
   }
 }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -89,6 +89,7 @@ class FilePickerMacOS extends FilePicker {
     List<String>? allowedExtensions,
     Uint8List? bytes,
     bool lockParentWindow = false,
+    String? mimeType,
   }) async {
     final String executable = await isExecutableOnPath('osascript');
     final String fileFilter = fileTypeToFileFilter(

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -87,6 +87,7 @@ class FilePickerLinux extends FilePicker {
     List<String>? allowedExtensions,
     Uint8List? bytes,
     bool lockParentWindow = false,
+    String? mimeType,
   }) async {
     final executable = await _getPathToExecutable();
     final dialogHandler = DialogHandler(executable);

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -172,6 +172,7 @@ class FilePickerWindows extends FilePicker {
     List<String>? allowedExtensions,
     Uint8List? bytes,
     bool lockParentWindow = false,
+    String? mimeType,
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(


### PR DESCRIPTION
Light temporary solution until better one for https://github.com/miguelpruivo/flutter_file_picker/issues/1669

The `savefile` method can be more simple, as a dev, we want to save a file by showing the native prompt. In theory, we don't have to provide `allowedExtensions` and `type` properties but we need a `mimeType` which is missing.