### PR TITLE
Feat: Add ability to auto detect mime type on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+### Android
+- Added new parameter `inferMimeType` to `saveFile()` which, when enabled, infers the MIME type using Apache Tika. Fixes incorrect file incrementing if a file with the same name in the destination folder already exists. ([#1669](https://github.com/miguelpruivo/flutter_file_picker/issues/1669)) [@Leapward-Koex](https://github.com/Leapward-Koex)
+
 ## 10.0.0
 ### General
 - **BREAKING CHANGE:** The `compressionQuality` property in the `pickFiles` method now defaults to `0`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,7 @@ android {
         implementation 'androidx.core:core:1.0.2'
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
+        implementation 'org.apache.tika:tika-core:3.1.0'
     }
 
     if (project.android.hasProperty("namespace")) {

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -311,7 +311,9 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
             try (TikaInputStream stream = TikaInputStream.get(bytes)) {
                 Metadata metadata = new Metadata();
                 Tika tika = new Tika();
-                metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName);
+                if (fileName != null && !fileName.isEmpty()) {
+                    metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName);
+                }
                 org.apache.tika.mime.MediaType mediaType = tika.getDetector().detect(stream, metadata);
 
                 String inferredMimeType = mediaType.toString();

--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java
@@ -137,8 +137,9 @@ public class FilePickerPlugin implements MethodChannel.MethodCallHandler, Flutte
             String type = resolveType((String) arguments.get("fileType"));
             String initialDirectory = (String) arguments.get("initialDirectory");
             String[] allowedExtensions = FileUtils.getMimeTypes((ArrayList<String>) arguments.get("allowedExtensions"));
+            boolean inferMimeType = (boolean) arguments.get("inferMimeType");
             byte[] bytes = (byte[]) arguments.get("bytes");
-            this.delegate.saveFile(fileName, type, initialDirectory, allowedExtensions, bytes,result);
+            this.delegate.saveFile(fileName, type, initialDirectory, allowedExtensions, inferMimeType, bytes,result);
             return;
         }
 

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -21,6 +21,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   String? _directoryPath;
   String? _extension;
   bool _isLoading = false;
+  bool _inferMimeType = false;
   bool _lockParentWindow = false;
   bool _userAborted = false;
   bool _multiPick = false;
@@ -120,6 +121,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         type: _pickingType,
         dialogTitle: _dialogTitleController.text,
         fileName: _defaultFileNameController.text,
+        inferMimeType: _inferMimeType,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
         bytes: _paths?.first.bytes,
@@ -291,6 +293,17 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
                   spacing: 10.0,
                   runSpacing: 10.0,
                   children: [
+                    SizedBox(
+                      width: 400.0,
+                      child: SwitchListTile.adaptive(
+                        title: Text(
+                          'Infer mime type',
+                          textAlign: TextAlign.left,
+                        ),
+                        onChanged: (bool value) => setState(() => _inferMimeType = value),
+                        value: _inferMimeType,
+                      ),
+                    ),
                     SizedBox(
                       width: 400.0,
                       child: SwitchListTile.adaptive(

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -195,6 +195,7 @@ class FilePickerWeb extends FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool inferMimeType = false,
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -186,6 +186,9 @@ abstract class FilePicker extends PlatformInterface {
   /// parameters are just a proposal to the user as the save file dialog does
   /// not enforce these restrictions.
   ///
+  /// (Android only) if [inferMimeType] is set to `true` then the type is inferred from the supplied bytes.
+  /// If inferring fails for whatever reason it will fallback to [type] and [allowedExtensions] if specified.
+  ///
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
   /// window). This parameter works only on Windows desktop.
@@ -198,6 +201,7 @@ abstract class FilePicker extends PlatformInterface {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool inferMimeType = false,
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async =>

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -145,6 +145,7 @@ class FilePickerIO extends FilePicker {
       String? initialDirectory,
       FileType type = FileType.any,
       List<String>? allowedExtensions,
+      bool inferMimeType = false,
       Uint8List? bytes,
       bool lockParentWindow = false}) {
     if (Platform.isIOS || Platform.isAndroid) {
@@ -158,6 +159,7 @@ class FilePickerIO extends FilePicker {
         "fileType": type.name,
         "initialDirectory": initialDirectory,
         "allowedExtensions": allowedExtensions,
+        "inferMimeType": inferMimeType,
         "bytes": bytes,
       });
     }

--- a/lib/src/file_picker_macos.dart
+++ b/lib/src/file_picker_macos.dart
@@ -78,6 +78,7 @@ class FilePickerMacOS extends FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool inferMimeType = false,
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -88,6 +88,7 @@ class FilePickerLinux extends FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool inferMimeType = false,
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -199,6 +199,7 @@ class FilePickerWindows extends FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
+    bool inferMimeType = false,
     Uint8List? bytes,
     bool lockParentWindow = false,
   }) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.0.0
+version: 10.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
This is fix for https://github.com/miguelpruivo/flutter_file_picker/issues/1669, taking a different approach to the already open PR here https://github.com/miguelpruivo/flutter_file_picker/pull/1682.

This PR takes into consideration of the [recommendation](https://github.com/miguelpruivo/flutter_file_picker/pull/1682#discussion_r2002650880) to try and automatically infer the mime type from the bytes and file name extension (if supplied) to pass to the `ACTION_CREATE_DOCUMENT` intent instead of making the mime type a field on the API. 

I ended up picking Apache Tika for this as it proved to the most accurate for many types of common files. Using the inbuilt java functionality such as [`URLConnection.guessContentTypeFromStream`](https://docs.oracle.com/javase/8/docs/api/java/net/URLConnection.html#guessContentTypeFromStream-java.io.InputStream-) proved to be inaccurate for certain file types such as webp and thus unsuitable for this usage.