### PR TITLE
Add Breaking Change for macOS Entitlement Requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 - Reimplement macOS file picker using method channels (fixes [#1492](https://github.com/miguelpruivo/flutter_file_picker/issues/1492), [#1445](https://github.com/miguelpruivo/flutter_file_picker/issues/1445), [#1674](https://github.com/miguelpruivo/flutter_file_picker/issues/1674), [#1685](https://github.com/miguelpruivo/flutter_file_picker/issues/1685))
 - **BREAKING CHANGE:** `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
 
-
 ## 8.1.7
 ### iOS 
 - Fix Image Picker to Handle Partial Failures Gracefully [#1554](https://github.com/miguelpruivo/flutter_file_picker/issues/1554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 ## 8.2.0
 ### Desktop (macOS)
 - Reimplement macOS file picker using method channels (fixes [#1492](https://github.com/miguelpruivo/flutter_file_picker/issues/1492), [#1445](https://github.com/miguelpruivo/flutter_file_picker/issues/1445), [#1674](https://github.com/miguelpruivo/flutter_file_picker/issues/1674), [#1685](https://github.com/miguelpruivo/flutter_file_picker/issues/1685))
-- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [WIKI](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
+- **BREAKING CHANGE:** `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
 
 
 ## 8.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ## 8.3.0
 ### Desktop (macOS) && iOS
 - Adds support for Swift Package Manager for compatibility with new projects [#1582](https://github.com/miguelpruivo/flutter_file_picker/issues/1582)
+### macOS
+- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [#1706](https://github.com/miguelpruivo/flutter_file_picker/issues/1706)
 
 ## 8.2.0
 ### Desktop (macOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,12 @@
 ## 8.3.0
 ### Desktop (macOS) && iOS
 - Adds support for Swift Package Manager for compatibility with new projects [#1582](https://github.com/miguelpruivo/flutter_file_picker/issues/1582)
-### macOS
-- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [WIKI](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
 
 ## 8.2.0
 ### Desktop (macOS)
 - Reimplement macOS file picker using method channels (fixes [#1492](https://github.com/miguelpruivo/flutter_file_picker/issues/1492), [#1445](https://github.com/miguelpruivo/flutter_file_picker/issues/1445), [#1674](https://github.com/miguelpruivo/flutter_file_picker/issues/1674), [#1685](https://github.com/miguelpruivo/flutter_file_picker/issues/1685))
+- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [WIKI](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
+
 
 ## 8.1.7
 ### iOS 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Desktop (macOS) && iOS
 - Adds support for Swift Package Manager for compatibility with new projects [#1582](https://github.com/miguelpruivo/flutter_file_picker/issues/1582)
 ### macOS
-- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [#1706](https://github.com/miguelpruivo/flutter_file_picker/issues/1706)
+- BREAKING CHANGE: `pickFiles()` now requires the `com.apple.security.files.user-selected.read-only` entitlement on macOS. Without this entitlement, the file picker will not open, and the method will return `null`. [WIKI](https://github.com/miguelpruivo/flutter_file_picker/wiki/Setup#macos)
 
 ## 8.2.0
 ### Desktop (macOS)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.3.6
+version: 8.3.5
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.3.5
+version: 8.3.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Pull Request: Add Breaking Change for macOS Entitlement Requirement  

### Description  
This pull request introduces a breaking change for macOS users of the `flutter_file_picker` package.  

### Breaking Change  
Starting from version **8.3.0**, the `pickFiles()` method now requires the entitlement `com.apple.security.files.user-selected.read-only` on macOS. If this entitlement is not present, the method will return `null` and the file picker will not open, potentially leading to confusion among developers upgrading from previous versions where this entitlement was not required.  

### Justification  
- This change was introduced silently in version **8.3.0** without clear documentation, which can cause issues for developers who may not be aware of the requirement.
- To ensure a smooth transition and proper functionality of the file picker on macOS, it is crucial to document this change as breaking in the changelog and update the API documentation accordingly.

### Changes Made  
- Updated the `CHANGELOG.md` to include the breaking change notice.
- Recommended that users add the entitlement to both `DebugProfile.entitlements` and `Release.entitlements` to restore the expected functionality.

### Related Issue  
- Reference to issue: #1706

### Additional Notes  
- Future updates should include a warning or error message when the entitlement is missing to improve user experience.
