### PR TITLE
Update Flutter version matrix in CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter: [ '3.24.0', '3.27.0', '3.29.0', 'stable', 'beta' ]
+        flutter: [ '3.24.0', '3.27.0', '3.29.0', '3.32.0', 'stable', 'beta' ]
     name: Tests on Flutter ${{ matrix.flutter }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by adding Flutter version `3.32.0` to the test matrix because `stable` now is not `3.32.0` anymore, [3.35.0 just arrived](https://medium.com/flutter/whats-new-in-flutter-3-35-c58ef72e3766). This ensures that automated tests will run against the full list of Flutter releases.