### PR TITLE
(feat) add broader uri to path conversion handling

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -162,7 +162,7 @@ object FileUtils {
                         putExtra(Intent.EXTRA_MIME_TYPES, it.toTypedArray())
                     }
                 }
-                
+
             }
 
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -7,7 +7,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
-import android.database.Cursor
 import android.os.Bundle
 import android.os.Environment
 import android.os.Parcelable
@@ -71,11 +70,11 @@ object FileUtils {
                     var uri = processUri(activity, data.data!!, compressionQuality)
 
                     if (type == "dir") {
-                        var docUriTree = DocumentsContract.buildDocumentUriUsingTree(
+                        uri = DocumentsContract.buildDocumentUriUsingTree(
                             uri,
                             DocumentsContract.getTreeDocumentId(uri)
                         )
-                        val dirPath = getFullPathFromTreeUri(uri, docUriTree, activity)
+                        val dirPath = getFullPathFromTreeUri(uri, activity)
                         if (dirPath != null) {
                             finishWithSuccess(dirPath)
                         } else {
@@ -515,7 +514,7 @@ object FileUtils {
     }
 
     @JvmStatic
-    fun getFullPathFromTreeUri(uri: Uri, treeUri: Uri?, con: Context): String? {
+    fun getFullPathFromTreeUri(treeUri: Uri?, con: Context): String? {
         if (treeUri == null) {
             return null
         }

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -162,6 +162,7 @@ object FileUtils {
                         putExtra(Intent.EXTRA_MIME_TYPES, it.toTypedArray())
                     }
                 }
+                
             }
 
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -514,50 +514,10 @@ object FileUtils {
         return "${Environment.getExternalStorageDirectory()}/${parts.last()}"
     }
 
-    private fun isGooglePhotosUri(uri: Uri): Boolean {
-        return "com.google.android.apps.photos.content" == uri.authority
-    }
-
-    private fun getDataColumn(
-        context: Context,
-        uri: Uri?,
-        selection: String?,
-        selectionArgs: Array<String>?
-    ): String {
-        var cursor: Cursor? = null
-        val column = "_data"
-        val projection = arrayOf(column)
-
-        try {
-            cursor = context.contentResolver.query(uri!!, projection, selection, selectionArgs, null)
-            if (cursor != null && cursor.moveToFirst()) {
-                val index = cursor.getColumnIndexOrThrow(column)
-                return cursor.getString(index)
-            }
-        } finally {
-            cursor?.close()
-        }
-
-        return ""
-    }
-
     @JvmStatic
     fun getFullPathFromTreeUri(uri: Uri, treeUri: Uri?, con: Context): String? {
         if (treeUri == null) {
             return null
-        }
-
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            if ("content".equals(treeUri.scheme, ignoreCase = true)) {
-                return when {
-                    isGooglePhotosUri(treeUri) -> uri.lastPathSegment ?: ""
-                    else -> getDataColumn(con, treeUri, null, null)
-                }
-            }
-
-            if ("file".equals(treeUri.scheme, ignoreCase = true)) {
-                return treeUri.path ?: ""
-            }
         }
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
+import android.database.Cursor
 import android.os.Bundle
 import android.os.Environment
 import android.os.Parcelable
@@ -70,11 +71,11 @@ object FileUtils {
                     var uri = processUri(activity, data.data!!, compressionQuality)
 
                     if (type == "dir") {
-                        uri = DocumentsContract.buildDocumentUriUsingTree(
+                        var docUriTree = DocumentsContract.buildDocumentUriUsingTree(
                             uri,
                             DocumentsContract.getTreeDocumentId(uri)
                         )
-                        val dirPath = getFullPathFromTreeUri(uri, activity)
+                        val dirPath = getFullPathFromTreeUri(uri, docUriTree, activity)
                         if (dirPath != null) {
                             finishWithSuccess(dirPath)
                         } else {
@@ -162,7 +163,6 @@ object FileUtils {
                         putExtra(Intent.EXTRA_MIME_TYPES, it.toTypedArray())
                     }
                 }
-
             }
 
 
@@ -407,6 +407,14 @@ object FileUtils {
     private fun isDownloadsDocument(uri: Uri): Boolean {
         return uri.authority == "com.android.providers.downloads.documents"
     }
+    
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is in External Storage Documents.
+     */
+    fun isExternalStorageDocument(uri: Uri): Boolean {
+        return uri.authority == "com.android.externalstorage.documents"
+    }
 
     @JvmStatic
     fun clearCache(context: Context): Boolean {
@@ -506,13 +514,74 @@ object FileUtils {
         return "${Environment.getExternalStorageDirectory()}/${parts.last()}"
     }
 
+    private fun isGooglePhotosUri(uri: Uri): Boolean {
+        return "com.google.android.apps.photos.content" == uri.authority
+    }
+
+    private fun getDataColumn(
+        context: Context,
+        uri: Uri?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): String {
+        var cursor: Cursor? = null
+        val column = "_data"
+        val projection = arrayOf(column)
+
+        try {
+            cursor = context.contentResolver.query(uri!!, projection, selection, selectionArgs, null)
+            if (cursor != null && cursor.moveToFirst()) {
+                val index = cursor.getColumnIndexOrThrow(column)
+                return cursor.getString(index)
+            }
+        } finally {
+            cursor?.close()
+        }
+
+        return ""
+    }
+
     @JvmStatic
-    fun getFullPathFromTreeUri(treeUri: Uri?, con: Context): String? {
+    fun getFullPathFromTreeUri(uri: Uri, treeUri: Uri?, con: Context): String? {
         if (treeUri == null) {
             return null
         }
 
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            if ("content".equals(treeUri.scheme, ignoreCase = true)) {
+                return when {
+                    isGooglePhotosUri(treeUri) -> uri.lastPathSegment ?: ""
+                    else -> getDataColumn(con, treeUri, null, null)
+                }
+            }
+
+            if ("file".equals(treeUri.scheme, ignoreCase = true)) {
+                return treeUri.path ?: ""
+            }
+        }
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            if (isExternalStorageDocument(treeUri)) {
+                val docId = DocumentsContract.getDocumentId(treeUri)
+                val split = docId.split(":")
+                val type = split[0]
+
+                if ((Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q && "home".equals(type, ignoreCase = true)) || "primary".equals(type, ignoreCase = true)) {
+                    return "${Environment.getExternalStorageDirectory()}/Documents/${split[1]}"
+                } else if ("primary".equals(type, ignoreCase = true)) {
+                    return "${Environment.getExternalStorageDirectory()}/${split[1]}"
+                } else {
+                    val externalStorageVolumes = con.getExternalFilesDirs(null)
+                    for (externalFile in externalStorageVolumes) {
+                        val path = externalFile.absolutePath
+                        if (path.contains(type)) {
+                            val subPath = path.substringBefore("/Android")
+                            return "$subPath/${split[1]}"
+                        }
+                    }
+                }
+            }
+
             if (isDownloadsDocument(treeUri)) {
                 val docId = DocumentsContract.getDocumentId(treeUri)
                 val extPath =


### PR DESCRIPTION
This branch has been rebased on the latest master

Main changes included are to add support for older Android versions and accurately converting paths across the board.


#### Tested with:
-  Documents folder on Android 10
-  Downloads folder on Android 10
-  Documents folder on Android KitKat