### PR TITLE
fix: Run `getDirectoryPath` in its own isolate to avoid COM initialization issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.1
+### Windows
+- Move `getDirectoryPath()` to its own isolate to avoid COM initialization conflicts with other plugins [#1713](https://github.com/miguelpruivo/flutter_file_picker/pull/1713) [@tguerin](https://github.com/tguerin). 
+
 ## 9.0.0
 ### Web
 - **BREAKING CHANGE:** `pickFiles()` now loads files as blobs. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-pickfiles)

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -106,7 +106,7 @@ class FilePickerWindows extends FilePicker {
   String? _getDirectoryPathIsolate(Map<String, Object?> args) {
     String? dialogTitle = args['dialogTitle'] as String?;
     String? initialDirectory = args['initialDirectory'] as String?;
-    bool? lockParentWindow = args['lockParentWindow'] as bool? ?? false;
+    bool lockParentWindow = args['lockParentWindow'] as bool? ?? false;
 
     int hr = CoInitializeEx(
       nullptr,

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -99,12 +99,14 @@ class FilePickerWindows extends FilePicker {
     return compute(_getDirectoryPathIsolate, {
       'dialogTitle': dialogTitle,
       'initialDirectory': initialDirectory,
+      'lockParentWindow': lockParentWindow,
     });
   }
 
-  String? _getDirectoryPathIsolate(Map<String, String?> args) {
-    String? dialogTitle = args['dialogTitle'];
-    String? initialDirectory = args['initialDirectory'];
+  String? _getDirectoryPathIsolate(Map<String, Object?> args) {
+    String? dialogTitle = args['dialogTitle'] as String?;
+    String? initialDirectory = args['initialDirectory'] as String?;
+    bool? lockParentWindow = args['lockParentWindow'] as bool? ?? false;
 
     int hr = CoInitializeEx(
       nullptr,
@@ -162,7 +164,8 @@ class FilePickerWindows extends FilePicker {
         }
       }
 
-      hr = fileDialog.show(NULL);
+      final hwndOwner = lockParentWindow ? GetForegroundWindow() : NULL;
+      hr = fileDialog.show(hwndOwner);
       if (!SUCCEEDED(hr)) return null;
 
       final ppv = calloc<Pointer<COMObject>>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.0.0
+version: 9.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
I’m the original reporter of https://github.com/alnitak/flutter_soloud/issues/180. Even with the previous fix, we continued seeing the following error in production: 

> comdlg32.dll exception code 0xc000005

After further investigation, I discovered that the issue was related to COM initialization on the main thread. If COM is initialized on the main thread, we should **not** call `CoUninitialize`, as it may affect other components relying on COM.

To prevent this issue, the best approach is to run `getDirectoryPath` in its own isolate. This allows us to safely initialize and release COM within the isolate without impacting the main thread or other parts of the application.

Additionally, I added `finally` blocks to properly release allocated memory and ensure cleanup happens reliably.

This should resolve the issue while maintaining stability for other COM-dependent components.