### PR TITLE
chore: Enable flutter_lints and fix warnings

### DIFF
--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -262,7 +262,7 @@ class FilePickerWindows extends FilePicker {
   }
 
   void validateFileName(String fileName) {
-    if (fileName.contains(RegExp(r'[<>:\/\\|?*"]'))) {
+    if (fileName.contains(RegExp(r'[<>:/\\|?*"]'))) {
       throw IllegalCharacterInFileNameException(
           'Reserved characters may not be used in file names. See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions');
     }

--- a/lib/src/windows/file_picker_windows.dart
+++ b/lib/src/windows/file_picker_windows.dart
@@ -112,7 +112,7 @@ class FilePickerWindows extends FilePicker {
 
     int hr = CoInitializeEx(
       nullptr,
-      COINIT.COINIT_APARTMENTTHREADED | COINIT.COINIT_DISABLE_OLE1DDE,
+      COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE,
     );
 
     if (!SUCCEEDED(hr)) {
@@ -128,9 +128,9 @@ class FilePickerWindows extends FilePicker {
         if (!SUCCEEDED(hr)) throw WindowsException(hr);
 
         final options = optionsPointer.value |
-            FILEOPENDIALOGOPTIONS.FOS_PICKFOLDERS |
-            FILEOPENDIALOGOPTIONS.FOS_FORCEFILESYSTEM |
-            FILEOPENDIALOGOPTIONS.FOS_NOCHANGEDIR;
+            FOS_PICKFOLDERS |
+            FOS_FORCEFILESYSTEM |
+            FOS_NOCHANGEDIR;
         hr = fileDialog.setOptions(options);
         if (!SUCCEEDED(hr)) throw WindowsException(hr);
       } finally {
@@ -178,7 +178,7 @@ class FilePickerWindows extends FilePicker {
 
         final item = IShellItem(ppv.cast());
         final pathPtr = calloc<Pointer<Utf16>>();
-        hr = item.getDisplayName(SIGDN.SIGDN_FILESYSPATH, pathPtr);
+        hr = item.getDisplayName(SIGDN_FILESYSPATH, pathPtr);
         if (SUCCEEDED(hr)) {
           selectedPath = pathPtr.value.toDartString();
         }
@@ -261,7 +261,7 @@ class FilePickerWindows extends FilePicker {
     }
   }
 
-  validateFileName(String fileName) {
+  void validateFileName(String fileName) {
     if (fileName.contains(RegExp(r'[<>:\/\\|?*"]'))) {
       throw IllegalCharacterInFileNameException(
           'Reserved characters may not be used in file names. See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   web: ^1.1.0
 
 dev_dependencies:
-  lints: ^5.1.1
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-setUpTestFiles(
+void setUpTestFiles(
   String appTestFilePath,
   String imageTestFilePath,
   String pdfTestFilePath,
@@ -20,7 +20,7 @@ setUpTestFiles(
   ).copySync(yamlTestFilePath);
 }
 
-tearDownTestFiles(
+void tearDownTestFiles(
   String appTestFilePath,
   String imageTestFilePath,
   String pdfTestFilePath,


### PR DESCRIPTION
This PR improves the overall code quality and maintainability of the project by introducing `flutter_lints` and addressing the issues it identified.

#### Changes

*   Added the `flutter_lints` package to `dev_dependencies` to enforce modern Dart and Flutter styling conventions.
*   Ran `dart fix --apply` and manually fixed all new linter warnings across the codebase.
*   This includes changes such as:
    *   Adding `void` to some missing functions.
    *   Correcting Regexp annotation on Windows.

This effort ensures the code is more consistent, readable, and less prone to common errors.