### PR TITLE
Feature/remove unnecesary code msd msf files

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -74,7 +74,7 @@ object FileUtils {
                             uri,
                             DocumentsContract.getTreeDocumentId(uri)
                         )
-                        val dirPath = getFullPathFromTreeUri(uri, activity)
+                        val dirPath = getFullPathFromTreeUri(uri)
                         if (dirPath != null) {
                             finishWithSuccess(dirPath)
                         } else {
@@ -521,7 +521,7 @@ object FileUtils {
     }
 
     @JvmStatic
-    fun getFullPathFromTreeUri(treeUri: Uri?, con: Context): String? {
+    fun getFullPathFromTreeUri(treeUri: Uri?): String? {
         if (treeUri == null) {
             return null
         }
@@ -533,9 +533,6 @@ object FileUtils {
                     Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
                 if (docId == "downloads") {
                     return extPath
-                } else if (docId.matches("^ms[df]:.*".toRegex())) {
-                    val fileName = getFileName(treeUri, con)
-                    return "$extPath/$fileName"
                 } else if (docId.startsWith("raw:")) {
                     return docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }
                         .toTypedArray()[1]
@@ -543,6 +540,7 @@ object FileUtils {
                 return null
             }
         }
+
         var volumePath = getPathFromTreeUri(treeUri)
 
         if (volumePath.endsWith(File.separator)) {

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -288,7 +288,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
 
     setState(() {
       _isLoading = true;
-      pickedFiles = null;
       _userAborted = true;
     });
   }

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -288,7 +288,8 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
 
     setState(() {
       _isLoading = true;
-      _userAborted = false;
+      pickedFiles = null;
+      _userAborted = true;
     });
   }
 


### PR DESCRIPTION
- Removed the condition that validated whether a file ID was in the msf or msd format. This check is now obsolete, as such formats are no longer used in current systems.

- Fixed an issue where temporary files were deleted but the associated selected file information remained. Now, deleting temporary files also clears the corresponding selected file data.