### PR TITLE
Update dependency versions for 12.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 12.0.0-beta.2
+### General
+- Updated dependencies: `flutter_plugin_android_lifecycle` to `2.0.34`, `path` to `1.9.1`, `win32` to `6.2.0`, `cross_file` to `0.3.5+2`, `web` to `1.1.1`, and `dbus` to `0.7.12`.
+
 ### Android
 - Added a controlled `out_of_memory` error when picking large files with `withData`, avoiding Android crashes and recommending `withReadStream` as a safer alternative for large or multiple selections. [#1997](https://github.com/miguelpruivo/flutter_file_picker/issues/1997)
 **Breaking Change**: `FileType.image` now opens the native image gallery instead of the document picker, ignoring `allowedExtensions` on Android. [#2004](https://github.com/miguelpruivo/flutter_file_picker/pull/2004)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  flutter_plugin_android_lifecycle: ^2.0.22
+  flutter_plugin_android_lifecycle: ^2.0.34
   plugin_platform_interface: ^2.1.8
   ffi: ^2.1.3
-  path: ^1.9.0
-  win32: ^6.0.1
-  cross_file: ^0.3.4+2
-  web: ^1.1.0
-  dbus: ^0.7.11
+  path: ^1.9.1
+  win32: ^6.2.0
+  cross_file: ^0.3.5+2
+  web: ^1.1.1
+  dbus: ^0.7.12
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
Closes #2005 
- Updates dependency versions from `flutter pub upgrade`
- Adds the matching changelog entry for 12.0.0-beta.2