### PR TITLE
Feature/issue select multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 10.1.6
-### iOS
-- Fixed an issue in android when you try to select more than one file
+### Android
+- Fixed an issue in android when you try to select more than one file[#1796](https://github.com/miguelpruivo/flutter_file_picker/issues/1796)
+- Fixed the app not filter correctly for the sleected file types [#1792](https://github.com/miguelpruivo/flutter_file_picker/issues/1792)
 
 ## 10.1.5
 ### iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.6
+### iOS
+- Fixed an issue in android when you try to select more than one file
+
 ## 10.1.5
 ### iOS
 - Fixed an app crash when calling `.saveFile` twice and cancelling the native save operation via the UI [#1626](https://github.com/miguelpruivo/flutter_file_picker/issues/1626) [@Leapward-Koex](https://github.com/Leapward-Koex)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 10.1.6
 ### Android
-- Fixed an issue in android when you try to select more than one file[#1796](https://github.com/miguelpruivo/flutter_file_picker/issues/1796)
-- Fixed the app not filter correctly for the sleected file types [#1792](https://github.com/miguelpruivo/flutter_file_picker/issues/1792)
+- Fixed an issue when you try to select more than one file[#1796](https://github.com/miguelpruivo/flutter_file_picker/issues/1796)
+- Fixed the app not filter correctly for the selected file types [#1792](https://github.com/miguelpruivo/flutter_file_picker/issues/1792)
 
 ## 10.1.5
 ### iOS

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -168,151 +168,151 @@ object FileUtils {
             }
 
 
-        if (intent.resolveActivity(activity.packageManager) != null) {
-            activity.startActivityForResult(intent, REQUEST_CODE)
-        } else {
-            Log.e(
-                FilePickerDelegate.TAG,
-                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
-            )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
-        }
-    }
-
-    fun FilePickerDelegate?.startFileExplorer(
-        type: String?,
-        isMultipleSelection: Boolean?,
-        withData: Boolean?,
-        allowedExtensions: ArrayList<String?>?,
-        compressionQuality: Int? = 0,
-        result: MethodChannel.Result
-    ) {
-        if (this?.setPendingMethodCallResult(result) == false) {
-            finishWithAlreadyActiveError(result)
-            return
-        }
-        this?.type = type
-        if (isMultipleSelection != null) {
-            this?.isMultipleSelection = isMultipleSelection
-        }
-        if (withData != null) {
-            this?.loadDataToMemory = withData
-        }
-        this?.allowedExtensions = allowedExtensions
-        if (compressionQuality != null) {
-            this?.compressionQuality = compressionQuality
-        }
-
-        this?.startFileExplorer()
-    }
-
-    fun getFileExtension(bytes: ByteArray?): String {
-        val tika = Tika()
-        val mimeType = tika.detect(bytes)
-        return mimeType.substringAfter("/")
-    }
-
-    fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
-        val tika = Tika()
-
-        if (fileName.isNullOrEmpty()) {
-            return tika.detect(bytes)
-        }
-        val detector = tika.detector
-
-        val stream = TikaInputStream.get(bytes)
-        val metadata = Metadata()
-        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
-        return detector.detect(stream, metadata).toString()
-    }
-
-    fun FilePickerDelegate.saveFile(
-        fileName: String?,
-        type: String?,
-        initialDirectory: String?,
-        bytes: ByteArray?,
-        result: MethodChannel.Result
-    ) {
-        if (!this.setPendingMethodCallResult(result)) {
-            finishWithAlreadyActiveError(result)
-            return
-        }
-        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-        intent.addCategory(Intent.CATEGORY_OPENABLE)
-        if (!fileName.isNullOrEmpty()) {
-            intent.putExtra(Intent.EXTRA_TITLE, fileName)
-        }
-        this.bytes = bytes
-        if ("dir" != type) {
-            intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
-        }
-        if (!initialDirectory.isNullOrEmpty()) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialDirectory.toUri())
-            }
-        }
-        if (intent.resolveActivity(activity.packageManager) != null) {
-            activity.startActivityForResult(intent, SAVE_FILE_CODE)
-        } else {
-            Log.e(
-                FilePickerDelegate.TAG,
-                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
-            )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
-        }
-    }
-
-    fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
-        return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
-            compressImage(uri, compressionQuality, activity.applicationContext)
-        } else {
-            uri
-        }
-    }
-
-    fun addFile(
-        activity: Activity,
-        uri: Uri,
-        loadDataToMemory: Boolean,
-        files: MutableList<FileInfo>
-    ) {
-        openFileStream(activity, uri, loadDataToMemory)?.let { file ->
-            files.add(file)
-        }
-    }
-
-    @Suppress("deprecation")
-    fun getSelectedItems(bundle: Bundle): ArrayList<Parcelable>? {
-        if (Build.VERSION.SDK_INT >= 33) {
-            return bundle.getParcelableArrayList("selectedItems", Parcelable::class.java)
-        }
-
-        return bundle.getParcelableArrayList("selectedItems")
-    }
-
-    fun getMimeTypes(allowedExtensions: ArrayList<String>?): ArrayList<String?>? {
-        if (allowedExtensions.isNullOrEmpty()) {
-            return null
-        }
-
-        val mimes = ArrayList<String?>()
-
-        for (i in allowedExtensions.indices) {
-            val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
-                allowedExtensions[i]
-            )
-            if (mime == null) {
-                Log.w(
-                    TAG,
-                    "Custom file type " + allowedExtensions[i] + " is unsupported and will be ignored."
+            if (intent.resolveActivity(activity.packageManager) != null) {
+                activity.startActivityForResult(intent, REQUEST_CODE)
+            } else {
+                Log.e(
+                    FilePickerDelegate.TAG,
+                    "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
                 )
-                continue
+                finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            }
+        }
+    }
+        fun FilePickerDelegate?.startFileExplorer(
+            type: String?,
+            isMultipleSelection: Boolean?,
+            withData: Boolean?,
+            allowedExtensions: ArrayList<String?>?,
+            compressionQuality: Int? = 0,
+            result: MethodChannel.Result
+        ) {
+            if (this?.setPendingMethodCallResult(result) == false) {
+                finishWithAlreadyActiveError(result)
+                return
+            }
+            this?.type = type
+            if (isMultipleSelection != null) {
+                this?.isMultipleSelection = isMultipleSelection
+            }
+            if (withData != null) {
+                this?.loadDataToMemory = withData
+            }
+            this?.allowedExtensions = allowedExtensions
+            if (compressionQuality != null) {
+                this?.compressionQuality = compressionQuality
             }
 
-            mimes.add(mime)
+            this?.startFileExplorer()
         }
-        return mimes
-    }
+
+        fun getFileExtension(bytes: ByteArray?): String {
+            val tika = Tika()
+            val mimeType = tika.detect(bytes)
+            return mimeType.substringAfter("/")
+        }
+
+        fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
+            val tika = Tika()
+
+            if (fileName.isNullOrEmpty()) {
+                return tika.detect(bytes)
+            }
+            val detector = tika.detector
+
+            val stream = TikaInputStream.get(bytes)
+            val metadata = Metadata()
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
+            return detector.detect(stream, metadata).toString()
+        }
+
+        fun FilePickerDelegate.saveFile(
+            fileName: String?,
+            type: String?,
+            initialDirectory: String?,
+            bytes: ByteArray?,
+            result: MethodChannel.Result
+        ) {
+            if (!this.setPendingMethodCallResult(result)) {
+                finishWithAlreadyActiveError(result)
+                return
+            }
+            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+            intent.addCategory(Intent.CATEGORY_OPENABLE)
+            if (!fileName.isNullOrEmpty()) {
+                intent.putExtra(Intent.EXTRA_TITLE, fileName)
+            }
+            this.bytes = bytes
+            if ("dir" != type) {
+                intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
+            }
+            if (!initialDirectory.isNullOrEmpty()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialDirectory.toUri())
+                }
+            }
+            if (intent.resolveActivity(activity.packageManager) != null) {
+                activity.startActivityForResult(intent, SAVE_FILE_CODE)
+            } else {
+                Log.e(
+                    FilePickerDelegate.TAG,
+                    "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
+                )
+                finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            }
+        }
+
+        fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
+            return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
+                compressImage(uri, compressionQuality, activity.applicationContext)
+            } else {
+                uri
+            }
+        }
+
+        fun addFile(
+            activity: Activity,
+            uri: Uri,
+            loadDataToMemory: Boolean,
+            files: MutableList<FileInfo>
+        ) {
+            openFileStream(activity, uri, loadDataToMemory)?.let { file ->
+                files.add(file)
+            }
+        }
+
+        @Suppress("deprecation")
+        fun getSelectedItems(bundle: Bundle): ArrayList<Parcelable>? {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return bundle.getParcelableArrayList("selectedItems", Parcelable::class.java)
+            }
+
+            return bundle.getParcelableArrayList("selectedItems")
+        }
+
+        fun getMimeTypes(allowedExtensions: ArrayList<String>?): ArrayList<String?>? {
+            if (allowedExtensions.isNullOrEmpty()) {
+                return null
+            }
+
+            val mimes = ArrayList<String?>()
+
+            for (i in allowedExtensions.indices) {
+                val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                    allowedExtensions[i]
+                )
+                if (mime == null) {
+                    Log.w(
+                        TAG,
+                        "Custom file type " + allowedExtensions[i] + " is unsupported and will be ignored."
+                    )
+                    continue
+                }
+
+                mimes.add(mime)
+            }
+            return mimes
+        }
 
     @JvmStatic
     fun getFileName(uri: Uri, context: Context): String? {

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -156,7 +156,7 @@ object FileUtils {
             } else {
                 intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    type = this@startFileExplorer.type // Obligatorio para que EXTRA_MIME_TYPES funcione
+                    type = this@startFileExplorer.type
                     putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection)
                     putExtra("multi-pick", isMultipleSelection)
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -168,15 +168,14 @@ object FileUtils {
             }
 
 
-            if (intent.resolveActivity(activity.packageManager) != null) {
-                activity.startActivityForResult(intent, REQUEST_CODE)
-            } else {
-                Log.e(
-                    FilePickerDelegate.TAG,
-                    "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
-                )
-                finishWithError("invalid_format_type", "Can't handle the provided file type.")
-            }
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivityForResult(intent, REQUEST_CODE)
+        } else {
+            Log.e(
+                FilePickerDelegate.TAG,
+                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
+            )
+            finishWithError("invalid_format_type", "Can't handle the provided file type.")
         }
     }
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -139,434 +139,447 @@ object FileUtils {
         } else {
             if (type == "image/*") {
                 intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+                val uri = (Environment.getExternalStorageDirectory().path + File.separator).toUri()
+                intent.setDataAndType(uri, type)
+                intent.type = this.type
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection)
+                intent.putExtra("multi-pick", this.isMultipleSelection)
+
+                type?.takeIf { it.contains(",") }
+                    ?.split(",")
+                    ?.filter { it.isNotEmpty() }
+                    ?.let { allowedExtensions = ArrayList(it) }
+
+                if (allowedExtensions != null) {
+                    intent.putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions)
+                }
             } else {
-                intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
-                intent.addCategory(Intent.CATEGORY_OPENABLE)
+                intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = this@startFileExplorer.type // Obligatorio para que EXTRA_MIME_TYPES funcione
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection)
+                    putExtra("multi-pick", isMultipleSelection)
+
+                    allowedExtensions?.let {
+                        putExtra(Intent.EXTRA_MIME_TYPES, it.toTypedArray())
+                    }
+                }
+
             }
