### PR TITLE
NSSavePanel Not Appearing Due to Missing Entitlements Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.2.2
+### Desktop (macOS)
+- Returns a clear FlutterError if the required entitlements are missing, instead of failing silently.
+
 ## 9.2.1
 ### Desktop (macOS)
 - Present file picker panel as a sheet modal to the Flutter application window. [#1734](https://github.com/miguelpruivo/flutter_file_picker/pull/1734)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.2.2
 ### Desktop (macOS)
-- Returns a clear FlutterError if the required entitlements are missing, instead of failing silently.
+- Updated the file picker to check for missing entitlements, instead of failing silently.
 
 ## 9.2.1
 ### Desktop (macOS)

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -2,181 +2,213 @@ import Cocoa
 import FlutterMacOS
 import UniformTypeIdentifiers
 
+enum EntitlementMode {
+    case requireWrite
+    case readOrWrite
+}
+
 public class FilePickerPlugin: NSObject, FlutterPlugin {
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(
-      name: "miguelruivo.flutter.plugins.filepicker",
-      binaryMessenger: registrar.messenger)
-    let instance = FilePickerPlugin(registrar: registrar)
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  private let registrar: FlutterPluginRegistrar
-
-  init(registrar: FlutterPluginRegistrar) {
-    self.registrar = registrar
-    super.init()
-  }
-
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult)
-  {
-    switch call.method {
-    case "pickFiles":
-      handleFileSelection(call, result: result)
-
-    case "getDirectoryPath":
-      handleDirectorySelection(call, result: result)
-
-    case "saveFile":
-      handleSaveFile(call, result: result)
-
-    default:
-      result(FlutterMethodNotImplemented)
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "miguelruivo.flutter.plugins.filepicker",
+            binaryMessenger: registrar.messenger)
+        let instance = FilePickerPlugin(registrar: registrar)
+        registrar.addMethodCallDelegate(instance, channel: channel)
     }
-  }
-
-  private func handleFileSelection(
-    _ call: FlutterMethodCall, result: @escaping FlutterResult
-  ) {
-    let dialog = NSOpenPanel()
-    let args = call.arguments as! [String: Any]
-
-    dialog.directoryURL = URL(
-      fileURLWithPath: args["initialDirectory"] as? String ?? ""
-    )
-    dialog.showsHiddenFiles = false
-    let allowMultiple = args["allowMultiple"] as? Bool ?? false
-    dialog.allowsMultipleSelection = allowMultiple
-    dialog.canChooseDirectories = false
-    dialog.canChooseFiles = true
-    let extensions = args["allowedExtensions"] as? [String] ?? []
-    applyExtensions(dialog, extensions)
-
-    guard let appWindow = getFlutterWindow() else {
-      result(nil)
-      return
-    }
-
-    dialog.beginSheetModal(for: appWindow) { response in
-      // User dismissed the dialog
-      if (response != .OK) {
-        result(nil)
-        return
-      }
-
-      if allowMultiple {
-        let pathResult = dialog.urls
-
-        if pathResult.isEmpty {
-          result(nil)
-        } else {
-          let paths = pathResult.map { $0.path }
-          result(paths)
-        }
-        return
-      }
-
-      if let pathResult = dialog.url {
-        result([pathResult.path])
-        return
-      }
-
-      result(nil)
-    }
-  }
-
-  private func handleDirectorySelection(
-    _ call: FlutterMethodCall, result: @escaping FlutterResult
-  ) {
-    let dialog = NSOpenPanel()
-    let args = call.arguments as! [String: Any]
-
-    dialog.directoryURL = URL(
-      fileURLWithPath: args["initialDirectory"] as? String ?? ""
-    )
-    dialog.showsHiddenFiles = false
-    dialog.allowsMultipleSelection = false
-    dialog.canChooseDirectories = true
-    dialog.canChooseFiles = false
     
-    guard let appWindow = getFlutterWindow()  else {
-      result(nil)
-      return
+    private let registrar: FlutterPluginRegistrar
+    
+    init(registrar: FlutterPluginRegistrar) {
+        self.registrar = registrar
+        super.init()
     }
-    dialog.beginSheetModal(for: appWindow) { response in
-      // User dismissed the dialog
-      if (response != .OK) {
-        result(nil)
-        return
-      }
-
-      if let url = dialog.url {
-        result(url.path)
-        return
-      }
-
-      result(nil)
-    }
-  }
-
-  private func handleSaveFile(
-    _ call: FlutterMethodCall, result: @escaping FlutterResult
-  ) {
-    let dialog = NSSavePanel()
-    let args = call.arguments as! [String: Any]
-
-    dialog.title = args["dialogTitle"] as? String ?? ""
-    dialog.showsTagField = false
-    dialog.showsHiddenFiles = false
-    dialog.canCreateDirectories = true
-    dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
-
-    if let initialDirectory = args["initialDirectory"] as? String,
-      !initialDirectory.isEmpty
-    {
-      dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
-    }
-
-    let extensions = args["allowedExtensions"] as? [String] ?? []
-    applyExtensions(dialog, extensions)
-
-    guard let appWindow = getFlutterWindow() else {
-      result(nil)
-      return
-    }
-    dialog.beginSheetModal(for: appWindow) { response in
-      // User dismissed the dialog
-      if (response != .OK) {
-        result(nil)
-        return
-      }
-
-      if let url = dialog.url {
-        result(url.path)
-        return
-      }
-
-      result(nil)
-    }
-  }
-
-  /// Applies extensions to dialog using appropriate API
-  private func applyExtensions(_ dialog: NSSavePanel, _ extensions: [String]) {
-    if !extensions.isEmpty {
-      if #available(macOS 11.0, *) {
-        let contentTypes = extensions.compactMap { ext in
-          UTType(filenameExtension: ext)
+    
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "pickFiles":
+            handleFileSelection(call, result: result)
+            
+        case "getDirectoryPath":
+            handleDirectorySelection(call, result: result)
+            
+        case "saveFile":
+            handleSaveFile(call, result: result)
+            
+        default:
+            result(FlutterMethodNotImplemented)
         }
-        dialog.allowedContentTypes = contentTypes
-      } else {
-        dialog.allowedFileTypes = extensions
-      }
     }
-  }
-
-  /// Gets the parent NSWindow
-  private func getFlutterWindow() -> NSWindow? {
-    let viewController = registrar.view?.window?.contentViewController
-    return (viewController as? FlutterViewController)?.view.window
-  }
+    
+    private func handleFileSelection(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if checkEntitlement(requiredMode: .readOrWrite, result: result) {
+            let dialog = NSOpenPanel()
+            let args = call.arguments as! [String: Any]
+            
+            dialog.directoryURL = URL(
+                fileURLWithPath: args["initialDirectory"] as? String ?? ""
+            )
+            dialog.showsHiddenFiles = false
+            let allowMultiple = args["allowMultiple"] as? Bool ?? false
+            dialog.allowsMultipleSelection = allowMultiple
+            dialog.canChooseDirectories = false
+            dialog.canChooseFiles = true
+            let extensions = args["allowedExtensions"] as? [String] ?? []
+            applyExtensions(dialog, extensions)
+            
+            guard let appWindow = getFlutterWindow() else {
+                result(nil)
+                return
+            }
+            
+            dialog.beginSheetModal(for: appWindow) { response in
+                // User dismissed the dialog
+                if (response != .OK) {
+                    result(nil)
+                    return
+                }
+                
+                if allowMultiple {
+                    let pathResult = dialog.urls
+                    
+                    if pathResult.isEmpty {
+                        result(nil)
+                    } else {
+                        let paths = pathResult.map { $0.path }
+                        result(paths)
+                    }
+                    return
+                }
+                
+                if let pathResult = dialog.url {
+                    result([pathResult.path])
+                    return
+                }
+                
+                result(nil)
+            }
+        }
+    }
+    
+    private func handleDirectorySelection(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if checkEntitlement(requiredMode: .readOrWrite, result: result) {
+            
+            let dialog = NSOpenPanel()
+            let args = call.arguments as! [String: Any]
+            
+            dialog.directoryURL = URL(
+                fileURLWithPath: args["initialDirectory"] as? String ?? ""
+            )
+            dialog.showsHiddenFiles = false
+            dialog.allowsMultipleSelection = false
+            dialog.canChooseDirectories = true
+            dialog.canChooseFiles = false
+            
+            guard let appWindow = getFlutterWindow()  else {
+                result(nil)
+                return
+            }
+            dialog.beginSheetModal(for: appWindow) { response in
+                // User dismissed the dialog
+                if (response != .OK) {
+                    result(nil)
+                    return
+                }
+                
+                if let url = dialog.url {
+                    result(url.path)
+                    return
+                }
+                
+                result(nil)
+            }
+        }
+    }
+    
+    private func handleSaveFile(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if checkEntitlement(requiredMode: .requireWrite, result: result) {
+            
+            let dialog = NSSavePanel()
+            let args = call.arguments as! [String: Any]
+            
+            dialog.title = args["dialogTitle"] as? String ?? ""
+            dialog.showsTagField = false
+            dialog.showsHiddenFiles = false
+            dialog.canCreateDirectories = true
+            dialog.nameFieldStringValue = args["fileName"] as? String ?? ""
+            
+            if let initialDirectory = args["initialDirectory"] as? String,
+               !initialDirectory.isEmpty
+            {
+                dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+            }
+            
+            let extensions = args["allowedExtensions"] as? [String] ?? []
+            applyExtensions(dialog, extensions)
+            
+            guard let appWindow = getFlutterWindow() else {
+                result(nil)
+                return
+            }
+            dialog.beginSheetModal(for: appWindow) { response in
+                // User dismissed the dialog
+                if (response != .OK) {
+                    result(nil)
+                    return
+                }
+                
+                if let url = dialog.url {
+                    result(url.path)
+                    return
+                }
+                
+                result(nil)
+            }
+        }
+    }
+    
+    /// Checks if the  entitlements file contains the required entitlement for save files.
+    private func checkEntitlement(requiredMode: EntitlementMode, result: @escaping FlutterResult) -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            result(FlutterError(code: "ENTITLEMENT_CHECK_FAILED", message: "Failed to create security task.", details: nil))
+            return false
+        }
+        
+        let readWriteEntitlement = SecTaskCopyValueForEntitlement(task, "com.apple.security.files.user-selected.read-write" as CFString, nil) as? Bool
+        let readOnlyEntitlement = SecTaskCopyValueForEntitlement(task, "com.apple.security.files.user-selected.read-only" as CFString, nil) as? Bool
+        
+        switch requiredMode {
+        case .requireWrite:
+            if readWriteEntitlement != true {
+                result(FlutterError(code: "ENTITLEMENT_REQUIRED_WRITE", message: "Read-write entitlement is required but not found.", details: nil))
+                return false
+            }
+            
+        case .readOrWrite:
+            if readWriteEntitlement != true && readOnlyEntitlement != true {
+                result(FlutterError(code: "ENTITLEMENT_NOT_FOUND", message: "Neither read-write nor read-only entitlements found.", details: nil))
+                return false
+            }
+        }
+        return true
+    }
+    
+    /// Applies extensions to dialog using appropriate API
+    private func applyExtensions(_ dialog: NSSavePanel, _ extensions: [String]) {
+        if !extensions.isEmpty {
+            if #available(macOS 11.0, *) {
+                let contentTypes = extensions.compactMap { ext in
+                    UTType(filenameExtension: ext)
+                }
+                dialog.allowedContentTypes = contentTypes
+            } else {
+                dialog.allowedFileTypes = extensions
+            }
+        }
+    }
+    
+    /// Gets the parent NSWindow
+    private func getFlutterWindow() -> NSWindow? {
+        let viewController = registrar.view?.window?.contentViewController
+        return (viewController as? FlutterViewController)?.view.window
+    }
 }

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -7,6 +7,11 @@ enum EntitlementMode {
     case readOrWrite
 }
 
