### PR TITLE
ci: add dedicated web build job

### DIFF
--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -2,9 +2,12 @@ export 'src/file_picker.dart';
 export 'src/api/platform_file.dart';
 export 'src/api/file_picker_result.dart';
 export 'src/api/file_picker_types.dart';
+
+// Platform-specific implementations are exported only for plugin registration.
+// These exports are hidden on Web to avoid dart:ffi and dart:io compatibility issues.
 export 'src/platform/linux/file_picker_linux.dart'
-    if (dart.library.html) 'src/web_hysteresis.dart';
+    if (dart.library.html) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/macos/file_picker_macos.dart'
-    if (dart.library.html) 'src/web_hysteresis.dart';
+    if (dart.library.html) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/windows/file_picker_windows.dart'
-    if (dart.library.html) 'src/web_hysteresis.dart';
+    if (dart.library.html) 'src/platform/web/file_picker_web.dart';

--- a/lib/src/web_hysteresis.dart
+++ b/lib/src/web_hysteresis.dart
@@ -1,1 +1,0 @@
-// This file is intentionally empty to hide desktop-specific exports on Web.


### PR DESCRIPTION
- Adds a dedicated job to build the example app for Web platform.
- Fixed: https://github.com/miguelpruivo/flutter_file_picker/issues/1933