### PR TITLE
Merge Hotfix v10.3.10 to Master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-## 10.3.9
-
+## 10.3.10
+#### General
+- Reverted breaking changes accidentally introduced in 10.3.9 to maintain Semantic Versioning compliance.
 #### Android
+- Updated Tika library to resolve vulnerability CVE-2025-66516 and CVE-2025-54988 (Critical XXE vulnerability).
 
-- Updated Apache Tika to 3.2.3 to address CVE-2025-66516 and
-  CVE-2025-54988 (Critical XXE vulnerability).
+## 10.3.9
+#### Android
+- Updated Apache Tika to 3.2.3 to address CVE-2025-66516 and CVE-2025-54988 (Critical XXE vulnerability).
 - Support Gradle 9
 
 ## 10.3.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 10.3.9
+version: 10.3.10
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR merges the hotfix release `v10.3.10` back into `master`.
It restores the history and resolves conflicts encountered during the merge of the hotfix branch.

**Before doing anything here, I suggest you read the commentary on what happened here:** https://github.com/miguelpruivo/flutter_file_picker/pull/1953#issuecomment-3809251517

**Changes:**
- Merged `hotfix/v10.3.8-restore` into `master` (via `merge/v10.3.10-fix`).
- Resolved conflicts in `CHANGELOG.md`, `pubspec.yaml`, and `android/build.gradle`.
