### PR TITLE
fix(darwin): avoid false FlutterMacOS SourceKit errors

### DIFF
--- a/darwin/file_picker/Sources/file_picker/FilePickerPlugin.swift
+++ b/darwin/file_picker/Sources/file_picker/FilePickerPlugin.swift
@@ -1,10 +1,11 @@
 #if os(iOS)
 import Flutter
-#elseif os(macOS)
+#elseif os(macOS) && canImport(FlutterMacOS)
 import FlutterMacOS
 #endif
 import Foundation
 
+#if os(iOS) || (os(macOS) && canImport(FlutterMacOS))
 public class FilePickerPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
 #if os(iOS)
@@ -19,7 +20,7 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
         let instance = FilePickerPlugin(registrar: registrar)
         registrar.addMethodCallDelegate(instance, channel: channel)
         eventChannel.setStreamHandler(instance.handler)
-#elseif os(macOS)
+#elseif os(macOS) && canImport(FlutterMacOS)
         let channel = FlutterMethodChannel(
             name: "miguelruivo.flutter.plugins.filepicker",
             binaryMessenger: registrar.messenger)
@@ -31,14 +32,14 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
 
 #if os(iOS)
     private let handler: IOSFilePickerHandler
-#elseif os(macOS)
+#elseif os(macOS) && canImport(FlutterMacOS)
     private let handler: MacOSFilePickerHandler
 #endif
 
     init(registrar: FlutterPluginRegistrar) {
 #if os(iOS)
         handler = IOSFilePickerHandler()
-#elseif os(macOS)
+#elseif os(macOS) && canImport(FlutterMacOS)
         handler = MacOSFilePickerHandler(registrar: registrar)
 #endif
         super.init()
@@ -48,3 +49,4 @@ public class FilePickerPlugin: NSObject, FlutterPlugin {
         handler.handle(call, result: result)
     }
 }
+#endif

--- a/darwin/file_picker/Sources/file_picker/MacOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/MacOSFilePickerHandler.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if os(macOS) && canImport(FlutterMacOS)
 import Cocoa
 import FlutterMacOS
 import UniformTypeIdentifiers


### PR DESCRIPTION
## Summary
- guard macOS-specific code paths with `canImport(FlutterMacOS)` in Darwin sources
- wrap `FilePickerPlugin` compilation so SourceKit/VS Code does not try to resolve Flutter macOS types when unavailable
- keep runtime behavior unchanged for actual iOS/macOS builds

## Why
VS Code SourceKit reported `No such module 'FlutterMacOS'` even though the plugin built and worked correctly. This PR removes those false-positive diagnostics while preserving normal plugin functionality.

## Files changed
- darwin/file_picker/Sources/file_picker/FilePickerPlugin.swift
- darwin/file_picker/Sources/file_picker/MacOSFilePickerHandler.swift

## Validation
- project builds continue to work as before
- SourceKit false-positive errors for `FlutterMacOS` are no longer reported in VS Code for this code path
