### PR TITLE
fix(android): Use wildcard MIME type for plain text to preserve file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.2
+### Android
+- Fixed an issue where some files would incorrectly append a `.txt` extension when saving files on Android. 
+
 ## 10.2.1
 ### Android
 - Fixed an issue where the image upload would not display the loading indicator.

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -244,7 +244,12 @@ object FileUtils {
         this.bytes = bytes
         if ("dir" != type) {
             try {
-                intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
+                val detectedMimeType = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
+                if (detectedMimeType == "text/plain") {
+                    intent.type = "*/*"
+                } else {
+                    intent.type = detectedMimeType
+                }
             } catch (t: Throwable) {
                 intent.type = "*/*"
                 Log.e(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.2.1
+version: 10.2.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Fix for Issue #1843: Prevent `.txt` Extension from Being Appended on Android
This PR addresses [Issue #1843](https://github.com/miguelpruivo/flutter_file_picker/issues/1843), where Android appends a `.txt` extension to files when using the MIME type `text/plain`, even if a different extension is specified in `Intent.EXTRA_TITLE`.

### The Problem
On Android, when using `Intent.ACTION_CREATE_DOCUMENT` with MIME type set to `text/plain`, the system automatically assumes the file must have a `.txt` extension. This results in filenames like:

- `config.json` → `config.json.txt`
- `data.csv` → `data.csv.txt`

This behavior affects users saving structured text data such as JSON, CSV, or log files, where the extension is semantically important.

### The Fix
To resolve this, we now:

- Detect when the MIME type is `text/plain`.
- Override it with the generic wildcard `*/*`.
  
This instructs Android not to force any specific extension and fully respects the filename given in `Intent.EXTRA_TITLE`.

### Results
- Files like `config.json` are saved correctly without an unwanted `.txt` suffix.
- No regressions expected for other MIME types.
- Fix remains backward-compatible with previous Android behavior.

### Platform
- Android
