### PR TITLE
Add line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+*.sln text eol=crlf
+*.vcxproj text eol=crlf
+*.vcxproj.filters text eol=crlf


### PR DESCRIPTION
## General
Add a repository-wide .gitattributes file to normalize line endings across Windows, macOS, and Linux. This prevents generated files from appearing modified due to EOL differences. 

## Issue resolved
When I switch platforms, opening the project causes the end-of-line formatting in some files to change unnecessarily.

<img width="681" height="253" alt="image" src="https://github.com/user-attachments/assets/bba022aa-8fd8-4134-96c0-f2de2ba99f81" />