-            val uri = (Environment.getExternalStorageDirectory().path + File.separator).toUri()
-            intent.setDataAndType(uri, this.type)
-            intent.type = this.type
-            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection)
-            intent.putExtra("multi-pick", this.isMultipleSelection)
 
-            type?.takeIf { it.contains(",") }
-                ?.split(",")
-                ?.filter { it.isNotEmpty() }
-                ?.let { allowedExtensions = ArrayList(it) }
 
-            if (allowedExtensions != null) {
-                intent.putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions)
-            }
-        }
-
-        if (intent.resolveActivity(activity.packageManager) != null) {
-            activity.startActivityForResult(intent, REQUEST_CODE)
-        } else {
-            Log.e(
-                FilePickerDelegate.TAG,
-                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
-            )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
-        }
-    }
-
-    fun FilePickerDelegate?.startFileExplorer(
-        type: String?,
-        isMultipleSelection: Boolean?,
-        withData: Boolean?,
-        allowedExtensions: ArrayList<String?>?,
-        compressionQuality: Int? = 0,
-        result: MethodChannel.Result
-    ) {
-        if (this?.setPendingMethodCallResult(result) == false) {
-            finishWithAlreadyActiveError(result)
-            return
-        }
-        this?.type = type
-        if (isMultipleSelection != null) {
-            this?.isMultipleSelection = isMultipleSelection
-        }
-        if (withData != null) {
-            this?.loadDataToMemory = withData
-        }
-        this?.allowedExtensions = allowedExtensions
-        if (compressionQuality != null) {
-            this?.compressionQuality = compressionQuality
-        }
-
-        this?.startFileExplorer()
-    }
-
-    fun getFileExtension(bytes: ByteArray?): String {
-        val tika = Tika()
-        val mimeType = tika.detect(bytes)
-        return mimeType.substringAfter("/")
-    }
-
-    fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
-        val tika = Tika()
-
-        if (fileName.isNullOrEmpty()) {
-            return tika.detect(bytes)
-        }
-        val detector = tika.detector
-
-        val stream = TikaInputStream.get(bytes)
-        val metadata = Metadata()
-        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
-        return detector.detect(stream, metadata).toString()
-    }
-
-    fun FilePickerDelegate.saveFile(
-        fileName: String?,
-        type: String?,
-        initialDirectory: String?,
-        bytes: ByteArray?,
-        result: MethodChannel.Result
-    ) {
-        if (!this.setPendingMethodCallResult(result)) {
-            finishWithAlreadyActiveError(result)
-            return
-        }
-        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-        intent.addCategory(Intent.CATEGORY_OPENABLE)
-        if (!fileName.isNullOrEmpty()) {
-            intent.putExtra(Intent.EXTRA_TITLE, fileName)
-        }
-        this.bytes = bytes
-        if ("dir" != type) {
-            intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
-        }
-        if (!initialDirectory.isNullOrEmpty()) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialDirectory.toUri())
-            }
-        }
-        if (intent.resolveActivity(activity.packageManager) != null) {
-            activity.startActivityForResult(intent, SAVE_FILE_CODE)
-        } else {
-            Log.e(
-                FilePickerDelegate.TAG,
-                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
-            )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
-        }
-    }
-
-    fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
-        return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
-            compressImage(uri, compressionQuality, activity.applicationContext)
-        } else {
-            uri
-        }
-    }
-
-    fun addFile(
-        activity: Activity,
-        uri: Uri,
-        loadDataToMemory: Boolean,
-        files: MutableList<FileInfo>
-    ) {
-        openFileStream(activity, uri, loadDataToMemory)?.let { file ->
-            files.add(file)
-        }
-    }
-
-    @Suppress("deprecation")
-    fun getSelectedItems(bundle: Bundle): ArrayList<Parcelable>? {
-        if (Build.VERSION.SDK_INT >= 33) {
-            return bundle.getParcelableArrayList("selectedItems", Parcelable::class.java)
-        }
-
-        return bundle.getParcelableArrayList("selectedItems")
-    }
-
-    fun getMimeTypes(allowedExtensions: ArrayList<String>?): ArrayList<String?>? {
-        if (allowedExtensions.isNullOrEmpty()) {
-            return null
-        }
-
-        val mimes = ArrayList<String?>()
-
-        for (i in allowedExtensions.indices) {
-            val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
-                allowedExtensions[i]
-            )
-            if (mime == null) {
-                Log.w(
-                    TAG,
-                    "Custom file type " + allowedExtensions[i] + " is unsupported and will be ignored."
+            if (intent.resolveActivity(activity.packageManager) != null) {
+                activity.startActivityForResult(intent, REQUEST_CODE)
+            } else {
+                Log.e(
+                    FilePickerDelegate.TAG,
+                    "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
                 )
-                continue
+                finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            }
+        }
+    }
+        fun FilePickerDelegate?.startFileExplorer(
+            type: String?,
+            isMultipleSelection: Boolean?,
+            withData: Boolean?,
+            allowedExtensions: ArrayList<String?>?,
+            compressionQuality: Int? = 0,
+            result: MethodChannel.Result
+        ) {
+            if (this?.setPendingMethodCallResult(result) == false) {
+                finishWithAlreadyActiveError(result)
+                return
+            }
+            this?.type = type
+            if (isMultipleSelection != null) {
+                this?.isMultipleSelection = isMultipleSelection
+            }
+            if (withData != null) {
+                this?.loadDataToMemory = withData
+            }
+            this?.allowedExtensions = allowedExtensions
+            if (compressionQuality != null) {
+                this?.compressionQuality = compressionQuality
             }
 
-            mimes.add(mime)
+            this?.startFileExplorer()
         }
-        return mimes
-    }
 
