### PR TITLE
Use sheet modal for panels on macOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.2.1
+### Desktop (macOS)
+- Present file picker panel as a sheet modal to the Flutter application window. [#1734](https://github.com/miguelpruivo/flutter_file_picker/pull/1734)
+
 ## 9.2.0
 ### Desktop (macOS, Windows, Linux)
 - Fixes an inconsistency for saveFile that did not save the file, when bytes are provided on desktop platforms. [@vicajilau](https://github.com/vicajilau).

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -165,6 +165,7 @@ abstract class FilePicker extends PlatformInterface {
   /// The User Selected File Read/Write entitlement is required on macOS.
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
+  /// Not supported on macOS.
   ///
   /// [fileName] can be set to a non-empty string to provide a default file
   /// name. Throws an `IllegalCharacterInFileNameException` under Windows if the

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -75,6 +75,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
             result([pathResult!.path])
           }
         }
+        return
       } else {
         // User dismissed the dialog
         result(nil)
@@ -87,7 +88,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
   ) {
     let dialog = NSOpenPanel()
     let args = call.arguments as! [String: Any]
-    
+
     dialog.directoryURL = URL(
       fileURLWithPath: args["initialDirectory"] as? String ?? ""
     )
@@ -104,11 +105,11 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
       if (response == .OK) {
         if let url = dialog.url {
           result(url.path)
+          return
         }
-      } else {
-        // User dismissed the dialog
-        result(nil)
       }
+      // User dismissed the dialog
+      result(nil)
     }
   }
 
@@ -141,11 +142,11 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
       if (response == .OK) {
         if let url = dialog.url {
           result(url.path)
+          return
         }
-      } else {
-        // User dismissed the dialog
-        result(nil)
       }
+      // User dismissed the dialog
+      result(nil)
     }
   }
 

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -7,7 +7,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     let channel = FlutterMethodChannel(
       name: "miguelruivo.flutter.plugins.filepicker",
       binaryMessenger: registrar.messenger)
-    let instance = FilePickerPlugin(registrar:registrar)
+    let instance = FilePickerPlugin(registrar: registrar)
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
@@ -52,32 +52,33 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     let extensions = args["allowedExtensions"] as? [String] ?? []
     applyExtensions(dialog, extensions)
 
