### PR TITLE
Fix web default for pickFiles withData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Improved `saveFile` naming behavior when a duplicate file exists, normalizing duplicate names to keep the extension suffix (for example, `file (1).bak` instead of `file.bak (1)`). [#1947](https://github.com/miguelpruivo/flutter_file_picker/issues/1947)
 
 ### Web
-- Fixed `pickFiles()` default `withData` behavior in the public API to correctly default to `true` on web when not explicitly provided, as agreed when `cancelUploadOnWindowBlur` was introduced. [#1987](https://github.com/miguelpruivo/flutter_file_picker/issues/1987) [#1961](https://github.com/miguelpruivo/flutter_file_picker/issues/1961)
+- Fixed `pickFiles()` default `withData` behavior in the public API to correctly default to `true` on web when not explicitly provided. [#1987](https://github.com/miguelpruivo/flutter_file_picker/issues/1987)
 
 ## 11.0.2
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Android
 - Improved `saveFile` naming behavior when a duplicate file exists, normalizing duplicate names to keep the extension suffix (for example, `file (1).bak` instead of `file.bak (1)`). [#1947](https://github.com/miguelpruivo/flutter_file_picker/issues/1947)
 
+### Web
+- Fixed `pickFiles()` default `withData` behavior in the public API to correctly default to `true` on web when not explicitly provided, as agreed when `cancelUploadOnWindowBlur` was introduced. [#1987](https://github.com/miguelpruivo/flutter_file_picker/issues/1987) [#1961](https://github.com/miguelpruivo/flutter_file_picker/issues/1961)
+
 ## 11.0.2
 ### Android
 - Fixed a Path Traversal vulnerability (CWE-22) when resolving file paths from external content providers. [#1967](https://github.com/miguelpruivo/flutter_file_picker/issues/1967)

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
@@ -62,7 +62,7 @@ abstract final class FilePicker {
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
     bool allowMultiple = false,
-    bool withData = false,
+    bool withData = kIsWeb,
     bool withReadStream = false,
     bool lockParentWindow = false,
     bool readSequential = false,


### PR DESCRIPTION
## Summary
- fix FilePicker.pickFiles to default withData to kIsWeb
- keep non-web default behavior unchanged (false)
- add changelog entry referencing #1987 and agreement from #1961

## Context
Per the agreement discussed in #1961, withData should default to true on web.
This PR aligns the public API default with that behavior.

Fixes #1987
