### PR TITLE
Add ProGuard consumer rules to avoid manual configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.0
+### Android
+- Added ProGuard consumer rules to automatically exclude `androidx.lifecycle.DefaultLifecycleObserver` from obfuscation.
+
 ## 9.0.2
 ### Android
 - Fixes: File streams not getting closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.1.0
+## 9.0.3
 ### Android
 - Added ProGuard consumer rules to automatically exclude `androidx.lifecycle.DefaultLifecycleObserver` from obfuscation.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdk 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class androidx.lifecycle.DefaultLifecycleObserver

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.1.0
+version: 9.0.3
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.0.2
+version: 9.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
Resolves [#1721](https://github.com/miguelpruivo/flutter_file_picker/issues/1721):

- Added `consumerProguardFiles` in `android/build.gradle`
- Created `proguard-rules.pro` in the `android/` folder
- Updated CHANGELOG.md to reflect the improvement
- Users no longer need to manually add ProGuard rules for `androidx.lifecycle.DefaultLifecycleObserver`