-    if let appWindow = getFlutterWindow() {
-      dialog.beginSheetModal(for:appWindow) { response in
-        if (response == .OK) {
-          if allowMultiple {
-            let pathResult = dialog.urls
-            if pathResult.isEmpty {
-              result(nil)
-            } else {
-              let paths = pathResult.map { $0.path }
-              result(paths)
-            }
+    guard let appWindow = getFlutterWindow() else {
+      result(nil)
+      return
+    }
+
+    dialog.beginSheetModal(for: appWindow) { response in
+      if (response == .OK) {
+        if allowMultiple {
+          let pathResult = dialog.urls
+          if pathResult.isEmpty {
+            result(nil)
           } else {
-            let pathResult = dialog.url
-            if pathResult == nil {
-              result(nil)
-            } else {
-              result([pathResult!.path])
-            }
+            let paths = pathResult.map { $0.path }
+            result(paths)
           }
         } else {
-          // User dismissed the dialog
-          result(nil)
+          let pathResult = dialog.url
+          if pathResult == nil {
+            result(nil)
+          } else {
+            result([pathResult!.path])
+          }
         }
+      } else {
+        // User dismissed the dialog
+        result(nil)
       }
-    } else {
-      result(nil)
     }
   }
 
@@ -86,7 +87,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
   ) {
     let dialog = NSOpenPanel()
     let args = call.arguments as! [String: Any]
-
+    
     dialog.directoryURL = URL(
       fileURLWithPath: args["initialDirectory"] as? String ?? ""
     )
@@ -94,20 +95,20 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     dialog.allowsMultipleSelection = false
     dialog.canChooseDirectories = true
     dialog.canChooseFiles = false
-
-    if let appWindow = getFlutterWindow() {
-      dialog.beginSheetModal(for: appWindow) { response in
-        if (response == .OK) {
-          if let url = dialog.url {
-            result(url.path)
-          }
-        } else {
-          // User dismissed the dialog
-          result(nil)
-        }
-      }
-    } else {
+    
+    guard let appWindow = getFlutterWindow()  else {
       result(nil)
+      return
+    }
+    dialog.beginSheetModal(for: appWindow) { response in
+      if (response == .OK) {
+        if let url = dialog.url {
+          result(url.path)
+        }
+      } else {
+        // User dismissed the dialog
+        result(nil)
+      }
     }
   }
 
@@ -132,19 +133,19 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     let extensions = args["allowedExtensions"] as? [String] ?? []
     applyExtensions(dialog, extensions)
 
-    if let appWindow = getFlutterWindow() {
-      dialog.beginSheetModal(for: appWindow) { response in
-        if (response == .OK) {
-          if let url = dialog.url {
-            result(url.path)
-          }
-        } else {
-          // User dismissed the dialog
-          result(nil)
-        }
-      }
-    } else {
+    guard let appWindow = getFlutterWindow() else {
       result(nil)
+      return
+    }
+    dialog.beginSheetModal(for: appWindow) { response in
+      if (response == .OK) {
+        if let url = dialog.url {
+          result(url.path)
+        }
+      } else {
+        // User dismissed the dialog
+        result(nil)
+      }
     }
   }
 
@@ -164,10 +165,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
 
   /// Gets the parent NSWindow
   private func getFlutterWindow() -> NSWindow? {
-    if let flutterViewController =
-        registrar.view?.window?.contentViewController as? FlutterViewController {
-      return flutterViewController.view.window
-    }
-    return nil
+    let viewController = registrar.view?.window?.contentViewController
+    return (viewController as? FlutterViewController)?.view.window
   }
 }

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -58,28 +58,30 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     }
 
     dialog.beginSheetModal(for: appWindow) { response in
-      if (response == .OK) {
-        if allowMultiple {
-          let pathResult = dialog.urls
-          if pathResult.isEmpty {
-            result(nil)
-          } else {
-            let paths = pathResult.map { $0.path }
-            result(paths)
-          }
+      // User dismissed the dialog
+      if (response != .OK) {
+        result(nil)
+        return
+      }
+
+      if allowMultiple {
+        let pathResult = dialog.urls
+
+        if pathResult.isEmpty {
+          result(nil)
         } else {
-          let pathResult = dialog.url
-          if pathResult == nil {
-            result(nil)
-          } else {
-            result([pathResult!.path])
-          }
+          let paths = pathResult.map { $0.path }
+          result(paths)
         }
         return
-      } else {
-        // User dismissed the dialog
-        result(nil)
       }
+
+      if let pathResult = dialog.url {
+        result([pathResult.path])
+        return
+      }
+
+      result(nil)
     }
   }
 
@@ -102,13 +104,17 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
       return
     }
     dialog.beginSheetModal(for: appWindow) { response in
-      if (response == .OK) {
-        if let url = dialog.url {
-          result(url.path)
-          return
-        }
-      }
       // User dismissed the dialog
+      if (response != .OK) {
+        result(nil)
+        return
+      }
+
+      if let url = dialog.url {
+        result(url.path)
+        return
+      }
+
       result(nil)
     }
   }
@@ -139,13 +145,17 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
       return
     }
     dialog.beginSheetModal(for: appWindow) { response in
-      if (response == .OK) {
-        if let url = dialog.url {
-          result(url.path)
-          return
-        }
-      }
       // User dismissed the dialog
+      if (response != .OK) {
+        result(nil)
+        return
+      }
+
+      if let url = dialog.url {
+        result(url.path)
+        return
+      }
+
       result(nil)
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.2.0
+version: 9.2.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
In #1718, I described that on macOS, the file_picker panels pause the parent app's run loop. I did some investigation and found out that using a sheet modal to present the file_picker panels improves the user experience - opening and saving files is similar to what users see in other apps, and the run loop in the parent window is still running.

This PR adds the change needed to use the sheet modal - please let me know if this is something we could eventually have in file_picker.

Notes:
- With this change, the file_picker panels lose the dialog title.
- Documentation for beginSheetModal: https://developer.apple.com/documentation/appkit/nssavepanel/beginsheetmodal(for:completionhandler:)

The recordings show the different behavior.

Before change:
https://github.com/user-attachments/assets/6e333148-8bb0-449d-bcec-f3e46e8e8c64

After change:
https://github.com/user-attachments/assets/74724d8a-a02d-4c45-81cf-d5216d11b64a

Fixes https://github.com/miguelpruivo/flutter_file_picker/issues/1718

