### PR TITLE
Feature/fix add loading into save (#1918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 12.0.0-beta.4
+### General
+- Added `onFileLoading` callback to `saveFile` and implemented status tracking via an event channel. `saveFile` now reports loading status (for example `FilePickerStatus.loading` and `FilePickerStatus.done`).
+- Offloaded file saving (writing bytes) to a background isolate to avoid blocking the UI when saving large files.
+- Ensured the event subscription used for loading status is always cancelled in a `finally` block to prevent leaks and spurious events.
+- Simplified exception handling and removed redundant print statements and comments in utility and platform method channel code.
+- Simplified isolate argument validation in `_saveBytesIsolateEntry` using Dart pattern matching and improved isolate argument handling.
+- Applied `dart format` and minor code cleanups to satisfy CI.
+
 ## 12.0.0-beta.3
 ### Android
 - Fixed Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`, while preserving support for older AGP setups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
-## 12.0.0-beta.4
+## 12.0.0-beta.3
 ### General
 - Added `onFileLoading` callback to `saveFile` and implemented status tracking via an event channel. `saveFile` now reports loading status (for example `FilePickerStatus.loading` and `FilePickerStatus.done`).
 - Offloaded file saving (writing bytes) to a background isolate to avoid blocking the UI when saving large files.
 - Ensured the event subscription used for loading status is always cancelled in a `finally` block to prevent leaks and spurious events.
-- Simplified exception handling and removed redundant print statements and comments in utility and platform method channel code.
-- Simplified isolate argument validation in `_saveBytesIsolateEntry` using Dart pattern matching and improved isolate argument handling.
-- Applied `dart format` and minor code cleanups to satisfy CI.
 
-## 12.0.0-beta.3
 ### Android
 - Fixed Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`, while preserving support for older AGP setups.
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -218,6 +218,7 @@ abstract final class FilePicker {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) {
     return FilePickerPlatform.instance.saveFile(
@@ -227,6 +228,7 @@ abstract final class FilePicker {
       type: type,
       allowedExtensions: allowedExtensions,
       bytes: bytes,
+      onFileLoading: onFileLoading,
       lockParentWindow: lockParentWindow,
     );
   }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -119,17 +119,25 @@ class FilePickerUtils {
   }
 }
 
-Future<void> _saveBytesIsolateEntry(List<dynamic> args) async {
-  final SendPort send = args[0] as SendPort;
-  final String path = args[1] as String;
-  final TransferableTypedData transferable = args[2] as TransferableTypedData;
-  try {
-    final Uint8List bytes = transferable.materialize().asUint8List();
-    final file = File(path);
-    await file.writeAsBytes(bytes);
-    send.send({'result': 'ok'});
-  } catch (e) {
-    send.send({'error trying to save file': e});
+Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
+  // Decode expected message shape using pattern matching to avoid explicit
+  // casts. Expected: [SendPort send, String path, TransferableTypedData transferable]
+  if (args case [SendPort send, String path, TransferableTypedData transferable]) {
+    try {
+      final Uint8List bytes = transferable.materialize().asUint8List();
+      final file = File(path);
+      await file.writeAsBytes(bytes);
+      send.send(true);
+    } catch (e) {
+      send.send(e);
+    }
+    return;
+  }
+
+  if (args.isNotEmpty && args[0] is SendPort) {
+    final Object? first = args[0];
+    if (first is SendPort) {
+      first.send(Exception('Invalid isolate arguments'));
+    }
   }
 }
-

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -146,10 +146,7 @@ Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
     return;
   }
 
-  if (args.isNotEmpty && args[0] is SendPort) {
-    final Object? first = args[0];
-    if (first is SendPort) {
-      first.send(Exception('Invalid isolate arguments'));
-    }
+  if (args case [final SendPort port, ...]) {
+    port.send(Exception('Invalid isolate arguments'));
   }
 }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -106,7 +106,9 @@ class FilePickerUtils {
 
       final result = await receivePort.first;
       receivePort.close();
-      if (result is Map && result['error trying to save file'] != null) {
+      if (result is Exception) {
+        throw result;
+      }
         throw result['error trying to save file'];
       }
     }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -106,8 +106,8 @@ class FilePickerUtils {
 
       final result = await receivePort.first;
       receivePort.close();
-      if (result is Map && result['error trying to save file'] != null) {
-        throw result['error trying to save file'];
+      if (result is Exception) {
+        throw result;
       }
     }
   }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -119,7 +119,6 @@ class FilePickerUtils {
   }
 }
 