+private extension CFString {
+    static let securityFilesUserSelectedReadOnly = "com.apple.security.files.user-selected.read-only" as CFString
+    static let securityFilesUserSelectedReadWrite = "com.apple.security.files.user-selected.read-write" as CFString
+}
+
 public class FilePickerPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
@@ -176,8 +181,8 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
             return FlutterError(code: "ENTITLEMENT_CHECK_FAILED", message: "Failed to verify file_picker entitlements.", details: nil)
         }
         
-        let readWriteEntitlement = SecTaskCopyValueForEntitlement(task, "com.apple.security.files.user-selected.read-write" as CFString, nil) as? Bool
-        let readOnlyEntitlement = SecTaskCopyValueForEntitlement(task, "com.apple.security.files.user-selected.read-only" as CFString, nil) as? Bool
+        let readWriteEntitlement = SecTaskCopyValueForEntitlement(task, .securityFilesUserSelectedReadWrite, nil) as? Bool
+        let readOnlyEntitlement = SecTaskCopyValueForEntitlement(task, .securityFilesUserSelectedReadOnly, nil) as? Bool
         
         switch requiredMode {
         case .requireWrite:

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -182,12 +182,12 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
         switch requiredMode {
         case .requireWrite:
             if readWriteEntitlement != true {
-                return FlutterError(code: "ENTITLEMENT_REQUIRED_WRITE", message: "Read-write entitlement is required but not found.", details: nil)
+                return FlutterError(code: "ENTITLEMENT_REQUIRED_WRITE", message: "The Read-Write entitlement is required for this action.", details: nil)
             }
             
         case .readOrWrite:
             if readWriteEntitlement != true && readOnlyEntitlement != true {
-                return FlutterError(code: "ENTITLEMENT_NOT_FOUND", message: "Neither read-write nor read-only entitlements found.", details: nil)
+                return FlutterError(code: "ENTITLEMENT_NOT_FOUND", message: "Either the Read-Only or Read-Write entitlement is required for this action.", details: nil)
             }
         }
         return nil

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.2.1
+version: 9.2.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
**Description:**
This PR addresses an issue where the `NSSavePanel` was not appearing when invoking the file picker on macOS. The root cause was an entitlement issue that was not properly handled, making it unclear why the panel failed to initialize. Now, the plugin correctly checks for the required entitlements (`com.apple.security.files.user-selected.read-write` or `com.apple.security.files.user-selected.read-only`) and returns an appropriate error if they are missing.

**Changes:**
- Implemented `checkEntitlement(requiredMode: EntitlementMode, result: @escaping FlutterResult)` to verify if the app has the correct entitlements before invoking `NSSavePanel`.
- Ensured that `NSSavePanel` is only initialized if the required entitlements are available.
- If entitlements are missing, the plugin now returns a `FlutterError` with a clear message instead of failing silently.

**How to Test:**
1. Run the file picker in an app with missing entitlements.
2. Observe that a clear error is returned instead of the panel failing to appear.
3. Run the file picker in an app with the correct entitlements.
4. Confirm that `NSSavePanel` appears as expected.

**Issue Reference:**
This fixes an issue where `NSSavePanel` would silently fail due to entitlement restrictions, making debugging difficult.

