### PR TITLE
Release 10.3.0

### DIFF
--- a/.github/workflows/pub.yml
+++ b/.github/workflows/pub.yml
@@ -1,0 +1,26 @@
+name: Publish package to pub.dev
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image:  google/dart:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup credentials
+        run: |
+          mkdir -p ~/.pub-cache 
+          cat <<EOF > ~/.pub-cache/credentials.json
+          {
+            "accessToken":"${{ secrets.OAUTH_ACCESS_TOKEN }}",
+            "refreshToken":"${{ secrets.OAUTH_REFRESH_TOKEN }}",
+            "tokenEndpoint":"https://accounts.google.com/o/oauth2/token",
+            "scopes": [ "openid", "https://www.googleapis.com/auth/userinfo.email" ],
+            "expiration": 1636213189469
+          }
+          EOF
+      - name: Publish package
+        run: pub publish -f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Android
 - Fixed an issue where CSV files were not properly filtered during file selection. [#1849](https://github.com/miguelpruivo/flutter_file_picker/pull/1849) [@SoftWyer](https://github.com/SoftWyer)
 
+### Web
+- Introduced bool flag to control upload behavior on window blur. [#1833](https://github.com/miguelpruivo/flutter_file_picker/issues/1833) [@mugglmenzel](https://github.com/mugglmenzel)
+
 ## 10.2.4
 ### Android
 - Fixed an issue where custom MIME types were failing to load picking files on Chromebook. [#1858](https://github.com/miguelpruivo/flutter_file_picker/issues/1858) [@vicajilau](https://github.com/vicajilau)

--- a/lib/src/file_picker_io.dart
+++ b/lib/src/file_picker_io.dart
@@ -92,7 +92,7 @@ class FilePickerIO extends FilePicker {
       );
     }
     try {
-      _eventSubscription?.cancel();
+      await _eventSubscription?.cancel();
       if (onFileLoading != null) {
         _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
               (data) => onFileLoading((data is bool && data)


### PR DESCRIPTION
This pull request restores the previous workflow for publishing packages to pub.dev. Since we still need Miguel to change the settings on pub.dev and he is currently OOO, we are reverting to the old mechanism to publish version 10.3.0. It also updates the changelog to include a web-specific feature and improves resource management in the IO file picker implementation. The most important changes are summarized below:

**CI/CD Automation:**

* Added a new GitHub Actions workflow (`.github/workflows/pub.yml`) to automate publishing the package to pub.dev when changes are pushed to the `master` branch, including credential setup and publishing steps.

**Added entry:**

* Updated `CHANGELOG.md` to document the introduction of a boolean flag that controls upload behavior on window blur for the web platform.

**Code Quality & Resource Management:**

* Improved the cancellation of the file loading event subscription in `FilePickerIO` by making it asynchronous with `await`, ensuring proper resource cleanup.