### PR TITLE
Suppress warning for XMLStreamException in ProGuard

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -3,5 +3,6 @@
 -keep class javax.xml.stream.XMLResolver.** { *; }
 -dontwarn javax.xml.stream.XMLInputFactory
 -dontwarn javax.xml.stream.XMLResolver
+-dontwarn javax.xml.stream.XMLStreamException
 -dontwarn org.osgi.**
 -dontwarn aQute.bnd.annotation.**


### PR DESCRIPTION
Fixes https://github.com/miguelpruivo/flutter_file_picker/issues/1828

See https://github.com/miguelpruivo/flutter_file_picker/issues/1828#issuecomment-4174593415