### PR TITLE
Upgrade JVM target version to 11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
         implementation "org.apache.tika:tika-core:3.2.0"
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     if (project.android.hasProperty("namespace")) {


### PR DESCRIPTION
Fixes #1891 

See https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/#specifying-jvm-bytecode-targets-9-–-12

Now both the example app and the plugin have the same JVM target version.