-// Entry point for the spawned isolate. Args: [SendPort, String path, TransferableTypedData]
 Future<void> _saveBytesIsolateEntry(List<dynamic> args) async {
   final SendPort send = args[0] as SendPort;
   final String path = args[1] as String;

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -98,7 +98,11 @@ class FilePickerUtils {
       final receivePort = ReceivePort();
       final transferable = TransferableTypedData.fromList([bytes]);
 
-      await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
+      await Isolate.spawn(_saveBytesIsolateEntry, [
+        receivePort.sendPort,
+        path,
+        transferable,
+      ]);
 
       final result = await receivePort.first;
       receivePort.close();
@@ -122,7 +126,11 @@ class FilePickerUtils {
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
   // Decode expected message shape using pattern matching to avoid explicit
   // casts. Expected: [SendPort send, String path, TransferableTypedData transferable]
-  if (args case [SendPort send, String path, TransferableTypedData transferable]) {
+  if (args case [
+    SendPort send,
+    String path,
+    TransferableTypedData transferable,
+  ]) {
     try {
       final Uint8List bytes = transferable.materialize().asUint8List();
       final file = File(path);

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart';
 
@@ -93,8 +95,16 @@ class FilePickerUtils {
   /// Does nothing if [path] or [bytes] is null or empty.
   static Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
     if (path != null && bytes != null && bytes.isNotEmpty) {
-      final file = File(path);
-      await file.writeAsBytes(bytes);
+      final receivePort = ReceivePort();
+      final transferable = TransferableTypedData.fromList([bytes]);
+
+      await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
+
+      final result = await receivePort.first;
+      receivePort.close();
+      if (result is Map && result['error trying to save file'] != null) {
+        throw result['error trying to save file'];
+      }
     }
   }
 
@@ -108,3 +118,19 @@ class FilePickerUtils {
         (codeUnit >= 97 && codeUnit <= 122); // a-z
   }
 }
+
+// Entry point for the spawned isolate. Args: [SendPort, String path, TransferableTypedData]
+Future<void> _saveBytesIsolateEntry(List<dynamic> args) async {
+  final SendPort send = args[0] as SendPort;
+  final String path = args[1] as String;
+  final TransferableTypedData transferable = args[2] as TransferableTypedData;
+  try {
+    final Uint8List bytes = transferable.materialize().asUint8List();
+    final file = File(path);
+    await file.writeAsBytes(bytes);
+    send.send({'result': 'ok'});
+  } catch (e) {
+    send.send({'error trying to save file': e});
+  }
+}
+

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -128,8 +128,6 @@ class FilePickerUtils {
 /// The [args] is expected to contain a [SendPort], the [String] file path
 /// and the [TransferableTypedData] bytes, in this order.
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-  // Decode expected message shape using pattern matching to avoid explicit
-  // casts. Expected: [SendPort send, String path, TransferableTypedData transferable]
   if (args case [
     SendPort send,
     String path,

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -139,7 +139,7 @@ Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
       final Uint8List bytes = transferable.materialize().asUint8List();
       final file = File(path);
       await file.writeAsBytes(bytes);
-      send.send(true);
+      send.send(null);
     } catch (e) {
       send.send(e);
     }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -123,6 +123,10 @@ class FilePickerUtils {
   }
 }
 
+/// Save the given bytes to a file, using a separate [Isolate].
+///
+/// The [args] is expected to contain a [SendPort], the [String] file path
+/// and the [TransferableTypedData] bytes, in this order.
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
   // Decode expected message shape using pattern matching to avoid explicit
   // casts. Expected: [SendPort send, String path, TransferableTypedData transferable]

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -176,23 +176,23 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       await _eventSubscription?.cancel();
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.picking);
-        _eventSubscription = eventChannel.receiveBroadcastStream().listen(
-          (data) {
-            if (data is! bool) return;
-            onFileLoading(
-              data ? FilePickerStatus.picking : FilePickerStatus.done,
-            );
-          },
-          onError: (error) => throw Exception(error),
-        );
+        _eventSubscription = eventChannel.receiveBroadcastStream().listen((
+          data,
+        ) {
+          if (data is! bool) return;
+          onFileLoading(
+            data ? FilePickerStatus.picking : FilePickerStatus.done,
+          );
+        }, onError: (error) => throw Exception(error));
       }
 
-      final String? savedPath = await methodChannel.invokeMethod<String>("save", {
-        "fileName": fileName,
-        "fileType": type.name,
-        "initialDirectory": initialDirectory,
-        "allowedExtensions": allowedExtensions,
-      });
+      final String? savedPath = await methodChannel
+          .invokeMethod<String>("save", {
+            "fileName": fileName,
+            "fileType": type.name,
+            "initialDirectory": initialDirectory,
+            "allowedExtensions": allowedExtensions,
+          });
 
       await FilePickerUtils.saveBytesToFile(bytes, savedPath);
 
@@ -201,7 +201,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       }
 
       return savedPath;
-    }catch (e) {
+    } catch (e) {
       rethrow;
     }
   }

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -153,6 +153,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       rethrow;
     } finally {
       await _eventSubscription?.cancel();
+      _eventSubscription = null;
     }
   }
 

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -150,13 +150,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       }
 
       return FilePickerResult(platformFiles);
