### PR TITLE
fixed event channel bug

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -197,11 +197,11 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
         delegate?.let { it ->
             EventChannel(messenger, EVENT_CHANNEL).setStreamHandler(object :
                 EventChannel.StreamHandler {
-                override fun onListen(arguments: Any, events: EventSink) {
+                override fun onListen(arguments: Any?, events: EventSink?) {
                     it.setEventHandler(events)
                 }
 
-                override fun onCancel(arguments: Any) {
+                override fun onCancel(arguments: Any?) {
                     it.setEventHandler(null)
                 }
             })


### PR DESCRIPTION
The bug cause the onFileLoading callback not invoking, and the logcat ouput:

```
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): Failed to open event stream
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): java.lang.NullPointerException: Parameter specified as non-null is null: method com.mr.flutter.plugin.filepicker.FilePickerPlugin$setup$1$1.onListen, parameter arguments
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at com.mr.flutter.plugin.filepicker.FilePickerPlugin$setup$1$1.onListen(Unknown Source:2)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at io.flutter.plugin.common.EventChannel$IncomingStreamRequestHandler.onListen(EventChannel.java:218)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at io.flutter.plugin.common.EventChannel$IncomingStreamRequestHandler.onMessage(EventChannel.java:197)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at android.os.Handler.handleCallback(Handler.java:959)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at android.os.Looper.loopOnce(Looper.java:232)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at android.os.Looper.loop(Looper.java:317)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at android.app.ActivityThread.main(ActivityThread.java:8592)
E/EventChannel#miguelruivo.flutter.plugins.filepickerevent( 1376): 	at java.lang.reflect.Method.invoke(Native Method)