### PR TITLE
correct external storage folder path on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.9
+### Android
+- Fixed an issue when a folder is selected on an external storage [#1801](https://github.com/miguelpruivo/flutter_file_picker/issues/1801)
+
 ## 10.1.8
 ### Android
 - Fixed an issue when a folder is selected [#1802](https://github.com/miguelpruivo/flutter_file_picker/issues/1802)

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -503,7 +503,21 @@ object FileUtils {
     private fun getPathFromTreeUri(uri: Uri): String {
         val docId = DocumentsContract.getTreeDocumentId(uri)
         val parts = docId.split(":")
-        return "${Environment.getExternalStorageDirectory()}/${parts.last()}"
+
+        // Check if the URI corresponds to external storage
+        return if (parts.size > 1) {
+            val volumeId = parts[0]
+            val path = parts[1]
+
+            // Map volume ID to external storage path
+            if ("primary".equals(volumeId, ignoreCase = true)) {
+                "${Environment.getExternalStorageDirectory()}/$path"
+            } else {
+                "/storage/$volumeId/$path"
+            }
+        } else {
+            "${Environment.getExternalStorageDirectory()}/${parts.last()}"
+        }
     }
 
     @JvmStatic

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.1.8
+version: 10.1.9
 
 dependencies:
   flutter:


### PR DESCRIPTION
This change fixes #1801.

Tested with a flash drive connected over OTG to Android phone and also external SD Card in Amazon Fire tablet.