### PR TITLE
fix(linux): resolve Cannot add to a fixed-length list (#1976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.2
+### Linux
+- Fixed "Cannot add to a fixed-length list" crash when opening or saving files with an initial directory on Linux. [#1976](https://github.com/miguelpruivo/flutter_file_picker/issues/1976)
+
 ## 11.0.1
 ### Android
 - Fixed backward compatibility with Android Gradle Plugin (AGP) versions below 9.0. [#1973](https://github.com/miguelpruivo/flutter_file_picker/issues/1973)

--- a/example/linux/CMakeLists.txt
+++ b/example/linux/CMakeLists.txt
@@ -44,11 +44,6 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
-
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(${TARGET} PRIVATE -stdlib=libc++)
-    target_link_options(${TARGET} PRIVATE -stdlib=libc++)
-  endif()
 endfunction()
 
 # Flutter library and tool build rules.

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -191,6 +191,6 @@ class FilePickerLinux extends FilePickerPlatform {
   }
 
   Uint8List _encodeDirectory(String initialDirectory) {
-    return utf8.encode(initialDirectory)..add(0);
+    return Uint8List.fromList([...utf8.encode(initialDirectory), 0]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 11.0.1
+version: 11.0.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
This issue was introduced here: https://github.com/miguelpruivo/flutter_file_picker/pull/1963. You can read more in detail here https://github.com/miguelpruivo/flutter_file_picker/issues/1976#issuecomment-4191988450. 

- Fixes #1976. 

This PR addresses an issue where utf8.encode on Linux returned a fixed-length list.