-    } on PlatformException catch (e) {
-      print('[$_tag] Platform exception: $e');
-      rethrow;
     } catch (e) {
-      print(
-        '[$_tag] Unsupported operation. Method not found. The exception thrown was: $e',
-      );
       rethrow;
     }
   }
@@ -207,13 +201,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       }
 
       return savedPath;
-    } on PlatformException catch (e) {
-      print('[$_tag] Platform exception: $e');
-      rethrow;
-    } catch (e) {
-      print(
-        '[$_tag] Unsupported operation. Method not found. The exception thrown was: $e',
-      );
+    }catch (e) {
       rethrow;
     }
   }

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -168,20 +169,46 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
-  }) {
+  }) async {
     if (bytes == null) {
       throw ArgumentError(
         'The "bytes" parameter is required on Android & iOS when calling "saveFile".',
       );
     }
 
-    return methodChannel.invokeMethod("save", {
-      "fileName": fileName,
-      "fileType": type.name,
-      "initialDirectory": initialDirectory,
-      "allowedExtensions": allowedExtensions,
-      "bytes": bytes,
-    });
+    try {
+      await _eventSubscription?.cancel();
+      if (onFileLoading != null) {
+        _eventSubscription = eventChannel.receiveBroadcastStream().listen(
+          (data) {
+            if (data is! bool) return;
+            onFileLoading(
+              data ? FilePickerStatus.picking : FilePickerStatus.done,
+            );
+          },
+          onError: (error) => throw Exception(error),
+        );
+      }
+
+      final String? savedPath = await methodChannel.invokeMethod<String>("save", {
+        "fileName": fileName,
+        "fileType": type.name,
+        "initialDirectory": initialDirectory,
+        "allowedExtensions": allowedExtensions,
+        "bytes": bytes,
+      });
+
+      return savedPath;
+    } on PlatformException catch (e) {
+      print('[$_tag] Platform exception: $e');
+      rethrow;
+    } catch (e) {
+      print(
+        '[$_tag] Unsupported operation. Method not found. The exception thrown was: $e',
+      );
+      rethrow;
+    }
   }
 }

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -111,7 +111,6 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       );
     }
     try {
-      await _eventSubscription?.cancel();
       if (onFileLoading != null) {
         _eventSubscription = eventChannel.receiveBroadcastStream().listen((
           data,
@@ -152,6 +151,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       return FilePickerResult(platformFiles);
     } catch (e) {
       rethrow;
+    } finally {
+      await _eventSubscription?.cancel();
     }
   }
 
@@ -173,7 +174,6 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     }
 
     try {
-      await _eventSubscription?.cancel();
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.picking);
         _eventSubscription = eventChannel.receiveBroadcastStream().listen((
@@ -203,6 +203,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       return savedPath;
     } catch (e) {
       rethrow;
+    } finally {
+      await _eventSubscription?.cancel();
     }
   }
 }

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -10,6 +9,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:file_picker/src/file_picker_utils.dart';
 
 /// An implementation of [FilePickerPlatform] that uses method channels.
 class MethodChannelFilePicker extends FilePickerPlatform {
@@ -181,6 +181,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     try {
       await _eventSubscription?.cancel();
       if (onFileLoading != null) {
+        onFileLoading(FilePickerStatus.picking);
         _eventSubscription = eventChannel.receiveBroadcastStream().listen(
           (data) {
             if (data is! bool) return;
@@ -197,8 +198,13 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         "fileType": type.name,
         "initialDirectory": initialDirectory,
         "allowedExtensions": allowedExtensions,
-        "bytes": bytes,
       });
+
+      await FilePickerUtils.saveBytesToFile(bytes, savedPath);
+
+      if (onFileLoading != null) {
+        onFileLoading(FilePickerStatus.done);
+      }
 
       return savedPath;
     } on PlatformException catch (e) {

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -88,6 +88,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     throw UnimplementedError('saveFile() has not been implemented.');

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -164,6 +164,7 @@ class FilePickerLinux extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     Map<String, DBusValue> xdpOption = {

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -99,6 +99,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -217,6 +217,7 @@ class FilePickerWeb extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     if (bytes == null || bytes.isEmpty) {

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -185,6 +185,7 @@ class FilePickerWindows extends FilePickerPlatform {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Uint8List? bytes,
+    Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     final port = ReceivePort();


### PR DESCRIPTION
perf: offload file saving to a background isolate and update loading status

- Implement `_saveBytesIsolateEntry` to handle file writing off the main thread using isolates.
- Use `TransferableTypedData` for efficient cross-isolate communication when saving bytes.
- Move byte-saving logic from the native platform side to the Dart side in `MethodChannelFilePicker`.
- Trigger `onFileLoading` status updates during the file saving process.

fix: https://github.com/miguelpruivo/flutter_file_picker/issues/1918
included in: https://github.com/miguelpruivo/flutter_file_picker/issues/1932