### PR TITLE
Fixed to get folder path duplicate in Android

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -537,7 +537,9 @@ object FileUtils {
         if (documentPath.endsWith(File.separator)) {
             documentPath = documentPath.substring(0, documentPath.length - 1)
         }
-
+        if(volumePath.endsWith(documentPath)){
+            return volumePath
+        }
         return if (!documentPath.isEmpty()) {
             if (documentPath.startsWith(File.separator)) {
                 volumePath + documentPath


### PR DESCRIPTION
fix https://github.com/miguelpruivo/flutter_file_picker/issues/1767