### PR TITLE
fix(android): restore subdirectory visibility for FileType.any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.0.0-beta.4
+
+### Android
+- Fixed `FileType.any` not showing subdirectories in the document picker due to `EXTRA_MIME_TYPES` being passed as a bare `String` instead of a `String[]`.
+
 ## 12.0.0-beta.3
 ### General
 - Added `onFileLoading` callback to `saveFile` and implemented status tracking via an event channel. `saveFile` now reports loading status (for example `FilePickerStatus.loading` and `FilePickerStatus.done`).

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -189,7 +189,7 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
                     fileType,
                     arguments?.get("allowMultipleSelection") as Boolean?,
                     arguments?.get("withData") as Boolean?,
-                    arrayListOf(),
+                    getMimeTypes(null),
                     arguments?.get("compressionQuality") as Int?,
                     androidSafOptions,
                     result

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.3
+version: 12.0.0-beta.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Should solve #2013 and #2012.

Hii @daniJimen I don't want to do anything I have no deep understanding from. And this PR is just some fast vibe coding without thoughts behind it. I think you edited this part a few days ago, so maybe you can have a look at it. After this change it was possible for me to navigate the directories and pick our .ini files again. Otherwise `any` behaves differently than `custom without extensions`.