### PR TITLE
Remove deprecated dart:html reference

### DIFF
--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -6,8 +6,8 @@ export 'src/api/file_picker_types.dart';
 // Platform-specific implementations are exported only for plugin registration.
 // These exports are hidden on Web to avoid dart:ffi and dart:io compatibility issues.
 export 'src/platform/linux/file_picker_linux.dart'
-    if (dart.library.html) 'src/platform/web/file_picker_web.dart';
+    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/macos/file_picker_macos.dart'
-    if (dart.library.html) 'src/platform/web/file_picker_web.dart';
+    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/windows/file_picker_windows.dart'
-    if (dart.library.html) 'src/platform/web/file_picker_web.dart';
+    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';


### PR DESCRIPTION
This was something I overlooked. Since `dart:html` is not available for WASM (it is deprecated), these conditionals were wrong.