### PR TITLE
fix(android): add missing kotlin-android plugin to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
     compileSdk flutter.compileSdkVersion
@@ -40,6 +41,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     
     dependencies {


### PR DESCRIPTION
## Summary

- Adds the missing `kotlin-android` plugin to `android/build.gradle`, fixing the Android build failure introduced in 11.0.0
- Adds `kotlinOptions` with `jvmTarget = VERSION_17` to match the `compileOptions` configuration

## Root Cause

The `android/build.gradle` applies only `com.android.library` but not `kotlin-android`. Since all Android source files are Kotlin (`.kt`), Gradle never compiles them — causing `GeneratedPluginRegistrant.java` to fail with `cannot find symbol: FilePickerPlugin`.

This is the same regression that occurred in `10.3.9` and was fixed in `10.3.10`, but the fix was not carried into the `11.0.0` release.

## Test Plan

- [x] Verified that `file_picker: 11.0.0` fails to build on Android with AGP 8.13.0 / Kotlin 2.2.20
- [x] Applied this fix via git dependency and confirmed `flutter build apk --debug` succeeds
- [x] Tested on a physical Android device (Samsung SM-M215F)

Fixes #1973
Related: #1952