### PR TITLE
fix fileType selection (audio, video, media) in Android

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -152,7 +152,7 @@ object FileUtils {
         } else {
             if (type == "image/*") {
                 // Use ACTION_PICK for images to allow using the Gallery app, which provides a better UX for image selection.
-                intent = Intent(Intent.ACTION_PICK)
+                intent = Intent(Intent.ACTION_GET_CONTENT)
                 val uri = (Environment.getExternalStorageDirectory().path + File.separator).toUri()
                 intent.setDataAndType(uri, type)
                 intent.type = this.type
@@ -167,7 +167,25 @@ object FileUtils {
                 if (allowedExtensions != null) {
                     intent.putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions)
                 }
-            } else {
+            }
+            else if (type == "audio/*" || type == "video/*"){
+                // Utilizza ACTION_GET_CONTENT per media (immagini, audio, video)
+                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    this.type = this@startFileExplorer.type
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
+                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
+                }
+            }
+            else if (type == "media") {
+                intent = Intent(Intent.ACTION_GET_CONTENT)
+                intent.type = "*/*" // Tipo base generico
+                val mimeTypes = arrayOf("image/*", "video/*", "audio/*")
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes) // Filtra solo i media
+                intent.addCategory(Intent.CATEGORY_OPENABLE)
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection)
+            }
+            else {
                 // Use ACTION_OPEN_DOCUMENT to allow selecting files from any document provider (SAF).
                 // We prefer ACTION_OPEN_DOCUMENT over ACTION_GET_CONTENT because it offers persistent
                 // access to the files via URI permissions, which is crucial for some use cases


### PR DESCRIPTION
To fix the problem that in Android the type selector does not consider the "audio" "video" and "media "choices as showed in this video


https://github.com/user-attachments/assets/fefa871e-e25a-4fb1-b1f6-ae6fdceda7d1

