### PR TITLE
Update tika-core to 3.2.3 without breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 10.3.10
+
+#### Android
+
+- Updated Tika library to resolve vulnerability [ID].
+- Reverted breaking changes accidentally introduced in 10.3.9 to maintain Semantic Versioning compliance.
+
+## 10.3.9
+
+#### Android
+
+- Updated Apache Tika to 3.2.3 to address CVE-2025-66516 and
+CVE-2025-54988 (Critical XXE vulnerability).
+- Support Gradle 9
+
 ## 10.3.8
 ### iOS
 - Rename FileUtils to FilePickerUtils [#1921](https://github.com/miguelpruivo/flutter_file_picker/issues/1921)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ android {
         implementation 'androidx.core:core:1.15.0'
         implementation 'androidx.annotation:annotation:1.9.1'
         implementation "androidx.lifecycle:lifecycle-runtime:2.8.7"
-        implementation "org.apache.tika:tika-core:3.2.0"
+        implementation "org.apache.tika:tika-core:3.2.3"
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.toString()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.3.8
+version: 10.3.10
 
 dependencies:
   flutter:


### PR DESCRIPTION
I have created this PR specifically to address the Tika security vulnerability without including the breaking changes currently on main.

**Technical Implementation**: This branch is based on v10.3.8 (the last stable release).

**Recommended Action for Maintainers**: Since `main` is currently ahead with breaking changes, please do the following:

1. Create a new branch called `maintenance/v10` starting from the v10.3.8 tag.
2. Change the Base Branch of this PR to that new `maintenance/v10` branch.
3. Merge and publish as v10.3.10

This protects the community from a 'breaking' patch while satisfying security requirements."