### PR TITLE
fix: file streams not getting closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.2
+### Android
+- Fix: File streams not getting closed.
+
 ## 9.0.1
 ### Windows
 - Move `getDirectoryPath()` to its own isolate to avoid COM initialization conflicts with other plugins [#1713](https://github.com/miguelpruivo/flutter_file_picker/pull/1713) [@tguerin](https://github.com/tguerin). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.0.2
 ### Android
-- Fix: File streams not getting closed.
+- Fixes: File streams not getting closed.
 
 ## 9.0.1
 ### Windows

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -288,6 +288,7 @@ public class FileUtils {
 
         Log.i(TAG, "Caching from URI: " + uri.toString());
         FileOutputStream fos = null;
+        InputStream in = null;
         final FileInfo.Builder fileInfo = new FileInfo.Builder();
         final String fileName = FileUtils.getFileName(uri, context);
         final String path = context.getCacheDir().getAbsolutePath() + "/file_picker/"+System.currentTimeMillis() +"/"+ (fileName != null ? fileName : "unamed");
@@ -295,12 +296,12 @@ public class FileUtils {
         final File file = new File(path);
 
         if(!file.exists()) {
-            file.getParentFile().mkdirs();
             try {
+                file.getParentFile().mkdirs();
                 fos = new FileOutputStream(path);
                 try {
                     final BufferedOutputStream out = new BufferedOutputStream(fos);
-                    final InputStream in = context.getContentResolver().openInputStream(uri);
+                    in = context.getContentResolver().openInputStream(uri);
 
                     final byte[] buffer = new byte[8192];
                     int len = 0;
@@ -314,14 +315,25 @@ public class FileUtils {
                     fos.getFD().sync();
                 }
             } catch (final Exception e) {
-                try {
-                    fos.close();
-                } catch (final IOException | NullPointerException ex) {
-                    Log.e(TAG, "Failed to close file streams: " + e.getMessage(), null);
-                    return null;
-                }
                 Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
                 return null;
+            } finally {
+                if (fos != null) {
+                    try {
+                        fos.close();
+                    } catch (final IOException ex) {
+                        Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
+                        return null;
+                    }
+                }
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (final IOException ex) {
+                        Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
+                        return null;
+                    }
+                }
             }
         }
 

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -318,12 +318,13 @@ public class FileUtils {
                 Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
                 return null;
             } finally {
+                boolean closeFailed = false;
                 if (fos != null) {
                     try {
                         fos.close();
                     } catch (final IOException ex) {
                         Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
-                        return null;
+                        closeFailed = true;
                     }
                 }
                 if (in != null) {
@@ -331,8 +332,11 @@ public class FileUtils {
                         in.close();
                     } catch (final IOException ex) {
                         Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
-                        return null;
+                        closeFailed = true;
                     }
+                }
+                if (closeFailed) {
+                    return null;
                 }
             }
         }

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FileUtils.java
@@ -318,13 +318,11 @@ public class FileUtils {
                 Log.e(TAG, "Failed to retrieve path: " + e.getMessage(), null);
                 return null;
             } finally {
-                boolean closeFailed = false;
                 if (fos != null) {
                     try {
                         fos.close();
                     } catch (final IOException ex) {
                         Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
-                        closeFailed = true;
                     }
                 }
                 if (in != null) {
@@ -332,11 +330,7 @@ public class FileUtils {
                         in.close();
                     } catch (final IOException ex) {
                         Log.e(TAG, "Failed to close file streams: " + ex.getMessage(), null);
-                        closeFailed = true;
                     }
-                }
-                if (closeFailed) {
-                    return null;
                 }
             }
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.0.1
+version: 9.0.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR fixes file streams not getting closed.

The issue resulted in the android app process being killed if a file was picked from an USB device, then the device was ejected.