### PR TITLE
[Web] Dispose `filesCompleter` to avoid memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.3
+### Web
+- Dispose `filesCompleter` to avoid memory leak
+
 ## 10.1.2
 ### Android
 - Improved mimetype detection. [@vicajilau](https://github.com/vicajilau)

--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -57,7 +57,7 @@ class FilePickerWeb extends FilePicker {
           'You are setting a type [$type]. Custom extension filters are only allowed with FileType.custom, please change it or remove filters.');
     }
 
-    final Completer<List<PlatformFile>?> filesCompleter =
+    Completer<List<PlatformFile>?>? filesCompleter =
         Completer<List<PlatformFile>?>();
 
     String accept = _fileType(type, allowedExtensions);
@@ -108,7 +108,7 @@ class FilePickerWeb extends FilePicker {
           if (onFileLoading != null) {
             onFileLoading(FilePickerStatus.done);
           }
-          filesCompleter.complete(pickedFiles);
+          filesCompleter?.complete(pickedFiles);
         }
       }
 
@@ -156,7 +156,7 @@ class FilePickerWeb extends FilePicker {
       Future.delayed(Duration(seconds: 1)).then((value) {
         if (!changeEventTriggered) {
           changeEventTriggered = true;
-          filesCompleter.complete(null);
+          filesCompleter?.complete(null);
         }
       });
     }
@@ -184,6 +184,7 @@ class FilePickerWeb extends FilePicker {
     }
 
     final List<PlatformFile>? files = await filesCompleter.future;
+    filesCompleter = null;
 
     return files == null ? null : FilePickerResult(files);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.1.2
+version: 10.1.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Why?
Memory leak is happening on web

## Reproducible code
<details>
  <summary>See here</summary>

```Dart
import 'package:file_picker/file_picker.dart';
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Material App',
      home: FirstPage(),
    );
  }
}

class FirstPage extends StatelessWidget {
  const FirstPage({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: TextButton(
          onPressed: () {
            Navigator.push(
              context,
              MaterialPageRoute(
                builder: (context) => SecondPage(),
              ),
            );
          },
          child: Text('Go'),
        ),
      ),
    );
  }
}

class SecondPage extends StatefulWidget {
  const SecondPage({super.key});

  @override
  State<SecondPage> createState() => _SecondPageState();
}

class _SecondPageState extends State<SecondPage> {
  bool filePicked = false;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: [
            Text('File picked: $filePicked'),
            TextButton(
              onPressed: () async {
                await FilePicker.platform.pickFiles();
                setState(() => filePicked = true);
              },
              child: Text('Pick file'),
            ),
            TextButton(
              onPressed: () {
                Navigator.pop(context);
              },
              child: Text('Back'),
            )
          ],
        ),
      ),
    );
  }
}
```
</details>

## Steps to reproduce

1. Run `flutter run -d chrome --profile`
2. Open Chrome dev tools, Memory tab, trigger garbage collector then snapshot main heap
3. Navigate to second screen by clicking on `Go` button
4. Pick a heavy file. In the above code, I chose to pick image because I already have a heavy image (5.2mb)
5. Go back to the previous screen either by clicking on `Back` or any conventional ways for web
6. Trigger garbage collector then snapshot main heap again. Compare two snapshots.

## Expected behavior
The file's data will be deallocated from memory
## Actual behavior
The file's data is still on memory

## Resolve demo
### Before
![Screenshot 2025-04-17 at 15 31 40](https://github.com/user-attachments/assets/3fe783b2-7e0d-49d6-9485-0d35c9b1950d)

### After
![Screenshot 2025-04-17 at 15 38 38](https://github.com/user-attachments/assets/e89fe8ba-60f6-498b-9e63-4c0dbda98de5)
