### PR TITLE
Fix Android breaking changes with AGP 9.0 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 10.3.10
+
+#### Android
+
+- Fixed missing Kotlin compiler options for AGP 9.0 compatibility.
+- Fixed Android build by enable kotlin-android plugin so FilePickerPlugin is compiled under current Flutter tooling.
+
 ## 10.3.9
 
 #### Android

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 group 'com.mr.flutter.plugin.filepicker'
 version '1.0-SNAPSHOT'
 
+
 buildscript {
     ext {
         kotlin_version = '1.8.22'
@@ -24,6 +25,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
     compileSdk flutter.compileSdkVersion
@@ -51,6 +53,12 @@ android {
 
     if (project.android.hasProperty("namespace")) {
         namespace 'com.mr.flutter.plugin.filepicker' 
+    }
+
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 dependencies {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.3.9
+version: 10.3.10
 
 dependencies:
   flutter:


### PR DESCRIPTION
This pull request addresses breaking changes introduced in Android Gradle Plugin (AGP) 9.0, which now requires JDK 17 or higher. The build.gradle file has been updated to include the necessary Kotlin compiler options as recommended by the [official Flutter migration guide](https://docs.flutter.dev/).

Additionally, I have applied the Kotlin Android plugin. Without this plugin, Kotlin code fails to compile, causing GeneratedPluginRegistrant to throw a "cannot find symbol: FilePickerPlugin" error on current Flutter versions (which still ship with AGP 8).