### PR TITLE
chore: update win32 dependency version to 6.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   ffi: ^2.1.3
   path: ^1.9.0
-  win32: ^5.9.0
+  win32: ^6.0.1
   cross_file: ^0.3.4+2
   web: ^1.1.0
   dbus: ^0.7.11


### PR DESCRIPTION
for working with new version of[package_info_plus 10.1.0 depends on win32 ^6.0.1 and file_picker 11.0.2 depends on win32 ^5.9.0,]