### PR TITLE
Fix picking CSV files on Android

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -302,6 +302,15 @@ object FileUtils {
             return null
         }
 
+        // On Android, the CSV mime type from getMimeTypeFromExtension() returns
+        // "text/comma-separated-values" which is non-standard and doesn't filter
+        // CSV files in Google Drive.
+        // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+        // (see https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java#439)
+        val CSV_EXTENSION = "csv";
+        val CSV_MIME_TYPE = "text/csv";
+
+
         val mimes = ArrayList<String?>()
 
         for (i in allowedExtensions.indices) {
@@ -317,6 +326,10 @@ object FileUtils {
             }
 
             mimes.add(mime)
+            if(allowedExtensions[i].equals(CSV_EXTENSION)) {
+                // Add the standard CSV mime type.
+                mimes.add(CSV_MIME_TYPE);
+            }
         }
         return mimes
     }


### PR DESCRIPTION
This fixes an issue on Android where the file picker does not allow CSV files to be picked when using the Custom option.