### PR TITLE
Fix: Ensure `saveFile` writes bytes on desktop platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 9.2.0
+### Desktop (macOS, Windows, Linux)
+- `saveFile` now writes the provided `bytes` to the selected file, ensuring consistency with mobile behavior. [@vicajilau](https://github.com/vicajilau).
+
 ## 9.1.0
 ### Web
-- Added an implementation for `saveFile()` on the web.
+- Added an implementation for `saveFile()` on the web. [@vicajilau](https://github.com/vicajilau).
 
 ## 9.0.3
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.2.0
 ### Desktop (macOS, Windows, Linux)
-- `saveFile` now writes the provided `bytes` to the selected file, ensuring consistency with mobile behavior. [@vicajilau](https://github.com/vicajilau).
+- Fixes an inconsistency for saveFile that did not save the file, when bytes are provided on desktop platforms. [@vicajilau](https://github.com/vicajilau).
 
 ## 9.1.0
 ### Web

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -154,7 +154,10 @@ abstract class FilePicker extends PlatformInterface {
   /// Opens a save file dialog which lets the user select a file path and a file
   /// name to save a file.
   ///
-  /// For mobile and desktop platforms, this function will save file with [bytes] to return a path.
+  /// For mobile, this function will save a file with the given [fileName] and [bytes] and return the path where the file was saved.
+  ///
+  /// For desktop platforms, this function opens a dialog to let the user choose a location for the file and returns the selected path.
+  /// If the bytes are provided, then the bytes are written to a file at the chosen path.
   ///
   /// On the web, this function will start a download for the file with [bytes] and [fileName].
   /// If the [bytes] or [fileName] are omitted, this will throw an [ArgumentError].

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -154,15 +154,10 @@ abstract class FilePicker extends PlatformInterface {
   /// Opens a save file dialog which lets the user select a file path and a file
   /// name to save a file.
   ///
-  /// For mobile platforms, this function will save file with [bytes] to return a path.
-  /// Throws UnsupportedError on macOS if bytes are provided.
+  /// For mobile and desktop platforms, this function will save file with [bytes] to return a path.
   ///
   /// On the web, this function will start a download for the file with [bytes] and [fileName].
   /// If the [bytes] or [fileName] are omitted, this will throw an [ArgumentError].
-  ///
-  /// For desktop platforms (Linux, macOS & Windows) this function does not actually
-  /// save a file. It only opens the dialog to let the user choose a location and
-  /// file name. This function only returns the **path** to this (non-existing) file.
   ///
   /// The User Selected File Read/Write entitlement is required on macOS.
   ///

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -79,9 +79,6 @@ class FilePickerMacOS extends FilePicker {
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {
-    if (bytes != null) {
-      throw UnsupportedError('Bytes are not supported on macOS');
-    }
     final fileFilter = fileTypeToFileFilter(
       type,
       allowedExtensions,
@@ -97,6 +94,7 @@ class FilePickerMacOS extends FilePicker {
       },
     );
 
+    saveBytesSyncToFile(bytes, savedFilePath);
     return savedFilePath;
   }
 

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -94,7 +94,7 @@ class FilePickerMacOS extends FilePicker {
       },
     );
 
-    saveBytesSyncToFile(bytes, savedFilePath);
+    await saveBytesToFile(bytes, savedFilePath);
     return savedFilePath;
   }
 

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+
 import 'package:file_picker/src/file_picker.dart';
 import 'package:file_picker/src/file_picker_result.dart';
 import 'package:file_picker/src/linux/dialog_handler.dart';
@@ -104,7 +105,8 @@ class FilePickerLinux extends FilePicker {
       saveFile: true,
     );
 
-    final savedFilePath = await runExecutableWithArguments(executable, arguments);
+    final savedFilePath =
+        await runExecutableWithArguments(executable, arguments);
     saveBytesSyncToFile(bytes, savedFilePath);
     return savedFilePath;
   }

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -107,7 +107,7 @@ class FilePickerLinux extends FilePicker {
 
     final savedFilePath =
         await runExecutableWithArguments(executable, arguments);
-    saveBytesSyncToFile(bytes, savedFilePath);
+    await saveBytesToFile(bytes, savedFilePath);
     return savedFilePath;
   }
 

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -104,7 +104,9 @@ class FilePickerLinux extends FilePicker {
       saveFile: true,
     );
 
-    return await runExecutableWithArguments(executable, arguments);
+    final savedFilePath = await runExecutableWithArguments(executable, arguments);
+    saveBytesSyncToFile(bytes, savedFilePath);
+    return savedFilePath;
   }
 
   /// Returns the path to the executables `qarma`, `zenity` or `kdialog` as a

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -64,6 +64,13 @@ Future<String> isExecutableOnPath(String executable) async {
   return path;
 }
 
+void saveBytesSyncToFile(Uint8List? bytes, String? path) {
+  if (path != null && bytes != null && bytes.isNotEmpty) {
+    final file = File(path);
+    file.writeAsBytesSync(bytes);
+  }
+}
+
 bool isAlpha(String x) {
   int codeUnit = x.codeUnitAt(0);
   return 'a'.codeUnitAt(0) <= codeUnit && codeUnit <= 'z'.codeUnitAt(0) ||

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -64,10 +64,10 @@ Future<String> isExecutableOnPath(String executable) async {
   return path;
 }
 
-void saveBytesSyncToFile(Uint8List? bytes, String? path) {
+Future<void> saveBytesSyncToFile(Uint8List? bytes, String? path) async {
   if (path != null && bytes != null && bytes.isNotEmpty) {
     final file = File(path);
-    file.writeAsBytesSync(bytes);
+    await file.writeAsBytes(bytes);
   }
 }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -64,7 +64,7 @@ Future<String> isExecutableOnPath(String executable) async {
   return path;
 }
 
-Future<void> saveBytesSyncToFile(Uint8List? bytes, String? path) async {
+Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
   if (path != null && bytes != null && bytes.isNotEmpty) {
     final file = File(path);
     await file.writeAsBytes(bytes);

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -214,7 +214,7 @@ class FilePickerWindows extends FilePicker {
           confirmOverwrite: true,
         ));
     final savedFilePath = (await port.first) as String?;
-    saveBytesSyncToFile(bytes, savedFilePath);
+    await saveBytesToFile(bytes, savedFilePath);
     return savedFilePath;
   }
 

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -213,7 +213,9 @@ class FilePickerWindows extends FilePicker {
           lockParentWindow: lockParentWindow,
           confirmOverwrite: true,
         ));
-    return (await port.first) as String?;
+    final savedFilePath = (await port.first) as String?;
+    saveBytesSyncToFile(bytes, savedFilePath);
+    return savedFilePath;
   }
 
   String? _saveFile(_OpenSaveFileArgs args) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.1.0
+version: 9.2.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Changes Made
On **desktop platforms**, when `bytes` is provided:
  1. The save dialog opens as usual.
  2. If a path is selected, the provided `bytes` are written to the file.
  3. The file path is returned (matching mobile behavior).

## Why This Change?
This modification improves cross-platform consistency, allowing developers to use `saveFile` without needing platform-specific logic.

## Testing
- Verified the new behavior on **Windows, macOS, and Linux**.
- Ensured existing functionality on mobile remains unchanged.

### Related Issue
Fixes #1725