### PR TITLE
fix(android): update error code to explorer_not_found when file explorer is missing (#1850)

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -252,7 +252,7 @@ object FileUtils {
                 FilePickerDelegate.TAG,
                 "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
             )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.")
         }
     }
 
@@ -364,7 +364,7 @@ object FileUtils {
                 FilePickerDelegate.TAG,
                 "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
             )
-            finishWithError("invalid_format_type", "Can't handle the provided file type.")
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.")
         }
     }
 

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -252,7 +252,7 @@ object FileUtils {
                 FilePickerDelegate.TAG,
                 "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
             )
-            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.")
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you have a file explorer installed.")
         }
     }
 
@@ -364,7 +364,7 @@ object FileUtils {
                 FilePickerDelegate.TAG,
                 "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
             )
-            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you've a file explorer installed.")
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you have a file explorer installed.")
         }
     }
 


### PR DESCRIPTION
fix(android): update error code to explorer_not_found when file explorer is missing

fix: https://github.com/miguelpruivo/flutter_file_picker/issues/1850
included in: https://github.com/miguelpruivo/flutter_file_picker/issues/1932