### PR TITLE
Dont clear _result of previous method call when multiple method calls are performed at once on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 10.1.3
 ### iOS
 - Fixed an app crash when calling `.saveFile` twice and cancelling the native save operation via the UI [#1626](https://github.com/miguelpruivo/flutter_file_picker/issues/1626) [@Leapward-Koex](https://github.com/Leapward-Koex)
-- Fixed a .saveFile future never completing when `.saveFile` is called twice without waiting for the first completion. [@Leapward-Koex](https://github.com/Leapward-Koex)
+- Fixed a `.saveFile` future never completing when `.saveFile` is called twice without waiting for the first completion. [@Leapward-Koex](https://github.com/Leapward-Koex)
 
 ## 10.1.2
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.1.3
+### iOS
+- Fixed an app crash when calling `.saveFile` twice and cancelling the native save operation via the UI [#1626](https://github.com/miguelpruivo/flutter_file_picker/issues/1626) [@Leapward-Koex](https://github.com/Leapward-Koex)
+- Fixed a .saveFile future never completing when `.saveFile` is called twice without waiting for the first completion. [@Leapward-Koex](https://github.com/Leapward-Koex)
+
 ## 10.1.2
 ### Android
 - Improved mimetype detection. [@vicajilau](https://github.com/vicajilau)

--- a/ios/file_picker/Sources/file_picker/FilePickerPlugin.m
+++ b/ios/file_picker/Sources/file_picker/FilePickerPlugin.m
@@ -85,7 +85,6 @@
         result([FlutterError errorWithCode:@"multiple_request"
                                    message:@"Cancelled by a second request"
                                    details:nil]);
-        _result = nil;
         return;
     }
     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.1.2
+version: 10.1.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
When the iOS plugin detects that a method call is already in progress it returns a error result for the subsequent call **but sets the previously saved `_result` to `nil`**.

This causes a native app crash when the first (inprogress call) calls `- (void)documentPickerWasCancelled` as it tries to call `_result(nil)` but _result has been set to `nil` from the subsequent call. Fixes https://github.com/miguelpruivo/flutter_file_picker/issues/1626

This also fixes an issue where in dart if you call FilePicker.platform.saveFile twice without waiting for the first call to finish and you catch the exception from the second call, that the first call's future will never resolve (as the _result was nilled by the second call).

Example of this second issue
```dart
       String? pickedSaveFilePath;
       final future1 = FilePicker.platform.saveFile(
           allowedExtensions: [".dat"],
           type: FileType.custom,
           dialogTitle: "Title",
           fileName: "myfile.dat",
           initialDirectory: "<a valid directory>",
           bytes: new Uint8List(100));
 
       try {
         await Future.delayed(Duration(seconds: 5));
         final future2 = FilePicker.platform.saveFile(
             allowedExtensions: [".dat"],
             type: FileType.custom,
             dialogTitle: "Title",
             fileName: "myfile.dat",
             initialDirectory: "<a valid directory>",
             bytes: new Uint8List(100));
         await future2;
       } catch (e) {
         // Expected due to calling FilePicker.platform.saveFile twice without waiting for the first call to finish.
         debugPrint(e.toString());
       }
       pickedSaveFilePath = await future1;
       // This code is unreachable as future1 will never complete.
```