-    @JvmStatic
-    fun getFileName(uri: Uri, context: Context): String? {
-        var result: String? = null
+        fun getFileExtension(bytes: ByteArray?): String {
+            val tika = Tika()
+            val mimeType = tika.detect(bytes)
+            return mimeType.substringAfter("/")
+        }
 
-        try {
-            if (uri.scheme == "content") {
-                context.contentResolver.query(
-                    uri,
-                    arrayOf(OpenableColumns.DISPLAY_NAME),
-                    null,
-                    null,
-                    null
-                ).use { cursor ->
-                    if (cursor != null && cursor.moveToFirst()) {
-                        result =
-                            cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+        fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
+            val tika = Tika()
+
+            if (fileName.isNullOrEmpty()) {
+                return tika.detect(bytes)
+            }
+            val detector = tika.detector
+
+            val stream = TikaInputStream.get(bytes)
+            val metadata = Metadata()
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
+            return detector.detect(stream, metadata).toString()
+        }
+
+        fun FilePickerDelegate.saveFile(
+            fileName: String?,
+            type: String?,
+            initialDirectory: String?,
+            bytes: ByteArray?,
+            result: MethodChannel.Result
+        ) {
+            if (!this.setPendingMethodCallResult(result)) {
+                finishWithAlreadyActiveError(result)
+                return
+            }
+            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+            intent.addCategory(Intent.CATEGORY_OPENABLE)
+            if (!fileName.isNullOrEmpty()) {
+                intent.putExtra(Intent.EXTRA_TITLE, fileName)
+            }
+            this.bytes = bytes
+            if ("dir" != type) {
+                intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
+            }
+            if (!initialDirectory.isNullOrEmpty()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialDirectory.toUri())
+                }
+            }
+            if (intent.resolveActivity(activity.packageManager) != null) {
+                activity.startActivityForResult(intent, SAVE_FILE_CODE)
+            } else {
+                Log.e(
+                    FilePickerDelegate.TAG,
+                    "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
+                )
+                finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            }
+        }
+
+        fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
+            return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
+                compressImage(uri, compressionQuality, activity.applicationContext)
+            } else {
+                uri
+            }
+        }
+
+        fun addFile(
+            activity: Activity,
+            uri: Uri,
+            loadDataToMemory: Boolean,
+            files: MutableList<FileInfo>
+        ) {
+            openFileStream(activity, uri, loadDataToMemory)?.let { file ->
+                files.add(file)
+            }
+        }
+
+        @Suppress("deprecation")
+        fun getSelectedItems(bundle: Bundle): ArrayList<Parcelable>? {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return bundle.getParcelableArrayList("selectedItems", Parcelable::class.java)
+            }
+
+            return bundle.getParcelableArrayList("selectedItems")
+        }
+
+        fun getMimeTypes(allowedExtensions: ArrayList<String>?): ArrayList<String?>? {
+            if (allowedExtensions.isNullOrEmpty()) {
+                return null
+            }
+
+            val mimes = ArrayList<String?>()
+
+            for (i in allowedExtensions.indices) {
+                val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                    allowedExtensions[i]
+                )
+                if (mime == null) {
+                    Log.w(
+                        TAG,
+                        "Custom file type " + allowedExtensions[i] + " is unsupported and will be ignored."
+                    )
+                    continue
+                }
+
+                mimes.add(mime)
+            }
+            return mimes
+        }
+
+        @JvmStatic
+        fun getFileName(uri: Uri, context: Context): String? {
+            var result: String? = null
+
+            try {
+                if (uri.scheme == "content") {
+                    context.contentResolver.query(
+                        uri,
+                        arrayOf(OpenableColumns.DISPLAY_NAME),
+                        null,
+                        null,
+                        null
+                    ).use { cursor ->
+                        if (cursor != null && cursor.moveToFirst()) {
+                            result =
+                                cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                        }
+                    }
+                }
+                if (result == null) {
+                    result = uri.path?.substringAfterLast('/')
+                }
+            } catch (ex: Exception) {
+                Log.e(
+                    TAG,
+                    "Failed to handle file name: $ex"
+                )
+            }
+
+            return result
+        }
+
+        @JvmStatic
+        fun isImage(context: Context, uri: Uri): Boolean {
+            val extension = getFileExtension(context, uri)
+
+            if (extension == null) {
+                return false
+            }
+
+            return extension.contentEquals("jpg") || extension.contentEquals("jpeg")
+                    || extension.contentEquals("png") || extension.contentEquals("webp")
+        }
+
+        private fun getFileExtension(context: Context, uri: Uri): String? {
+            val contentResolver = context.contentResolver
+            val mimeType = contentResolver.getType(uri)
+            return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+        }
+
+        private fun getCompressFormat(context: Context, uri: Uri): Bitmap.CompressFormat {
+            val format = getFileExtension(context, uri)
+            return when (format!!.uppercase(Locale.getDefault())) {
+                "PNG" -> Bitmap.CompressFormat.PNG
+                "WEBP" -> Bitmap.CompressFormat.WEBP
+                else -> Bitmap.CompressFormat.JPEG
+            }
+        }
+
+        @JvmStatic
+        fun compressImage(originalImageUri: Uri, compressionQuality: Int, context: Context): Uri {
+            val compressedUri: Uri
+            try {
+                context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
+                    val compressedFile = createImageFile(context, originalImageUri)
+                    val originalBitmap = BitmapFactory.decodeStream(imageStream)
+                    // Compress and save the image
+                    val fileOutputStream = FileOutputStream(compressedFile)
+                    originalBitmap.compress(
+                        getCompressFormat(context, originalImageUri),
+                        compressionQuality,
+                        fileOutputStream
+                    )
+                    fileOutputStream.flush()
+                    fileOutputStream.close()
+                    compressedUri = Uri.fromFile(compressedFile)
+                }
+            } catch (e: IOException) {
+                throw RuntimeException(e)
+            }
+            return compressedUri
+        }
+
+        @Throws(IOException::class)
+        private fun createImageFile(context: Context, uri: Uri): File {
+            val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+            val imageFileName = "IMAGE_" + timeStamp + "_"
+            val storageDir = context.cacheDir
+            return File.createTempFile(
+                imageFileName,
+                "." + getFileExtension(context, uri),
+                storageDir
+            )
+        }
+
+        /**
+         * @param uri The Uri to check.
+         * @return Whether the Uri authority is DownloadsProvider.
+         */
+        fun isDownloadsDocument(uri: Uri): Boolean {
+            return uri.authority == "com.android.providers.downloads.documents"
+        }
+
+        @JvmStatic
+        fun clearCache(context: Context): Boolean {
+            try {
+                val cacheDir = File(context.cacheDir.toString() + "/file_picker/")
+                recursiveDeleteFile(cacheDir)
+            } catch (ex: Exception) {
+                Log.e(
+                    TAG,
+                    "There was an error while clearing cached files: $ex"
+                )
+                return false
+            }
+            return true
+        }
+
+        fun loadData(file: File, fileInfo: FileInfo.Builder) {
+            try {
+                val size = file.length().toInt()
+                val bytes = ByteArray(size)
+
+                try {
+                    val buf = BufferedInputStream(FileInputStream(file))
+                    buf.read(bytes, 0, bytes.size)
+                    buf.close()
+                } catch (e: FileNotFoundException) {
+                    Log.e(TAG, "File not found: " + e.message, null)
+                } catch (e: IOException) {
+                    Log.e(TAG, "Failed to close file streams: " + e.message, null)
+                }
+                fileInfo.withData(bytes)
+            } catch (e: Exception) {
+                Log.e(
+                    TAG,
+                    "Failed to load bytes into memory with error $e. Probably the file is too big to fit device memory. Bytes won't be added to the file this time."
+                )
+            }
+        }
+
+        @JvmStatic
+        fun openFileStream(context: Context, uri: Uri, withData: Boolean): FileInfo? {
+            var fileInputStream: InputStream? = null
+            var fileOutputStream: FileOutputStream? = null
+            val fileInfo = FileInfo.Builder()
+            val fileName = getFileName(uri, context)
+            val path =
+                context.cacheDir.absolutePath + "/file_picker/" + System.currentTimeMillis() + "/" + (fileName
+                    ?: "unamed")
+
+            val file = File(path)
+
+            if (!file.exists()) {
+                try {
+                    file.parentFile?.mkdirs()
+
+                    fileInputStream = context.contentResolver.openInputStream(uri)
+                    fileOutputStream = FileOutputStream(file)
+
+                    val out = BufferedOutputStream(fileOutputStream)
+                    val buffer = ByteArray(8192)
+                    var len: Int
+
+                    while ((fileInputStream!!.read(buffer).also { len = it }) >= 0) {
+                        out.write(buffer, 0, len)
+                    }
+                    out.flush()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to retrieve and cache file: " + e.message, e)
+                    return null
+                } finally {
+                    try {
+                        fileOutputStream?.fd?.sync()
+                        fileOutputStream?.close()
+                        fileInputStream?.close()
+                    } catch (ex: IOException) {
+                        Log.e(TAG, "Failed to close file streams: " + ex.message, ex)
                     }
                 }
             }
-            if (result == null) {
-                result = uri.path?.substringAfterLast('/')
+
+            if (withData) {
+                loadData(file, fileInfo)
             }
-        } catch (ex: Exception) {
-            Log.e(
-                TAG,
-                "Failed to handle file name: $ex"
-            )
+
+            fileInfo
+                .withPath(path)
+                .withName(fileName)
+                .withUri(uri)
+                .withSize(file.length())
+
+            return fileInfo.build()
         }
 
-        return result
-    }
-
-    @JvmStatic
-    fun isImage(context: Context, uri: Uri): Boolean {
-        val extension = getFileExtension(context, uri)
-
-        if (extension == null) {
-            return false
+        fun getPathFromTreeUri(uri: Uri): String? {
+            val docId = DocumentsContract.getTreeDocumentId(uri)
+            val parts = docId.split(":")
+            return "${Environment.getExternalStorageDirectory()}/${parts.last()}"
         }
 
-        return extension.contentEquals("jpg") || extension.contentEquals("jpeg")
-            || extension.contentEquals("png") || extension.contentEquals("webp")
-    }
-
-    private fun getFileExtension(context: Context, uri: Uri): String? {
-        val contentResolver = context.contentResolver
-        val mimeType = contentResolver.getType(uri)
-        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
-    }
-
-    private fun getCompressFormat(context: Context, uri: Uri): Bitmap.CompressFormat {
-        val format = getFileExtension(context, uri)
-        return when (format!!.uppercase(Locale.getDefault())) {
-            "PNG" -> Bitmap.CompressFormat.PNG
-            "WEBP" -> Bitmap.CompressFormat.WEBP
-            else -> Bitmap.CompressFormat.JPEG
-        }
-    }
-
-    @JvmStatic
-    fun compressImage(originalImageUri: Uri, compressionQuality: Int, context: Context): Uri {
-        val compressedUri: Uri
-        try {
-            context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
-                val compressedFile = createImageFile(context, originalImageUri)
-                val originalBitmap = BitmapFactory.decodeStream(imageStream)
-                // Compress and save the image
-                val fileOutputStream = FileOutputStream(compressedFile)
-                originalBitmap.compress(
-                    getCompressFormat(context, originalImageUri),
-                    compressionQuality,
-                    fileOutputStream
-                )
-                fileOutputStream.flush()
-                fileOutputStream.close()
-                compressedUri = Uri.fromFile(compressedFile)
-            }
-        } catch (e: IOException) {
-            throw RuntimeException(e)
-        }
-        return compressedUri
-    }
-
-    @Throws(IOException::class)
-    private fun createImageFile(context: Context, uri: Uri): File {
-        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-        val imageFileName = "IMAGE_" + timeStamp + "_"
-        val storageDir = context.cacheDir
-        return File.createTempFile(imageFileName, "." + getFileExtension(context, uri), storageDir)
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is DownloadsProvider.
-     */
-    fun isDownloadsDocument(uri: Uri): Boolean {
-        return uri.authority == "com.android.providers.downloads.documents"
-    }
-
-    @JvmStatic
-    fun clearCache(context: Context): Boolean {
-        try {
-            val cacheDir = File(context.cacheDir.toString() + "/file_picker/")
-            recursiveDeleteFile(cacheDir)
-        } catch (ex: Exception) {
-            Log.e(
-                TAG,
-                "There was an error while clearing cached files: $ex"
-            )
-            return false
-        }
-        return true
-    }
-
-    fun loadData(file: File, fileInfo: FileInfo.Builder) {
-        try {
-            val size = file.length().toInt()
-            val bytes = ByteArray(size)
-
-            try {
-                val buf = BufferedInputStream(FileInputStream(file))
-                buf.read(bytes, 0, bytes.size)
-                buf.close()
-            } catch (e: FileNotFoundException) {
-                Log.e(TAG, "File not found: " + e.message, null)
-            } catch (e: IOException) {
-                Log.e(TAG, "Failed to close file streams: " + e.message, null)
-            }
-            fileInfo.withData(bytes)
-        } catch (e: Exception) {
-            Log.e(
-                TAG,
-                "Failed to load bytes into memory with error $e. Probably the file is too big to fit device memory. Bytes won't be added to the file this time."
-            )
-        }
-    }
-
-    @JvmStatic
-    fun openFileStream(context: Context, uri: Uri, withData: Boolean): FileInfo? {
-        var fileInputStream: InputStream? = null
-        var fileOutputStream: FileOutputStream? = null
-        val fileInfo = FileInfo.Builder()
-        val fileName = getFileName(uri, context)
-        val path =
-            context.cacheDir.absolutePath + "/file_picker/" + System.currentTimeMillis() + "/" + (fileName
-                ?: "unamed")
-
-        val file = File(path)
-
-        if (!file.exists()) {
-            try {
-                file.parentFile?.mkdirs()
-
-                fileInputStream = context.contentResolver.openInputStream(uri)
-                fileOutputStream = FileOutputStream(file)
-
-                val out = BufferedOutputStream(fileOutputStream)
-                val buffer = ByteArray(8192)
-                var len: Int
-
-                while ((fileInputStream!!.read(buffer).also { len = it }) >= 0) {
-                    out.write(buffer, 0, len)
-                }
-                out.flush()
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to retrieve and cache file: " + e.message, e)
-                return null
-            } finally {
-                try {
-                    fileOutputStream?.fd?.sync()
-                    fileOutputStream?.close()
-                    fileInputStream?.close()
-                } catch (ex: IOException) {
-                    Log.e(TAG, "Failed to close file streams: " + ex.message, ex)
-                }
-            }
-        }
-
-        if (withData) {
-            loadData(file, fileInfo)
-        }
-
-        fileInfo
-            .withPath(path)
-            .withName(fileName)
-            .withUri(uri)
-            .withSize(file.length())
-
-        return fileInfo.build()
-    }
-
-    fun getPathFromTreeUri(uri: Uri): String? {
-        val docId = DocumentsContract.getTreeDocumentId(uri)
-        val parts = docId.split(":")
-        return "${Environment.getExternalStorageDirectory()}/${parts.last()}"
-    }
-
-    @JvmStatic
-    fun getFullPathFromTreeUri(treeUri: Uri?, con: Context): String? {
-        if (treeUri == null) {
-            return null
-        }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            if (isDownloadsDocument(treeUri)) {
-                val docId = DocumentsContract.getDocumentId(treeUri)
-                val extPath =
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
-                if (docId == "downloads") {
-                    return extPath
-                } else if (docId.matches("^ms[df]\\:.*".toRegex())) {
-                    val fileName = getFileName(treeUri, con)
-                    return "$extPath/$fileName"
-                } else if (docId.startsWith("raw:")) {
-                    return docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }
-                        .toTypedArray()[1]
-                }
+        @JvmStatic
+        fun getFullPathFromTreeUri(treeUri: Uri?, con: Context): String? {
+            if (treeUri == null) {
                 return null
             }
-        }
-        var volumePath = getPathFromTreeUri(treeUri)
-            ?: return File.separator
 
-        if (volumePath.endsWith(File.separator)) {
-            volumePath = volumePath.substring(0, volumePath.length - 1)
-        }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                if (isDownloadsDocument(treeUri)) {
+                    val docId = DocumentsContract.getDocumentId(treeUri)
+                    val extPath =
+                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
+                    if (docId == "downloads") {
+                        return extPath
+                    } else if (docId.matches("^ms[df]\\:.*".toRegex())) {
+                        val fileName = getFileName(treeUri, con)
+                        return "$extPath/$fileName"
+                    } else if (docId.startsWith("raw:")) {
+                        return docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }
+                            .toTypedArray()[1]
+                    }
+                    return null
+                }
+            }
+            var volumePath = getPathFromTreeUri(treeUri)
+                ?: return File.separator
 
