### PR TITLE
Introduce bool flag to control upload behavior on window blur

### DIFF
--- a/lib/_internal/file_picker_web.dart
+++ b/lib/_internal/file_picker_web.dart
@@ -50,6 +50,7 @@ class FilePickerWeb extends FilePicker {
     bool withReadStream = false,
     bool lockParentWindow = false,
     bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
     int compressionQuality = 0,
   }) async {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
@@ -165,8 +166,10 @@ class FilePickerWeb extends FilePicker {
     uploadInput.addEventListener('change', changeEventListener.toJS);
     uploadInput.addEventListener('cancel', cancelledEventListener.toJS);
 
-    // Listen focus event for cancelled
-    window.addEventListener('focus', cancelledEventListener.toJS);
+    if (cancelUploadOnWindowBlur) {
+      // Listen focus event for cancelled
+      window.addEventListener('focus', cancelledEventListener.toJS);
+    }
 
     //Add input element to the page body
     Node? firstChild = _target.firstChild;


### PR DESCRIPTION
See issue #1833 for more details.

Feature:
This PR adds a new configuration flag for uploads on web which prevents upload cancellation when window focus is lost. 

Reason:
Various extensions (e.g. exfiltration scanners) process upload files and remove focus from a window. Thereby uploads are cancelled due to the windows focus cancellation listener.