### PR TITLE
fix(android): update gradle wrapper to 8.7 to fix AGP 8.5.1 minimum requirement error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed the DKImagePickerController / DKPhotoGallery dependency chain from the Darwin iOS path.
 
 ### Android
+- Updated the Android Gradle Wrapper to `8.7` to ensure compatibility with Android Gradle Plugin (AGP) `8.5.1`.
 - Improved `saveFile` naming behavior when a duplicate file exists, normalizing duplicate names to keep the extension suffix (for example, `file (1).bak` instead of `file.bak (1)`). [#1947](https://github.com/miguelpruivo/flutter_file_picker/issues/1947)
 
 ### Web

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 01 08:56:40 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

This PR fixes an IDE warning and synchronization exception regarding the Android Gradle Plugin (AGP) compatibility by explicitly updating the plugin's internal Gradle wrapper distribution to version `8.7`.

AGP `8.5.1` requires at least Gradle `8.7`. Since the plugin's standalone `gradle-wrapper.properties` was set to `8.5`, evaluating the Android project in IDEs like VS Code or Android Studio resulted in a warning/exception during Gradle Sync:

```sh
Failed to apply plugin 'com.android.internal.version-check'. Minimum supported Gradle version is 8.7. Current version is 8.5.
```

*Note: This issue did not break actual app builds, as Flutter targets use the host application's Gradle wrapper (for example, `9.3.0` in the case of the test app), which overrides the plugin's local wrapper. This PR resolves the IDE-level warnings.*

### Changes Made

- Updated `distributionUrl` in `android/gradle/wrapper/gradle-wrapper.properties` to `gradle-8.7-all.zip`.
- Added an entry to the `CHANGELOG.md` under the `12.0.0` version section.