### PR TITLE
fix(android): support AGP 9+ and android.builtInKotlin property for plugin registration (#2002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Android
 - Added a controlled `out_of_memory` error when picking large files with `withData`, avoiding Android crashes and recommending `withReadStream` as a safer alternative for large or multiple selections. [#1997](https://github.com/miguelpruivo/flutter_file_picker/issues/1997)
 **Breaking Change**: `FileType.image` now opens the native image gallery instead of the document picker, ignoring `allowedExtensions` on Android. [#2004](https://github.com/miguelpruivo/flutter_file_picker/pull/2004)
+- Fixed Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`, while preserving support for older AGP setups.
 
 ## 12.0.0-beta.1
 ### General

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,9 +24,12 @@ rootProject.allprojects {
 }
 
 def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+def builtInKotlinProperty = providers.gradleProperty('android.builtInKotlin').orNull
+def isBuiltInKotlinEnabled = isAgp9OrAbove && (builtInKotlinProperty == null || builtInKotlinProperty.toBoolean())
+def shouldApplyKotlinAndroidPlugin = !isAgp9OrAbove || !isBuiltInKotlinEnabled
 
 apply plugin: 'com.android.library'
-if (!isAgp9OrAbove) {
+if (shouldApplyKotlinAndroidPlugin) {
     apply plugin: 'org.jetbrains.kotlin.android'
 }
 
@@ -47,7 +50,7 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    if (!isAgp9OrAbove) {
+    if (shouldApplyKotlinAndroidPlugin) {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_17.toString()
         }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,7 +1,20 @@
+import org.gradle.kotlin.dsl.withGroovyBuilder
+
 plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    .substringBefore('.')
+    .toInt()
+val builtInKotlinProperty = providers.gradleProperty("android.builtInKotlin").orNull
+val isBuiltInKotlinEnabled = agpMajorVersion >= 9 &&
+    (builtInKotlinProperty == null || builtInKotlinProperty.toBoolean())
+
+if (!isBuiltInKotlinEnabled) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 android {
@@ -13,9 +26,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+
+    if (!isBuiltInKotlinEnabled) {
+        withGroovyBuilder {
+            "kotlinOptions" {
+                setProperty("jvmTarget", JavaVersion.VERSION_17.toString())
+            }
         }
     }
 


### PR DESCRIPTION
- Update `android/build.gradle` to conditionally apply the Kotlin plugin based on AGP version and the `android.builtInKotlin` property.
- Update `example/android/app/build.gradle.kts` to align with new AGP 9+ registration logic.
- Update `CHANGELOG.md` to document support for AGP 9+ setups where built-in Kotlin is disabled.

fix: https://github.com/miguelpruivo/flutter_file_picker/issues/2002 
included in: https://github.com/miguelpruivo/flutter_file_picker/issues/1932