### PR TITLE
Windows fix: already initialized COM theading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 8.3.7
-### Desktop (Windows)
-- Fixes the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer windows doesn't popup. [#1708](https://github.com/miguelpruivo/flutter_file_picker/pull/1708)
-
 ## 8.3.6
 ### General
 - Added compatibility with Flutter 3.29. [@vicajilau](https://github.com/vicajilau).
+
+### Desktop (Windows)
+- Fixes the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer windows doesn't popup. [#1708](https://github.com/miguelpruivo/flutter_file_picker/pull/1708)
 
 ## 8.3.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.3.6
+### Desktop (Windows)
+-- Fixes the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer windows doesn't popup. [#1708](https://github.com/miguelpruivo/flutter_file_picker/pull/1708)
+
 ## 8.3.5
 ### Android
 - Fixes allowCompression not working on Android. [1633](https://github.com/miguelpruivo/flutter_file_picker/issues/1633)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.3.6
 ### Desktop (Windows)
--- Fixes the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer windows doesn't popup. [#1708](https://github.com/miguelpruivo/flutter_file_picker/pull/1708)
+- Fixes the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer windows doesn't popup. [#1708](https://github.com/miguelpruivo/flutter_file_picker/pull/1708)
 
 ## 8.3.5
 ### Android

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -100,7 +100,12 @@ class FilePickerWindows extends FilePicker {
       COINIT.COINIT_APARTMENTTHREADED | COINIT.COINIT_DISABLE_OLE1DDE,
     );
 
-    if (!SUCCEEDED(hr)) throw WindowsException(hr);
+    // Ignore the error if COM is already initialized.
+    // If this is the case, CoInitializeEx will return
+    // RPC_E_CHANGED_MODE (0x80010106 = -2147417850).
+    if (!SUCCEEDED(hr) && hr != -2147417850) {
+      throw WindowsException(hr);
+    }
 
     final fileDialog = FileOpenDialog.createInstance();
 

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -102,8 +102,8 @@ class FilePickerWindows extends FilePicker {
 
     // Ignore the error if COM is already initialized.
     // If this is the case, CoInitializeEx will return
-    // RPC_E_CHANGED_MODE (0x80010106 = -2147417850).
-    if (!SUCCEEDED(hr) && hr != -2147417850) {
+    // RPC_E_CHANGED_MODE.
+    if (!SUCCEEDED(hr) && hr != RPC_E_CHANGED_MODE) {
       throw WindowsException(hr);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.3.7
+version: 8.3.6
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.3.6
+version: 8.3.7
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 8.3.5
+version: 8.3.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi,

I am the author of [flutter_soloud](https://github.com/alnitak/flutter_soloud) plugin. Has been reported that when the audio player has already been initialized, an error occurs when trying to use `getDirectoryPath` in this [issue](https://github.com/alnitak/flutter_soloud/issues/180) with this error:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Error 0x80010106: Cannot change thread mode after it is set.
```

This should fix the issue under Windows that could be raised when another plugin uses `CoInitializeEx` and the File Explorer window doesn't pop up.

Digging around and searching on the web, I found that it's safe to use an already created COM and this PR checks this case, but I'm not familiar with Windows, so it might be worth doing a bit more research.

I can provide a simple project using *flutter_soloud* together *flutteR_file_picker* if you want.