-        var documentPath = getDocumentPathFromTreeUri(treeUri)
+            if (volumePath.endsWith(File.separator)) {
+                volumePath = volumePath.substring(0, volumePath.length - 1)
+            }
 
-        if (documentPath.endsWith(File.separator)) {
-            documentPath = documentPath.substring(0, documentPath.length - 1)
-        }
+            var documentPath = getDocumentPathFromTreeUri(treeUri)
 
-        return if (!documentPath.isEmpty()) {
-            if (documentPath.startsWith(File.separator)) {
-                volumePath + documentPath
+            if (documentPath.endsWith(File.separator)) {
+                documentPath = documentPath.substring(0, documentPath.length - 1)
+            }
+
+            return if (!documentPath.isEmpty()) {
+                if (documentPath.startsWith(File.separator)) {
+                    volumePath + documentPath
+                } else {
+                    volumePath + File.separator + documentPath
+                }
             } else {
-                volumePath + File.separator + documentPath
-            }
-        } else {
-            volumePath
-        }
-    }
-
-    private fun getDocumentPathFromTreeUri(treeUri: Uri): String {
-        val docId = DocumentsContract.getTreeDocumentId(treeUri)
-        val split = docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        return if ((split.size >= 2)) split[1]
-        else File.separator
-    }
-
-    private fun recursiveDeleteFile(file: File?) {
-        if (file == null || !file.exists()) {
-            return
-        }
-
-        if (file.listFiles() != null && file.isDirectory) {
-            for (child in file.listFiles().orEmpty()) {
-                recursiveDeleteFile(child)
+                volumePath
             }
         }
 
-        file.delete()
+        private fun getDocumentPathFromTreeUri(treeUri: Uri): String {
+            val docId = DocumentsContract.getTreeDocumentId(treeUri)
+            val split = docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+            return if ((split.size >= 2)) split[1]
+            else File.separator
+        }
+
+        private fun recursiveDeleteFile(file: File?) {
+            if (file == null || !file.exists()) {
+                return
+            }
+
+            if (file.listFiles() != null && file.isDirectory) {
+                for (child in file.listFiles().orEmpty()) {
+                    recursiveDeleteFile(child)
+                }
+            }
+
+            file.delete()
+        }
     }
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.1.5
+version: 10.1.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
The issue with the Android file picker not supporting multiple file selection has been resolved. The implementation now correctly uses the appropriate intent configuration to allow users to select multiple files at once.

Additionally, the file picker now filters and displays only the specified file types, improving usability and ensuring users can only choose valid file formats.

- Fixed an issue in android when you try to select more than one file[#1796](https://github.com/miguelpruivo/flutter_file_picker/issues/1796)
- Fixed the app not filter correctly for the sleected file types [#1792](https://github.com/miguelpruivo/flutter_file_picker/issues/1792)