### PR TITLE
chore: fix unreachable switch default

### DIFF
--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -136,8 +136,6 @@ class FilePickerMacOS extends FilePicker {
         return '"avi", "flv", "m4v", "mkv", "mov", "mp4", "mpeg", "webm", "wmv", "bmp", "gif", "jpeg", "jpg", "png"';
       case FileType.video:
         return '"avi", "flv", "mkv", "mov", "mp4", "m4v", "mpeg", "webm", "wmv"';
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/linux/kdialog_handler.dart
+++ b/lib/src/linux/kdialog_handler.dart
@@ -65,8 +65,6 @@ class KDialogHandler implements DialogHandler {
         return 'Media File (${DialogHandler.toCaseInsensitive("*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png")})';
       case FileType.video:
         return 'Video File (${DialogHandler.toCaseInsensitive("*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv")})';
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/linux/qarma_and_zenity_handler.dart
+++ b/lib/src/linux/qarma_and_zenity_handler.dart
@@ -57,8 +57,6 @@ class QarmaAndZenityHandler implements DialogHandler {
         return "Media Files | ${DialogHandler.toCaseInsensitive('*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv *.bmp *.gif *.jpeg *.jpg *.png')}";
       case FileType.video:
         return "Video Files | ${DialogHandler.toCaseInsensitive('*.avi *.flv *.mkv *.mov *.mp4 *.mpeg *.webm *.wmv')}";
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -227,8 +227,6 @@ class FilePickerWindows extends FilePicker {
         return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
       case FileType.video:
         return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
-      default:
-        throw Exception('unknown file type');
     }
   }
 

--- a/test/linux/kdialog_handler_test.dart
+++ b/test/linux/kdialog_handler_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(
         dialogHandler.fileTypeToFileFilter(FileType.audio, null),
         equals(
-            'Audio File (*.[aA][aA][cC] *.[mM][iI][dD][iI] *.[mM][pP]3 *.[oO][gG][gG] *.[wW][aA][vV])'),
+            'Audio File (*.[aA][aA][cC] *.[mM][iI][dD][iI] *.[mM][pP]3 *.[oO][gG][gG] *.[wW][aA][vV] *.[mM]4[aA])'),
       );
 
       expect(

--- a/test/linux/qarma_and_zenity_handler_test.dart
+++ b/test/linux/qarma_and_zenity_handler_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(
         dialogHandler.fileTypeToFileFilter(FileType.audio, null),
         equals(
-            'Audio Files | *.[aA][aA][cC] *.[mM][iI][dD][iI] *.[mM][pP]3 *.[oO][gG][gG] *.[wW][aA][vV]'),
+            'Audio Files | *.[aA][aA][cC] *.[mM][iI][dD][iI] *.[mM][pP]3 *.[oO][gG][gG] *.[wW][aA][vV] *.[mM]4[aA]'),
       );
 
       expect(


### PR DESCRIPTION
This PR fixes some failing checks due to https://dart.dev/tools/diagnostic-messages?utm_source=dartdev&utm_medium=redir&utm_id=diagcode&utm_content=unreachable_switch_default#unreachable_switch_default

The one in MacOS is fixed by #1690 
This unblocks landing #1690 