### PR TITLE
Implement saveFile for Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.0
+### Web
+- `saveFile()` now downloads the file. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-savefile)
+
 ## 9.0.0
 ### Web
 - **BREAKING CHANGE:** `pickFiles()` now loads files as blobs. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-pickfiles)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.1.0
 ### Web
-- Added an implementation for `saveFile()` on the web. See the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-savefile)
+- Added an implementation for `saveFile()` on the web.
 
 ## 9.0.2
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.1.0
 ### Web
-- `saveFile()` now downloads the file. See the note in the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-savefile)
+- Added an implementation for `saveFile()` on the web. See the updated [wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api#-savefile)
 
 ## 9.0.1
 ### Windows

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 ![fluter_file_picker](https://user-images.githubusercontent.com/27860743/64064695-b88dab00-cbfc-11e9-814f-30921b66035f.png)
 <p align="center">
- <a href="https://pub.dartlang.org/packages/file_picker">
+  <a href="https://pub.dartlang.org/packages/file_picker">
     <img alt="File Picker" src="https://img.shields.io/pub/v/file_picker.svg">
   </a>
- <a href="https://github.com/Solido/awesome-flutter">
+  <a href="https://github.com/Solido/awesome-flutter">
     <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square">
   </a>
- <a href="https://www.buymeacoffee.com/gQyz2MR">
+  <a href="https://www.buymeacoffee.com/gQyz2MR">
     <img alt="Buy me a coffee" src="https://img.shields.io/badge/Donate-Buy%20Me%20A%20Coffee-yellow.svg">
   </a>
-  <a href="https://github.com/miguelpruivo/flutter_file_picker/issues"><img src="https://img.shields.io/github/issues/miguelpruivo/flutter_file_picker">
+  <a href="https://github.com/miguelpruivo/flutter_file_picker/issues">
+    <img src="https://img.shields.io/github/issues/miguelpruivo/flutter_file_picker" alt="GitHub issues badge">
   </a>
-  <img src="https://img.shields.io/github/license/miguelpruivo/flutter_file_picker">
+  <a href="https://github.com/miguelpruivo/flutter_file_picker?tab=MIT-1-ov-file">
+    <img src="https://img.shields.io/github/license/miguelpruivo/flutter_file_picker" alt="GitHub license badge">
+  </a>
   <a href="https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/main.yml">
     <img alt="CI pipeline status" src="https://github.com/miguelpruivo/flutter_file_picker/actions/workflows/main.yml/badge.svg">
   </a>

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ If you have any feature that you want to see in this package, please feel free t
 ## Compatibility Chart
 
 | API                   | Android            | iOS                | Linux              | macOS              | Windows            | Web                |
-| --------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+|-----------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
 | clearTemporaryFiles() | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                | :x:                | :x:                |
 | getDirectoryPath()    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | pickFiles()           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| saveFile()            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                |
+| saveFile()            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 See the [API section of the File Picker Wiki](https://github.com/miguelpruivo/flutter_file_picker/wiki/api) or the [official API reference on pub.dev](https://pub.dev/documentation/file_picker/latest/file_picker/FilePicker-class.html) for further details.
 

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -122,7 +122,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         fileName: _defaultFileNameController.text,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
-        bytes: _paths?.single.bytes,
       );
       setState(() {
         _saveAsFileName = fileName;

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -112,7 +112,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   }
 
   Future<void> _saveFile() async {
-    _resetState();
     try {
       String? fileName = await FilePicker.platform.saveFile(
         allowedExtensions: (_extension?.isNotEmpty ?? false)
@@ -123,6 +122,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         fileName: _defaultFileNameController.text,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
+        bytes: _paths?.single.bytes,
       );
       setState(() {
         _saveAsFileName = fileName;
@@ -133,6 +133,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     } catch (e) {
       _logException(e.toString());
     } finally {
+      _resetState();
       setState(() => _isLoading = false);
     }
   }

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -200,10 +200,6 @@ class FilePickerWeb extends FilePicker {
       throw ArgumentError(
         'The bytes are required when saving a file on the web.',
       );
-        'The bytes are required when saving a file on the web.',
-      );
-        'The bytes are required when saving a file on the web.',
-      );
     }
 
     if (fileName == null || fileName.isEmpty) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -224,7 +224,7 @@ class FilePickerWeb extends FilePicker {
 
     // Release the Blob URL to free up memory after the download
     URL.revokeObjectURL(url);
-    return null; // Cleans up the URL to release memory.
+    return null;
   }
 
   static String _fileType(FileType type, List<String>? allowedExtensions) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -214,7 +214,7 @@ class FilePickerWeb extends FilePicker {
 
     final url = URL.createObjectURL(blob);
 
-    // Create an anchor element for triggering the download
+    // Start a download by using a click event on an anchor element that contains the Blob.
     HTMLAnchorElement()
       ..href = url // Set the URL to download
       ..target = 'blank' // Open the file in a new tab (if supported)

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -204,7 +204,8 @@ class FilePickerWeb extends FilePicker {
 
     if (fileName == null || fileName.isEmpty) {
       throw ArgumentError(
-          'A file name is required when saving a file on the web.');
+          'A file name is required when saving a file on the web.',
+       );
     }
 
     if (p.extension(fileName).isEmpty) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -221,7 +221,7 @@ class FilePickerWeb extends FilePicker {
       ..download = fileName // Set the file name for the download
       ..click(); // Simulate a click to start the download
 
-    // Release the Blob URL to free up memory after the download
+    // Release the Blob URL after the download started.
     URL.revokeObjectURL(url);
     return null;
   }

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:path/path.dart' as p;
 import 'package:web/web.dart';
 
 class FilePickerWeb extends FilePicker {
@@ -183,6 +184,45 @@ class FilePickerWeb extends FilePicker {
     final List<PlatformFile>? files = await filesCompleter.future;
 
     return files == null ? null : FilePickerResult(files);
+  }
+
+  @override
+  Future<String?> saveFile({
+    String? dialogTitle,
+    String? fileName,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Uint8List? bytes,
+    bool lockParentWindow = false,
+  }) async {
+    if (bytes == null) {
+      throw ArgumentError(
+          'The "bytes" parameter is required for saveFile on web');
+    }
+
+    if (fileName == null || p.extension(fileName).isEmpty) {
+      throw ArgumentError(
+          'The "fileName" parameter is required and must include a valid file extension (e.g., ".txt", ".pdf") when using saveFile on web.');
+    }
+
+    // Open a save dialog for the user to select a file path
+    // Create a new Blob containing the bytes
+    final blob = Blob([bytes.toJS].toJS);
+
+    // Generate a URL for the Blob, allowing it to be downloaded
+    final url = URL.createObjectURL(blob);
+
+    // Create an anchor element for triggering the download
+    HTMLAnchorElement()
+      ..href = url // Set the URL to download
+      ..target = 'blank' // Open the file in a new tab (if supported)
+      ..download = fileName // Set the file name for the download
+      ..click(); // Simulate a click to start the download
+
+    // Release the Blob URL to free up memory after the download
+    URL.revokeObjectURL(url);
+    return null; // Cleans up the URL to release memory.
   }
 
   static String _fileType(FileType type, List<String>? allowedExtensions) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -202,9 +202,14 @@ class FilePickerWeb extends FilePicker {
       );
     }
 
-    if (fileName == null || p.extension(fileName).isEmpty) {
+    if (fileName == null || fileName.isEmpty) {
       throw ArgumentError(
-          'The "fileName" parameter is required and must include a valid file extension (e.g., ".txt", ".pdf") when using saveFile on web.');
+          'A file name is required when saving a file on the web.');
+    }
+
+    if (p.extension(fileName).isEmpty) {
+      throw ArgumentError(
+          'The file name should include a valid file extension.');
     }
 
     final blob = Blob([bytes.toJS].toJS);

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -200,7 +200,6 @@ class FilePickerWeb extends FilePicker {
       throw ArgumentError(
         'The bytes are required when saving a file on the web.',
       );
-          'The "bytes" parameter is required for saveFile on web');
     }
 
     if (fileName == null || p.extension(fileName).isEmpty) {
@@ -208,10 +207,7 @@ class FilePickerWeb extends FilePicker {
           'The "fileName" parameter is required and must include a valid file extension (e.g., ".txt", ".pdf") when using saveFile on web.');
     }
 
-    // Open a save dialog for the user to select a file path
-    // Create a new Blob containing the bytes
     final blob = Blob([bytes.toJS].toJS);
-
     final url = URL.createObjectURL(blob);
 
     // Start a download by using a click event on an anchor element that contains the Blob.
@@ -220,9 +216,6 @@ class FilePickerWeb extends FilePicker {
       ..target = 'blank' // Always open the file in a new tab.
       ..download = fileName
       ..click();
-      ..target = 'blank' // Open the file in a new tab (if supported)
-      ..download = fileName // Set the file name for the download
-      ..click(); // Simulate a click to start the download
 
     // Release the Blob URL after the download started.
     URL.revokeObjectURL(url);

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -202,6 +202,8 @@ class FilePickerWeb extends FilePicker {
       );
         'The bytes are required when saving a file on the web.',
       );
+        'The bytes are required when saving a file on the web.',
+      );
     }
 
     if (fileName == null || fileName.isEmpty) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -210,7 +210,8 @@ class FilePickerWeb extends FilePicker {
 
     if (p.extension(fileName).isEmpty) {
       throw ArgumentError(
-          'The file name should include a valid file extension.');
+          'The file name should include a valid file extension.',
+        );
     }
 
     final blob = Blob([bytes.toJS].toJS);

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -216,7 +216,10 @@ class FilePickerWeb extends FilePicker {
 
     // Start a download by using a click event on an anchor element that contains the Blob.
     HTMLAnchorElement()
-      ..href = url // Set the URL to download
+      ..href = url
+      ..target = 'blank' // Always open the file in a new tab.
+      ..download = fileName
+      ..click();
       ..target = 'blank' // Open the file in a new tab (if supported)
       ..download = fileName // Set the file name for the download
       ..click(); // Simulate a click to start the download

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -204,14 +204,14 @@ class FilePickerWeb extends FilePicker {
 
     if (fileName == null || fileName.isEmpty) {
       throw ArgumentError(
-          'A file name is required when saving a file on the web.',
-       );
+        'A file name is required when saving a file on the web.',
+      );
     }
 
     if (p.extension(fileName).isEmpty) {
       throw ArgumentError(
-          'The file name should include a valid file extension.',
-        );
+        'The file name should include a valid file extension.',
+      );
     }
 
     final blob = Blob([bytes.toJS].toJS);

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -196,7 +196,7 @@ class FilePickerWeb extends FilePicker {
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {
-    if (bytes == null) {
+    if (bytes == null || bytes.isEmpty) {
       throw ArgumentError(
         'The bytes are required when saving a file on the web.',
       );

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -198,6 +198,8 @@ class FilePickerWeb extends FilePicker {
   }) async {
     if (bytes == null) {
       throw ArgumentError(
+        'The bytes are required when saving a file on the web.',
+      );
           'The "bytes" parameter is required for saveFile on web');
     }
 

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -200,6 +200,8 @@ class FilePickerWeb extends FilePicker {
       throw ArgumentError(
         'The bytes are required when saving a file on the web.',
       );
+        'The bytes are required when saving a file on the web.',
+      );
     }
 
     if (fileName == null || fileName.isEmpty) {

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -212,7 +212,6 @@ class FilePickerWeb extends FilePicker {
     // Create a new Blob containing the bytes
     final blob = Blob([bytes.toJS].toJS);
 
-    // Generate a URL for the Blob, allowing it to be downloaded
     final url = URL.createObjectURL(blob);
 
     // Create an anchor element for triggering the download

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -157,6 +157,9 @@ abstract class FilePicker extends PlatformInterface {
   /// For mobile platforms, this function will save file with [bytes] to return a path.
   /// Throws UnsupportedError on macOS if bytes are provided.
   ///
+  /// For web platform, this function will download the file with [bytes] and [fileName].
+  /// Throws ArgumentError on web if bytes or fileName are not provided.
+  ///
   /// For desktop platforms (Linux, macOS & Windows) this function does not actually
   /// save a file. It only opens the dialog to let the user choose a location and
   /// file name. This function only returns the **path** to this (non-existing) file.

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -160,9 +160,6 @@ abstract class FilePicker extends PlatformInterface {
   /// On the web, this function will start a download for the file with [bytes] and [fileName].
   /// If the [bytes] or [fileName] are omitted, this will throw an [ArgumentError].
   ///
-  /// If the bytes or filename are omitted, this will throw an ArgumentError.
-  /// Throws ArgumentError on web if bytes or fileName are not provided.
-  ///
   /// For desktop platforms (Linux, macOS & Windows) this function does not actually
   /// save a file. It only opens the dialog to let the user choose a location and
   /// file name. This function only returns the **path** to this (non-existing) file.

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -158,6 +158,8 @@ abstract class FilePicker extends PlatformInterface {
   /// Throws UnsupportedError on macOS if bytes are provided.
   ///
   /// On the web, this function will start a download for the file with [bytes] and [fileName].
+  /// If the [bytes] or [fileName] are omitted, this will throw an [ArgumentError].
+  ///
   /// If the bytes or filename are omitted, this will throw an ArgumentError.
   /// Throws ArgumentError on web if bytes or fileName are not provided.
   ///

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -157,7 +157,8 @@ abstract class FilePicker extends PlatformInterface {
   /// For mobile platforms, this function will save file with [bytes] to return a path.
   /// Throws UnsupportedError on macOS if bytes are provided.
   ///
-  /// For web platform, this function will download the file with [bytes] and [fileName].
+  /// On the web, this function will start a download for the file with [bytes] and [fileName].
+  /// If the bytes or filename are omitted, this will throw an ArgumentError.
   /// Throws ArgumentError on web if bytes or fileName are not provided.
   ///
   /// For desktop platforms (Linux, macOS & Windows) this function does not actually

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.0.0
+version: 9.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description  
This PR adds support for the `saveFile` method on web platforms. Previously, calling `saveFile` on web resulted in an `UnimplementedError`. Now, this method triggers a file download using the provided `bytes` and `fileName`.  

## Changes  
- Implemented file download functionality for web using `AnchorElement`.  
- Added validation to ensure `fileName` and `bytes` are provided, throwing an `ArgumentError` otherwise.  
- Updated method documentation to reflect web-specific behavior.  

## Behavior on Web  
- **Required parameters:** `fileName` and `bytes`.  
- **Functionality:** Downloads the file using a browser download prompt.  
- **Error handling:**  
  - If `fileName` is `null` or does not include an extension, an `ArgumentError` is thrown.  
  - If `bytes` is `null`, an `ArgumentError` is thrown.  

## Example Usage  
```dart
await FilePicker.platform.saveFile(
  fileName: "example.txt",
  bytes: Uint8List.fromList(utf8.encode("Hello, world!")),
);
```

## Testing
- Verified file download behavior across Chrome, Firefox, and Edge.
- Ensured that missing parameters trigger appropriate exceptions.