### PR TITLE
[macOS] Ignore view controller type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.2.3
+### Desktop (macOS)
+- Fixed an issue when the active viewController is not a FlutterViewController.
+
 ## 9.2.2
 ### Desktop (macOS)
 - Updated the file picker to check for missing entitlements, instead of failing silently.

--- a/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/macos/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -214,7 +214,6 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
     
     /// Gets the parent NSWindow
     private func getFlutterWindow() -> NSWindow? {
-        let viewController = registrar.view?.window?.contentViewController
-        return (viewController as? FlutterViewController)?.view.window
+        return registrar.view?.window
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 9.2.2
+version: 9.2.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
`contentViewController` might be replaced by objects which are not `FlutterViewController`. In that the file_picker plugin fails to open needed dialogs.

This fix avoids checking the type and returns the views window.

Fixes #1739 