### PR TITLE
Update version to 12.0.0-beta.3 and fix Android plugin registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.0-beta.3
+### Android
+- Fixed Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`, while preserving support for older AGP setups.
+
 ## 12.0.0-beta.2
 ### General
 - Updated dependencies: `flutter_plugin_android_lifecycle` to `2.0.34`, `path` to `1.9.1`, `win32` to `6.2.0`, `cross_file` to `0.3.5+2`, `web` to `1.1.1`, and `dbus` to `0.7.12`.
@@ -5,7 +9,6 @@
 ### Android
 - Added a controlled `out_of_memory` error when picking large files with `withData`, avoiding Android crashes and recommending `withReadStream` as a safer alternative for large or multiple selections. [#1997](https://github.com/miguelpruivo/flutter_file_picker/issues/1997)
 **Breaking Change**: `FileType.image` now opens the native image gallery instead of the document picker, ignoring `allowedExtensions` on Android. [#2004](https://github.com/miguelpruivo/flutter_file_picker/pull/2004)
-- Fixed Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`, while preserving support for older AGP setups.
 
 ## 12.0.0-beta.1
 ### General

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.2
+version: 12.0.0-beta.3
 
 dependencies:
   flutter:


### PR DESCRIPTION
This pull request prepares for the `12.0.0-beta.3` release by updating the package version and changelog. The primary change is a fix for Android plugin registration when using AGP 9+ with `android.builtInKotlin=false`.

Release preparation:

* Updated the `pubspec.yaml` version to `12.0.0-beta.3`.
* Added a changelog entry for `12.0.0-beta.3` documenting the Android plugin registration fix for AGP 9+ with `android.builtInKotlin=false`, while maintaining support for older AGP setups.