### PR TITLE
Fix a crash when initialDirectory contains special characters on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.11
+### Linux
+- Fixed a crash when initialDirectory contains special characters [#1963](https://github.com/miguelpruivo/flutter_file_picker/pull/1963)
+
 ## 10.3.10
 #### Android
 - Reverted breaking changes accidentally introduced in 10.3.9 to maintain Semantic Versioning compliance.

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -51,7 +51,7 @@ class FilePickerLinux extends FilePicker {
       'filters': filter.toDBusArray(),
     };
     if (initialDirectory != null) {
-      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
+      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -101,7 +101,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
+      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -155,7 +155,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
+      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -51,7 +51,7 @@ class FilePickerLinux extends FilePicker {
       'filters': filter.toDBusArray(),
     };
     if (initialDirectory != null) {
-      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
+      final Uint8List tmp = _encodeDirectory(initialDirectory);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -101,7 +101,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
+      final Uint8List tmp = _encodeDirectory(initialDirectory);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -155,7 +155,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      final Uint8List tmp = utf8.encode(initialDirectory)..add(0);
+      final Uint8List tmp = _encodeDirectory(initialDirectory);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -188,4 +188,7 @@ class FilePickerLinux extends FilePicker {
 
     return savedFilePath;
   }
+
+  Uint8List _encodeDirectory(String initialDirectory) =>
+      utf8.encode(initialDirectory)..add(0);
 }

--- a/lib/src/linux/file_picker_linux.dart
+++ b/lib/src/linux/file_picker_linux.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:file_picker/src/file_picker.dart';
@@ -50,11 +51,7 @@ class FilePickerLinux extends FilePicker {
       'filters': filter.toDBusArray(),
     };
     if (initialDirectory != null) {
-      List<int> tmp = [];
-      for (var i = 0; i < initialDirectory.length; i++) {
-        tmp.add(initialDirectory[i].codeUnitAt(0));
-      }
-      tmp.add(0);
+      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -104,11 +101,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      List<int> tmp = [];
-      for (var i = 0; i < initialDirectory.length; i++) {
-        tmp.add(initialDirectory[i].codeUnitAt(0));
-      }
-      tmp.add(0);
+      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }
@@ -162,11 +155,7 @@ class FilePickerLinux extends FilePicker {
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {
-      List<int> tmp = [];
-      for (var i = 0; i < initialDirectory.length; i++) {
-        tmp.add(initialDirectory[i].codeUnitAt(0));
-      }
-      tmp.add(0);
+      final List<int> tmp = utf8.encode(initialDirectory).toList()..add(0);
       DBusArray directory = DBusArray.byte(tmp);
       xdpOption["current_folder"] = directory;
     }


### PR DESCRIPTION
Today, I was testing my Flutter program, and happened to select a directory that has a non-ASCII character in it.

Specifically, this character: گ (Arabic letter Kaf with line, used for /g/)

The selecting part went okay, and I got the result back just fine.
However, my application stores the resulting path, and uses that as the `initialDirectory` for the next pick.
There, it would keep crashing:

<details>
<summary>Stacktrace</summary>

```
Performing hot restart...
Syncing files to device Linux...
Restarted application in 547ms.
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: 'package:dbus/src/dbus_value.dart': Failed assertion: line 151 pos 16: 'value >= 0 && value <= 255': Byte must be in range [0, 255]
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:67:4)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:49:5)
#2      new DBusByte (package:dbus/src/dbus_value.dart:151:16)
#3      new DBusArray.byte.<anonymous closure> (package:dbus/src/dbus_value.dart:919:51)
#4      MappedListIterable.elementAt (dart:_internal/iterable.dart:442:31)
#5      ListIterator.moveNext (dart:_internal/iterable.dart:371:26)
#6      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:194:27)
#7      new _GrowableList.of (dart:core-patch/growable_array.dart:154:28)
#8      new List.of (dart:core-patch/array_patch.dart:39:18)
#9      ListIterable.toList (dart:_internal/iterable.dart:224:7)
#10     new DBusArray (package:dbus/src/dbus_value.dart:893:29)
#11     new DBusArray.byte (package:dbus/src/dbus_value.dart:918:12)
#12     FilePickerLinux.getDirectoryPath (package:file_picker/src/linux/file_picker_linux.dart:112:39)
#13     PathPickerButton.build.<anonymous closure> (package:bluemap_gui/project_view/configs/views/base.dart:117:60)
#14     _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1224:21)
#15     GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:345:24)
#16     TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:758:11)
#17     BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:383:5)
#18     BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:353:7)
#19     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:173:27)
#20     GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:532:20)
#21     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:498:22)
#22     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:473:11)
#23     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:437:7)
#24     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:394:5)
#25     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:341:7)
#26     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:308:9)
#27     _invoke1 (dart:ui/hooks.dart:372:13)
#28     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:467:7)
#29     _dispatchPointerDataPacket (dart:ui/hooks.dart:307:31)
```

</details>

The exact code it was crashing on was this:
```dart
List<int> tmp = [];
for (var i = 0; i < initialDirectory.length; i++) {
  tmp.add(initialDirectory[i].codeUnitAt(0));
}
tmp.add(0);
DBusArray directory = DBusArray.byte(tmp);
```
In that last line is an assert that ensures the `int`s of the `tmp` list are actually bytes, and not way too high.

However, that special character results in the value being `1711`, as you can see in this screenshot of the debugger:
<img width="712" height="258" alt="image" src="https://github.com/user-attachments/assets/1be52abe-58c3-4010-8268-dd076d6cec51" />

<details>
<summary>The full contents of the tmp list</summary>

<img width="631" height="1302" alt="image" src="https://github.com/user-attachments/assets/4c6680cf-8dd7-4005-9584-d3ce6746e63f" />

<img width="212" height="846" alt="image" src="https://github.com/user-attachments/assets/33bb7e20-23c2-4aad-b41b-4ad906f99f74" />

</details>

And so, together with a friend, we concluded that the way that the `tmp` list is being constructed isn't completely proper.

This PR fixes that, by using Dart's built-in UTF-8 encoder to convert the string to a byte array.

I verified with the DBus docs, and DBus String are indeed only allowed to be UTF-8:
- https://dbus.freedesktop.org/doc/api/html/group__DBusString.html
- https://dbus.freedesktop.org/doc/api/html/group__DBusSyntax.html#ga7d98d5d9af66ff78e74d5dd1d8cd3390

I have tested this in my own program, and it does solve the issue.

Here's a pair of (somewhat crappy) videos demonstrating the issue and that the fix works:

The issue:

https://github.com/user-attachments/assets/91ded6b5-b9c0-4815-b782-ee3b605faee1

The fix:

https://github.com/user-attachments/assets/2a57db66-0e90-4f82-bc71-a10a57dd9f99

