### PR TITLE
feat(example): Reset picked files when aborting

### DIFF
--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -172,6 +172,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   }
 
   void _clearCachedFiles() async {
+    pickedFiles = [];
     _resetState();
     try {
       bool? result = await FilePicker.clearTemporaryFiles();
@@ -293,7 +294,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     setState(() {
       _isLoading = true;
       _userAborted = true;
-      pickedFiles = [];
     });
   }
 


### PR DESCRIPTION
Resets the list of `pickedFiles` to an empty list when the user aborts the file picking process. This ensures that previously selected files are cleared from the UI when the operation is canceled.