### PR TITLE
Resolves the backward compatibility issue with the AGP 9 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.1
+### Android
+- Fixed backward compatibility with Android Gradle Plugin (AGP) versions below 9.0. [#1973](https://github.com/miguelpruivo/flutter_file_picker/issues/1973)
+
 ## 11.0.0
 ### General
 - **BREAKING CHANGE**: Refactored `FilePicker` class to use `static` methods instead of an instance-based approach. Users should now call `FilePicker.pickFiles()`, `FilePicker.getDirectoryPath()`, and `FilePicker.saveFile()` directly.
@@ -9,7 +13,7 @@
 
 ### Android
 - Fixed an issue where file type selection (`audio`, `video`, `media`) was not being considered correctly on Android. [#1959](https://github.com/miguelpruivo/flutter_file_picker/pull/1959)
-- Updated Android example app to use Flutter-managed SDK versions (Gradle 8+, Kotlin, targetSdk 36).
+- Updated Android example app to use Flutter-managed SDK versions (Gradle 8+, Kotlin, targetSdk 36 and Java 17).
 
 ### Desktop (macOS)
 - Added a new method, `skipEntitlementsChecks()`, to allow users to bypass entitlements checks on macOS when using the plugin without Sandbox enabled. [#1845](https://github.com/miguelpruivo/flutter_file_picker/issues/1845)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Android
 - Fixed an issue where file type selection (`audio`, `video`, `media`) was not being considered correctly on Android. [#1959](https://github.com/miguelpruivo/flutter_file_picker/pull/1959)
-- Updated Android example app to use Flutter-managed SDK versions (Gradle 8+, Kotlin, targetSdk 36 and Java 17).
+- Updated Android package to support AGP 9. [#1942](https://github.com/miguelpruivo/flutter_file_picker/issues/1942)
 
 ### Desktop (macOS)
 - Added a new method, `skipEntitlementsChecks()`, to allow users to bypass entitlements checks on macOS when using the plugin without Sandbox enabled. [#1845](https://github.com/miguelpruivo/flutter_file_picker/issues/1845)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
     compileSdk flutter.compileSdkVersion
@@ -40,6 +41,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,11 +23,15 @@ rootProject.allprojects {
     }
 }
 
+def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+
 apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+if (!isAgp9OrAbove) {
+    apply plugin: 'org.jetbrains.kotlin.android'
+}
 
 android {
-    compileSdk flutter.compileSdkVersion
+    compileSdk (project.hasProperty('flutter') ? flutter.compileSdkVersion : 36)
 
     defaultConfig {
         minSdk 21
@@ -43,8 +47,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    if (!isAgp9OrAbove) {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_17.toString()
+        }
     }
     
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ if (!isAgp9OrAbove) {
 }
 
 android {
-    compileSdk (project.hasProperty('flutter') ? flutter.compileSdkVersion : 36)
+    compileSdk flutter.compileSdkVersion
 
     defaultConfig {
         minSdk 21

--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/example/windows/runner/flutter_window.cpp
+++ b/example/windows/runner/flutter_window.cpp
@@ -31,6 +31,11 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  // Flutter can complete the first frame before the "show window" callback is
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  flutter_controller_->ForceRedraw();
+
   return true;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 11.0.0
+version: 11.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Based on @mfurkanyuceal's PR (https://github.com/miguelpruivo/flutter_file_picker/pull/1974), this PR closes #1973 and related #1952. I've merged his commits into this PR as a starting point. However, while that PR works in earlier versions of AGP, it breaks AGP 9. I've added a conditional to detect the AGP version, ensuring backward compatibility. I've tested it on both AGP 8 and AGP 9, and it works successfully on both. 

I propose deploying to production as soon as possible.