### PR TITLE
Android: Avoid MIME filter error when custom MIME types are unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.4
+### Android
+- Fixed an issue where custom MIME types were failing to load picking files on Chromebook. [#1858](https://github.com/miguelpruivo/flutter_file_picker/issues/1858)
+
 ## 10.2.3
 ### General
 - Fixed build failures on Flutter 3.24 caused by changes to address Win32 deprecation warnings on Windows. [#1855](https://github.com/miguelpruivo/flutter_file_picker/issues/1855)

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -31,7 +31,7 @@ class FilePickerDelegate(
     var loadDataToMemory = false
     var type: String? = null
     var compressionQuality = 0
-    var allowedExtensions: ArrayList<String?>? = null
+    var allowedExtensions: ArrayList<String>? = null
     var eventSink: EventSink? = null
     var bytes: ByteArray? = null
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -146,22 +146,14 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
             "custom" -> {
                 val allowedExtensions =
                     getMimeTypes(arguments?.get("allowedExtensions") as ArrayList<String>?)
-                if (allowedExtensions.isNullOrEmpty()) {
-                    result.error(
-                        TAG,
-                        "Unsupported filter. Ensure using extension without dot (e.g., jpg, not .jpg).",
-                        null
-                    )
-                } else {
-                    delegate?.startFileExplorer(
-                        resolveType(method),
-                        arguments?.get("allowMultipleSelection") as Boolean?,
-                        arguments?.get("withData") as Boolean?,
-                        allowedExtensions,
-                        arguments?.get("compressionQuality") as Int?,
-                        result
-                    )
-                }
+                delegate?.startFileExplorer(
+                    resolveType(method),
+                    arguments?.get("allowMultipleSelection") as Boolean?,
+                    arguments?.get("withData") as Boolean?,
+                    allowedExtensions,
+                    arguments?.get("compressionQuality") as Int?,
+                    result
+                )
             }
 
             else -> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.2.3
+version: 10.2.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Summary
- When `MimeTypeMap` cannot resolve one or more custom extensions to a MIME type, the plugin now adds `[*/*]` into `Intent.EXTRA_MIME_TYPES` instead of failing or passing an invalid/empty list.
- Refactored saveFile implementation reorganizing the implementation following same flow. 

Rationale
- `MimeTypeMap.getMimeTypeFromExtension` can return `null` for custom types (e.g., `.quiz`, `.maso`). On some devices like Chromebooks, this leads to inconsistent behavior. Not applying a restrictive filter is preferable to silently failing.

Notes
- No Dart API changes.
- Behavior only changes when the allowed extensions cannot be resolved to known MIME types; otherwise, MIME filters are applied as before.

This resolve: https://github.com/miguelpruivo/flutter_file_picker/issues/1858
