### PR TITLE
feat: add support for custom dialog titles in pickFileAndDirectoryPaths (#1911)

### DIFF
--- a/darwin/file_picker/Sources/file_picker/MacOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/MacOSFilePickerHandler.swift
@@ -61,6 +61,10 @@ final class MacOSFilePickerHandler {
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
         }
+        if let title = args["dialogTitle"] as? String {
+            dialog.title = title
+            dialog.message = title
+        }
         dialog.showsHiddenFiles = false
         let allowMultiple = args["allowMultiple"] as? Bool ?? false
         dialog.allowsMultipleSelection = allowMultiple
@@ -109,12 +113,17 @@ final class MacOSFilePickerHandler {
             result(entitlementError)
             return
         }
+
         let dialog: NSOpenPanel = NSOpenPanel()
         let args = call.arguments as! [String: Any]
 
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        }
+        if let title = args["dialogTitle"] as? String {
+            dialog.title = title
+            dialog.message = title
         }
         dialog.showsHiddenFiles = false
         dialog.allowsMultipleSelection = true
@@ -160,6 +169,14 @@ final class MacOSFilePickerHandler {
         if let initialDirectory = args["initialDirectory"] as? String,
            !initialDirectory.isEmpty {
             dialog.directoryURL = URL(fileURLWithPath: initialDirectory)
+        }
+        if let title = args["dialogTitle"] as? String {
+            dialog.title = title
+            if #available(macOS 10.10, *) {
+                dialog.titleVisibility = .visible
+                dialog.titlebarAppearsTransparent = false
+            }
+            dialog.message = title
         }
         dialog.showsHiddenFiles = false
         dialog.allowsMultipleSelection = false

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -138,6 +138,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
 
     try {
       pickedFilesAndDirectories = await FilePicker.pickFileAndDirectoryPaths(
+        dialogTitle: _dialogTitleController.text,
         type: _pickingType,
         allowedExtensions: (_extension?.isNotEmpty ?? false)
             ? _extension?.replaceAll(' ', '').split(',')

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -67,6 +67,15 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     }
   }
 
+  @override
+  void dispose() {
+    _defaultFileNameController.dispose();
+    _dialogTitleController.dispose();
+    _initialDirectoryController.dispose();
+    _fileExtensionController.dispose();
+    super.dispose();
+  }
+
   void _pickFiles() async {
     bool hasUserAborted = true;
     _resetState();

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -106,11 +106,13 @@ abstract final class FilePicker {
   /// paths for the selected files and directories. If the user cancels the
   /// dialog or if the paths cannot be resolved, the method returns `null`.
   static Future<List<String>?> pickFileAndDirectoryPaths({
+    String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
   }) {
     return FilePickerPlatform.instance.pickFileAndDirectoryPaths(
+      dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,
       allowedExtensions: allowedExtensions,

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -50,6 +50,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// Displays a dialog that allows the user to select both files and
   /// directories simultaneously, returning their absolute paths.
   Future<List<String>?> pickFileAndDirectoryPaths({
+    String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -19,6 +19,7 @@ class FilePickerMacOS extends FilePickerPlatform {
 
   @override
   Future<List<String>?> pickFileAndDirectoryPaths({
+    String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
@@ -30,6 +31,9 @@ class FilePickerMacOS extends FilePickerPlatform {
       <String, dynamic>{
         'allowedExtensions': fileFilter,
         'initialDirectory': escapeInitialDirectory(initialDirectory),
+        'dialogTitle': dialogTitle == null
+            ? null
+            : escapeDialogTitle(dialogTitle),
       },
     );
 
@@ -57,6 +61,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     final filePaths = await methodChannel
         .invokeListMethod<String>('pickFiles', <String, dynamic>{
           'allowedExtensions': fileFilter,
+          'dialogTitle': dialogTitle,
           'initialDirectory': escapeInitialDirectory(initialDirectory),
           'allowMultiple': allowMultiple,
         });


### PR DESCRIPTION
- Add `dialogTitle` parameter to `pickFileAndDirectoryPaths` in the plugin interface and macOS implementation.
- Update macOS native handler to set the title and message on `NSOpenPanel` dialogs.
- Update the example application to allow providing a custom dialog title.


fix: https://github.com/miguelpruivo/flutter_file_picker/issues/1911
included in: https://github.com/miguelpruivo/flutter_file_picker/issues/1932