### PR TITLE
fix(android): normalize duplicate save names and avoid nested collision suffixes

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -363,9 +363,8 @@ object FileUtils {
         var success = false
         var currentSuffix = suffix ?: 0
         var attempts = 0
-        val maxAttempts = MAX_RENAME_ATTEMPTS
 
-        while (!success && attempts < maxAttempts) {
+        while (!success && attempts < MAX_RENAME_ATTEMPTS) {
             val targetName = when {
                 currentSuffix > 0 -> "$baseName ($currentSuffix).$extension"
                 else -> "$baseName.$extension"
@@ -396,10 +395,10 @@ object FileUtils {
             } catch (ex: Exception) {
                 currentSuffix++
                 attempts++
-                if (attempts >= maxAttempts) {
+                if (attempts >= MAX_RENAME_ATTEMPTS) {
                     Log.w(
                         TAG,
-                        "Failed to normalize saved document name from '$currentName' to '$targetName' after $maxAttempts attempts. MIME=$mimeType, error=$ex"
+                        "Failed to normalize saved document name from '$currentName' to '$targetName' after $MAX_RENAME_ATTEMPTS attempts. MIME=$mimeType, error=$ex"
                     )
                 }
             }

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -37,7 +37,6 @@ import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import java.util.regex.Pattern
 
 object FileUtils {
     private const val TAG = "FilePickerUtils"
@@ -350,37 +349,91 @@ object FileUtils {
         }
 
         val currentName = getFileName(uri, context) ?: return uri
-        val escapedExtension = Pattern.quote(extension)
-        // Android duplicate style "name.ext (N)" that we normalize.
-        val duplicatedExtensionPattern = Regex("^(.*)\\.${escapedExtension} \\((\\d+)\\)$")
-        // Desired style "name (N).ext"; leave unchanged.
-        val alreadyNormalizedPattern = Regex("^.* \\((\\d+)\\)\\.${escapedExtension}$")
-        // Regular "name.ext"; leave unchanged.
-        val hasExtensionPattern = Regex("^.*\\.${escapedExtension}$")
+        val escapedExtension = Regex.escape(extension)
 
-        val targetName = when {
-            duplicatedExtensionPattern.matches(currentName) -> {
-                val match = duplicatedExtensionPattern.matchEntire(currentName) ?: return uri
-                "${match.groupValues[1]} (${match.groupValues[2]}).$extension"
+        // Android duplicate style "name.ext (N)" that we normalize.
+        val androidCollisionRegex = Regex("^(.*)\\.$escapedExtension \\((\\d+)\\)$")
+        // Desired style "name (N).ext"
+        val normalizedCollisionRegex = Regex("^(.*) \\((\\d+)\\)\\.$escapedExtension$")
+        // Regular "name.ext"
+        val plainNameRegex = Regex("^(.*)\\.$escapedExtension$")
+
+        var (baseName, suffix) = when {
+            androidCollisionRegex.matches(currentName) -> {
+                val match = androidCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            normalizedCollisionRegex.matches(currentName) -> {
+                val match = normalizedCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            plainNameRegex.matches(currentName) -> {
+                val match = plainNameRegex.matchEntire(currentName)!!
+                match.groupValues[1] to null
+            }
+            else -> {
+                currentName to null
+            }
+        }
+
+        // Clean up baseName if it already has one or more " (M)" suffixes to prevent nesting
+        val baseNameSuffixRegex = Regex("^(.*) \\((\\d+)\\)$")
+        while (true) {
+            val baseMatch = baseNameSuffixRegex.matchEntire(baseName) ?: break
+
+            val realBase = baseMatch.groupValues[1]
+            val baseSuffix = baseMatch.groupValues[2].toInt()
+            baseName = realBase
+            suffix = (suffix ?: 0) + baseSuffix
+        }
+
+        var finalUri = uri
+        var success = false
+        var currentSuffix = suffix ?: 0
+        var attempts = 0
+        val maxAttempts = 100
+
+        while (!success && attempts < maxAttempts) {
+            val targetName = when {
+                currentSuffix > 0 -> "$baseName ($currentSuffix).$extension"
+                else -> "$baseName.$extension"
             }
 
-            alreadyNormalizedPattern.matches(currentName) || hasExtensionPattern.matches(currentName) -> {
+            if (targetName == currentName && attempts == 0) {
                 return uri
             }
 
-            // Provider returned a name without extension, so append it.
-            else -> "$currentName.$extension"
+            try {
+                val newUri = DocumentsContract.renameDocument(context.contentResolver, finalUri, targetName)
+                if (newUri != null) {
+                    val actualName = getFileName(newUri, context)
+                    if (actualName == targetName) {
+                        finalUri = newUri
+                        success = true
+                    } else {
+                        // The provider likely auto-suffixed because targetName exists (e.g., "file (1).ext" -> "file (1) (1).ext").
+                        // Update finalUri and increment our suffix to try to find a "clean" one ourselves.
+                        finalUri = newUri
+                        currentSuffix++
+                        attempts++
+                    }
+                } else {
+                    currentSuffix++
+                    attempts++
+                }
+            } catch (ex: Exception) {
+                currentSuffix++
+                attempts++
+                if (attempts >= maxAttempts) {
+                    Log.w(
+                        TAG,
+                        "Failed to normalize saved document name from '$currentName' to '$targetName' after $maxAttempts attempts. MIME=$mimeType, error=$ex"
+                    )
+                }
+            }
         }
 
-        return try {
-            DocumentsContract.renameDocument(context.contentResolver, uri, targetName) ?: uri
-        } catch (ex: Exception) {
-            Log.w(
-                TAG,
-                "Failed to normalize saved document name from '$currentName' to '$targetName'. MIME=$mimeType, error=$ex"
-            )
-            uri
-        }
+        return finalUri
     }
 
     private fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -40,6 +40,7 @@ import java.util.Locale
 
 object FileUtils {
     private const val TAG = "FilePickerUtils"
+    private const val MAX_RENAME_ATTEMPTS = 20
     // On Android, the CSV mime type from getMimeTypeFromExtension() returns
     // "text/comma-separated-values" which is non-standard and doesn't filter
     // CSV files in Google Drive.
@@ -351,47 +352,18 @@ object FileUtils {
         val currentName = getFileName(uri, context) ?: return uri
         val escapedExtension = Regex.escape(extension)
 
-        // Android duplicate style "name.ext (N)" that we normalize.
-        val androidCollisionRegex = Regex("^(.*)\\.$escapedExtension \\((\\d+)\\)$")
-        // Desired style "name (N).ext"
-        val normalizedCollisionRegex = Regex("^(.*) \\((\\d+)\\)\\.$escapedExtension$")
-        // Regular "name.ext"
-        val plainNameRegex = Regex("^(.*)\\.$escapedExtension$")
+        var (baseName, suffix) = extractBaseNameAndSuffix(currentName, escapedExtension)
 
-        var (baseName, suffix) = when {
-            androidCollisionRegex.matches(currentName) -> {
-                val match = androidCollisionRegex.matchEntire(currentName)!!
-                match.groupValues[1] to match.groupValues[2].toInt()
-            }
-            normalizedCollisionRegex.matches(currentName) -> {
-                val match = normalizedCollisionRegex.matchEntire(currentName)!!
-                match.groupValues[1] to match.groupValues[2].toInt()
-            }
-            plainNameRegex.matches(currentName) -> {
-                val match = plainNameRegex.matchEntire(currentName)!!
-                match.groupValues[1] to null
-            }
-            else -> {
-                currentName to null
-            }
-        }
-
-        // Clean up baseName if it already has one or more " (M)" suffixes to prevent nesting
-        val baseNameSuffixRegex = Regex("^(.*) \\((\\d+)\\)$")
-        while (true) {
-            val baseMatch = baseNameSuffixRegex.matchEntire(baseName) ?: break
-
-            val realBase = baseMatch.groupValues[1]
-            val baseSuffix = baseMatch.groupValues[2].toInt()
-            baseName = realBase
-            suffix = (suffix ?: 0) + baseSuffix
-        }
+        // Clean up baseName if it already has one or more " (M)" suffixes to prevent nesting.
+        val normalized = normalizeBaseNameAndSuffix(baseName, suffix)
+        baseName = normalized.first
+        suffix = normalized.second
 
         var finalUri = uri
         var success = false
         var currentSuffix = suffix ?: 0
         var attempts = 0
-        val maxAttempts = 100
+        val maxAttempts = MAX_RENAME_ATTEMPTS
 
         while (!success && attempts < maxAttempts) {
             val targetName = when {
@@ -434,6 +406,52 @@ object FileUtils {
         }
 
         return finalUri
+    }
+
+    private fun extractBaseNameAndSuffix(currentName: String, escapedExtension: String): Pair<String, Int?> {
+        // Android duplicate style "name.ext (N)" that we normalize. Example: "report.pdf (1)"
+        val androidCollisionRegex = Regex("^(.*)\\.$escapedExtension \\((\\d+)\\)$")
+        // Desired style "name (N).ext"
+        val normalizedCollisionRegex = Regex("^(.*) \\((\\d+)\\)\\.$escapedExtension$")
+        // Regular "name.ext"
+        val plainNameRegex = Regex("^(.*)\\.$escapedExtension$")
+
+        return when {
+            androidCollisionRegex.matches(currentName) -> {
+                val match = androidCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            normalizedCollisionRegex.matches(currentName) -> {
+                val match = normalizedCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            plainNameRegex.matches(currentName) -> {
+                val match = plainNameRegex.matchEntire(currentName)!!
+                match.groupValues[1] to null
+            }
+            else -> {
+                currentName to null
+            }
+        }
+    }
+
+    private fun normalizeBaseNameAndSuffix(baseName: String, suffix: Int?): Pair<String, Int?> {
+        var normalizedBaseName = baseName
+        var normalizedSuffix = suffix
+        // Trailing numeric suffix chunk "name (N)" we repeatedly strip and accumulate.
+        // Example: "report (1)" -> base "report", suffix +1
+        val baseNameSuffixRegex = Regex("^(.*) \\((\\d+)\\)$")
+
+        while (true) {
+            val baseMatch = baseNameSuffixRegex.matchEntire(normalizedBaseName) ?: break
+
+            val realBase = baseMatch.groupValues[1]
+            val baseSuffix = baseMatch.groupValues[2].toInt()
+            normalizedBaseName = realBase
+            normalizedSuffix = (normalizedSuffix ?: 0) + baseSuffix
+        }
+
+        return normalizedBaseName to normalizedSuffix
     }
 
     private fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {


### PR DESCRIPTION
## What was happening

On Android document providers, saving a file with an existing name can trigger provider-side collision suffixes (for example: `example.sqlite (1)`).

Our previous rename normalization could still end up accepting provider-generated nested names like:
- `example (1) (1).sqlite`
- `example (1) (2).sqlite`

instead of clean sequential names:
- `example (1).sqlite`
- `example (2).sqlite`
- `example (3).sqlite`

## Root cause

The provider may apply its own collision suffix even after `renameDocument(...)` is requested.  
So a requested target name is not guaranteed to be the final persisted display name.

## Fix

In `FileUtils.maybeRenameGenericMimeDuplicate(...)`:

- Normalize/parse collision patterns (`name.ext (N)`, `name (N).ext`, plain `name.ext`).
- Recursively clean `baseName` suffixes to prevent nested accumulation.
- Add retry loop with bounded attempts.
- After each rename attempt, verify with `actualName == targetName`.
- If provider returns a different name (auto-suffixed), increment suffix and retry until a clean normalized name is achieved.
- Keep a final warning only when retries are exhausted.

## Result

Duplicate saves now converge to clean names (`example (2).sqlite`, `example (3).sqlite`, etc.) instead of nested names (`example (1) (1).sqlite`).

## Validation

Manually verified repeated saves against existing `example.sqlite`:
1. first duplicate -> `example (1).sqlite`
2. next duplicates -> `example (2).sqlite`, `example (3).sqlite`, ...
3. no nested collision suffixes observed

Closes: https://github.com/miguelpruivo/flutter_file_picker/issues/1947

Many thanks @Gabbar-v7 for your comments here https://github.com/miguelpruivo/flutter_file_picker/pull/1985#issuecomment-4251323738