### PR TITLE
fix fileType selection (audio, video, media) in Android

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -39,7 +39,7 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
                 "audio" -> "audio/*"
                 "image" -> "image/*"
                 "video" -> "video/*"
-                "media" -> "image/*,video/*"
+                "media" -> "media"
                 "any", "custom" -> "*/*"
                 "dir" -> "dir"
                 else -> null

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -182,7 +182,7 @@ object FileUtils {
                         putExtra(DocumentsContract.EXTRA_INITIAL_URI, audioRootUri)
                     }
                 }
-            } else if(type == "video"){
+            } else if(type == "video/*"){
                 intent = Intent(Intent.ACTION_GET_CONTENT).apply {
                     this.type = this@startFileExplorer.type
                     addCategory(Intent.CATEGORY_OPENABLE)


### PR DESCRIPTION

To fix the problem that in Android the type selector does not consider the "audio" "video" and "media "choices as showed in this video

https://github.com/user-attachments/assets/4dcdad32-5037-467b-ab34-0dbe1376804f

