### PR TITLE
Flutter 3.29 Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.3.6
 ### General
-- Updates to flutter 3.29. [@vicajilau](https://github.com/vicajilau).
+- Added compatibility with Flutter 3.29. [@vicajilau](https://github.com/vicajilau).
 
 ## 8.3.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.3.6
+### General
+- Updates to flutter 3.29. [@vicajilau](https://github.com/vicajilau).
+
 ## 8.3.5
 ### Android
 - Fixes allowCompression not working on Android. [1633](https://github.com/miguelpruivo/flutter_file_picker/issues/1633)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,6 @@ linter:
     - comment_references
     - slash_for_doc_comments
     - use_key_in_widget_constructors
-    - unsafe_html
     - unnecessary_statements
     - throw_in_finally
     - always_use_package_imports

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -5,6 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+.cxx/
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -66,6 +66,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -77,6 +77,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
- `unsafe_html` was removed in Dart 3.7.0
- `enableGPUValidationMode` in macOS and iOS.
- Added `.cxx` folder to `.gitignore`.