### PR TITLE
feat: implement pickFile() API and improve PlatformFile documentation (#1469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 12.0.0-beta.4
 ### General
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
+- **BREAKING CHANGE**: Refactored `saveFile()` to make `fileName` and `bytes` required parameters across all platforms for a more consistent API. Improved the method's documentation for better clarity.
 - Improved documentation for `PlatformFile` properties (`path`, `bytes`, `readStream`) to clarify nullability and usage across platforms. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
- - The `allowMultiple` parameter on `pickFiles()` now defaults to `true`. Use `pickFile()` for single-file selection. (`allowMultiple` is deprecated and will be removed in a future release.)
- - Deprecated `withData`, `withReadStream`, and `readSequential` on `pickFiles()`/`pickFile()`. Users should call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` to load file data on demand. These parameters will be removed in a future release.
+- **BREAKING CHANGE**: The `allowMultiple` parameter on `pickFiles()` now defaults to `true`. Use `pickFile()` for single-file selection. (`allowMultiple` is deprecated and will be removed in a future release.)
+- Deprecated `withData`, `withReadStream`, and `readSequential` on `pickFiles()`/`pickFile()`. Users should call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` to load file data on demand. These parameters will be removed in a future release.
 
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 12.0.0-beta.4
+### General
+- Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
+- Improved documentation for `PlatformFile` properties (`path`, `bytes`, `readStream`) to clarify nullability and usage across platforms. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
+
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
 - Improved documentation for `PlatformFile` properties (`path`, `bytes`, `readStream`) to clarify nullability and usage across platforms. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
  - The `allowMultiple` parameter on `pickFiles()` now defaults to `true`. Use `pickFile()` for single-file selection. (`allowMultiple` is deprecated and will be removed in a future release.)
+ - Deprecated `withData`, `withReadStream`, and `readSequential` on `pickFiles()`/`pickFile()`. Users should call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` to load file data on demand. These parameters will be removed in a future release.
 
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### General
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
 - Improved documentation for `PlatformFile` properties (`path`, `bytes`, `readStream`) to clarify nullability and usage across platforms. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
+ - The `allowMultiple` parameter on `pickFiles()` now defaults to `true`. Use `pickFile()` for single-file selection. (`allowMultiple` is deprecated and will be removed in a future release.)
 
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you have any feature that you want to see in this package, please feel free t
 | `clearTemporaryFiles()`       | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
 | `getDirectoryPath()`          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | `pickFileAndDirectoryPaths()` | :x:                | :x:                | :x:                | :white_check_mark: | :x:                | :x:                |
+| `pickFile()`                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `pickFiles()`                 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `saveFile()`                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
@@ -93,10 +94,11 @@ You can still use `withData: true` for small files or single selections when imm
 
 #### Single file
 ```dart
-FilePickerResult? result = await FilePicker.pickFiles();
+PlatformFile? file = await FilePicker.pickFile();
 
-if (result != null) {
-  File file = File(result.files.single.path!);
+if (file != null) {
+  print(file.name);
+  print(file.size);
 } else {
   // User canceled the picker
 }

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    deprecated_member_use_from_same_package: false
+analyzer:
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    deprecated_member_use_from_same_package: false

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -85,52 +85,26 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         final result = await FilePicker.pickFiles(
           type: _pickingType,
           allowMultiple: true,
-          onFileLoading: (FilePickerStatus status) => setState(() {
-            _isLoading = status == FilePickerStatus.picking;
-          }),
-          allowedExtensions: (_extension?.isNotEmpty ?? false)
-              ? _extension?.replaceAll(' ', '').split(',')
-              : null,
+          onFileLoading: _onFileLoading,
+          allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
           lockParentWindow: _lockParentWindow,
           withData: _withData,
-          androidSafOptions: (_safPersist || _safReadWrite)
-              ? AndroidSAFOptions(
-                  grant: _safPersist
-                      ? AndroidSAFGrant.lifetime
-                      : AndroidSAFGrant.transient,
-                  accessMode: _safReadWrite
-                      ? AndroidSAFAccessMode.readWrite
-                      : AndroidSAFAccessMode.readOnly,
-                )
-              : null,
+          androidSafOptions: _androidSafOptionsFromFlags(),
         );
         printInDebug("pickedFiles: $result");
         pickedFiles = result?.files;
       } else {
         final file = await FilePicker.pickFile(
           type: _pickingType,
-          onFileLoading: (FilePickerStatus status) => setState(() {
-            _isLoading = status == FilePickerStatus.picking;
-          }),
-          allowedExtensions: (_extension?.isNotEmpty ?? false)
-              ? _extension?.replaceAll(' ', '').split(',')
-              : null,
+          onFileLoading: _onFileLoading,
+          allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
           lockParentWindow: _lockParentWindow,
           withData: _withData,
-          androidSafOptions: (_safPersist || _safReadWrite)
-              ? AndroidSAFOptions(
-                  grant: _safPersist
-                      ? AndroidSAFGrant.lifetime
-                      : AndroidSAFGrant.transient,
-                  accessMode: _safReadWrite
-                      ? AndroidSAFAccessMode.readWrite
-                      : AndroidSAFAccessMode.readOnly,
-                )
-              : null,
+          androidSafOptions: _androidSafOptionsFromFlags(),
         );
         printInDebug("pickedFile: $file");
         pickedFiles = file != null ? [file] : null;
@@ -177,9 +151,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       pickedFilesAndDirectories = await FilePicker.pickFileAndDirectoryPaths(
         dialogTitle: _dialogTitleController.text,
         type: _pickingType,
-        allowedExtensions: (_extension?.isNotEmpty ?? false)
-            ? _extension?.replaceAll(' ', '').split(',')
-            : null,
+        allowedExtensions: _allowedExtensionsFromInput(),
         initialDirectory: _initialDirectoryController.text,
       );
       hasUserAborted = pickedFilesAndDirectories == null;
@@ -252,16 +224,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         dialogTitle: _dialogTitleController.text,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
-        androidSafOptions: (_safPersist || _safReadWrite)
-            ? AndroidSAFOptions(
-                grant: _safPersist
-                    ? AndroidSAFGrant.lifetime
-                    : AndroidSAFGrant.transient,
-                accessMode: _safReadWrite
-                    ? AndroidSAFAccessMode.readWrite
-                    : AndroidSAFAccessMode.readOnly,
-              )
-            : null,
+        androidSafOptions: _androidSafOptionsFromFlags(),
       );
       hasUserAborted = pickedDirectoryPath == null;
     } on PlatformException catch (e) {
@@ -301,9 +264,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
 
     try {
       pickedSaveFilePath = await FilePicker.saveFile(
-        allowedExtensions: (_extension?.isNotEmpty ?? false)
-            ? _extension?.replaceAll(' ', '').split(',')
-            : null,
+        allowedExtensions: _allowedExtensionsFromInput(),
         type: FileType.custom,
         dialogTitle: _dialogTitleController.text,
         fileName: _defaultFileNameController.text,
@@ -351,6 +312,31 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       _isLoading = true;
       _userAborted = true;
     });
+  }
+
+  void _onFileLoading(FilePickerStatus status) {
+    setState(() {
+      _isLoading = status == FilePickerStatus.picking;
+    });
+  }
+
+  List<String>? _allowedExtensionsFromInput() {
+    return (_extension?.isNotEmpty ?? false)
+        ? _extension?.replaceAll(' ', '').split(',')
+        : null;
+  }
+
+  AndroidSAFOptions? _androidSafOptionsFromFlags() {
+    return (_safPersist || _safReadWrite)
+        ? AndroidSAFOptions(
+            grant: _safPersist
+                ? AndroidSAFGrant.lifetime
+                : AndroidSAFGrant.transient,
+            accessMode: _safReadWrite
+                ? AndroidSAFAccessMode.readWrite
+                : AndroidSAFAccessMode.readOnly,
+          )
+        : null;
   }
 
   @override

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -261,15 +261,17 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     String? pickedSaveFilePath;
     bool hasUserAborted = true;
 
-    final bytes = pickedFiles?.firstOrNull?.bytes;
+    final file = pickedFiles?.firstOrNull;
     final fileName = _defaultFileNameController.text;
 
-    if (bytes == null || fileName.isEmpty) {
+    if (file == null || fileName.isEmpty) {
       _logException(
-        'Please pick a file with data enabled first and provide a default file name.',
+        'Please pick a file first and provide a default file name.',
       );
       return;
     }
+
+    final bytes = await file.readAsBytes();
 
     _resetState();
 

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -260,6 +260,17 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   Future<void> _saveFile() async {
     String? pickedSaveFilePath;
     bool hasUserAborted = true;
+
+    final bytes = pickedFiles?.firstOrNull?.bytes;
+    final fileName = _defaultFileNameController.text;
+
+    if (bytes == null || fileName.isEmpty) {
+      _logException(
+        'Please pick a file with data enabled first and provide a default file name.',
+      );
+      return;
+    }
+
     _resetState();
 
     try {
@@ -267,10 +278,10 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         allowedExtensions: _allowedExtensionsFromInput(),
         type: FileType.custom,
         dialogTitle: _dialogTitleController.text,
-        fileName: _defaultFileNameController.text,
+        fileName: fileName,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
-        bytes: pickedFiles?.first.bytes,
+        bytes: bytes,
       );
       hasUserAborted = pickedSaveFilePath == null;
     } on PlatformException catch (e) {

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -81,32 +81,60 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _resetState();
 
     try {
-      final result = await FilePicker.pickFiles(
-        type: _pickingType,
-        allowMultiple: _multiPick,
-        onFileLoading: (FilePickerStatus status) => setState(() {
-          _isLoading = status == FilePickerStatus.picking;
-        }),
-        allowedExtensions: (_extension?.isNotEmpty ?? false)
-            ? _extension?.replaceAll(' ', '').split(',')
-            : null,
-        dialogTitle: _dialogTitleController.text,
-        initialDirectory: _initialDirectoryController.text,
-        lockParentWindow: _lockParentWindow,
-        withData: _withData,
-        androidSafOptions: (_safPersist || _safReadWrite)
-            ? AndroidSAFOptions(
-                grant: _safPersist
-                    ? AndroidSAFGrant.lifetime
-                    : AndroidSAFGrant.transient,
-                accessMode: _safReadWrite
-                    ? AndroidSAFAccessMode.readWrite
-                    : AndroidSAFAccessMode.readOnly,
-              )
-            : null,
-      );
-      printInDebug("pickedFiles: $result");
-      pickedFiles = result?.files;
+      if (_multiPick) {
+        final result = await FilePicker.pickFiles(
+          type: _pickingType,
+          allowMultiple: true,
+          onFileLoading: (FilePickerStatus status) => setState(() {
+            _isLoading = status == FilePickerStatus.picking;
+          }),
+          allowedExtensions: (_extension?.isNotEmpty ?? false)
+              ? _extension?.replaceAll(' ', '').split(',')
+              : null,
+          dialogTitle: _dialogTitleController.text,
+          initialDirectory: _initialDirectoryController.text,
+          lockParentWindow: _lockParentWindow,
+          withData: _withData,
+          androidSafOptions: (_safPersist || _safReadWrite)
+              ? AndroidSAFOptions(
+                  grant: _safPersist
+                      ? AndroidSAFGrant.lifetime
+                      : AndroidSAFGrant.transient,
+                  accessMode: _safReadWrite
+                      ? AndroidSAFAccessMode.readWrite
+                      : AndroidSAFAccessMode.readOnly,
+                )
+              : null,
+        );
+        printInDebug("pickedFiles: $result");
+        pickedFiles = result?.files;
+      } else {
+        final file = await FilePicker.pickFile(
+          type: _pickingType,
+          onFileLoading: (FilePickerStatus status) => setState(() {
+            _isLoading = status == FilePickerStatus.picking;
+          }),
+          allowedExtensions: (_extension?.isNotEmpty ?? false)
+              ? _extension?.replaceAll(' ', '').split(',')
+              : null,
+          dialogTitle: _dialogTitleController.text,
+          initialDirectory: _initialDirectoryController.text,
+          lockParentWindow: _lockParentWindow,
+          withData: _withData,
+          androidSafOptions: (_safPersist || _safReadWrite)
+              ? AndroidSAFOptions(
+                  grant: _safPersist
+                      ? AndroidSAFGrant.lifetime
+                      : AndroidSAFGrant.transient,
+                  accessMode: _safReadWrite
+                      ? AndroidSAFAccessMode.readWrite
+                      : AndroidSAFAccessMode.readOnly,
+                )
+              : null,
+        );
+        printInDebug("pickedFile: $file");
+        pickedFiles = file != null ? [file] : null;
+      }
       hasUserAborted = pickedFiles == null;
     } on PlatformException catch (e) {
       _logException('Unsupported operation: $e');

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -103,7 +103,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
           lockParentWindow: _lockParentWindow,
-          withData: _withData,
           androidSafOptions: _androidSafOptionsFromFlags(),
         );
         printInDebug("pickedFile: $file");

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -60,6 +60,9 @@ class PlatformFile {
   /// Out Of Memory (OOM) issues; use [readStream] instead.
   ///
   /// [Check here in the FAQ](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ) an example on how to use it to upload on web.
+  @Deprecated(
+    'Use readAsBytes() instead to avoid OOM issues on mobile platforms',
+  )
   final Uint8List? bytes;
 
   /// File content as a stream of bytes.
@@ -67,6 +70,7 @@ class PlatformFile {
   /// This property is `null` unless [FilePicker.pickFiles] (or `pickFile`) was called with
   /// `withReadStream: true`. This is the recommended way to handle large files on
   /// mobile and desktop platforms.
+  @Deprecated('Use readAsByteStream() instead')
   final Stream<List<int>>? readStream;
 
   /// The file size in bytes. Defaults to `0` if the file size could not be

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -42,7 +42,7 @@ class PlatformFile {
   /// ```
   ///
   /// This property is `null` on Android, when using SAF without caching enabled.
-  /// 
+  ///
   /// On the web this may or may not point to a Blob URL, which can be cleaned up using [URL.revokeObjectURL](https://pub.dev/documentation/web/latest/web/URL/revokeObjectURL.html).
   /// Read more about it [here](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)
   final String? path;
@@ -114,6 +114,25 @@ class PlatformFile {
   /// to create the stream. This is a limitation that should be addressed in a future version to
   /// support proper streaming on web without requiring `withData`.
   Stream<Uint8List> readAsByteStream() => xFile.openRead();
+
+  /// Returns the length of the file in bytes.
+  ///
+  /// Resolution order:
+  /// 1. If `size` is > 0, it is returned immediately.
+  /// 2. Otherwise, attempts to use `xFile.length()` which works across platforms.
+  /// 3. If that fails, falls back to `bytes?.lengthInBytes` or `0`.
+  ///
+  /// Note: on Web, `xFile.length()` depends on the underlying `XFile` implementation
+  /// and may require `withData: true` when using `XFile.fromData` — in that case the
+  /// fallback to `bytes` will be used.
+  Future<int> length() async {
+    if (size > 0) return size;
+    try {
+      return await xFile.length();
+    } catch (_) {
+      return bytes?.lengthInBytes ?? 0;
+    }
+  }
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -117,11 +117,6 @@ class PlatformFile {
 
   /// Returns the length of the file in bytes.
   ///
-  /// Resolution order:
-  /// 1. If `size` is > 0, it is returned immediately.
-  /// 2. Otherwise, attempts to use `xFile.length()` which works across platforms.
-  /// 3. If that fails, falls back to `bytes?.lengthInBytes` or `0`.
-  ///
   /// Note: on Web, `xFile.length()` depends on the underlying `XFile` implementation
   /// and may require `withData: true` when using `XFile.fromData` — in that case the
   /// fallback to `bytes` will be used.

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -93,10 +93,8 @@ class PlatformFile {
   /// Retrieves this as a XFile
   XFile get xFile {
     if (kIsWeb) {
-      // ignore: deprecated_member_use_from_same_package
       return XFile.fromData(bytes!, name: name, length: size);
     } else {
-      // ignore: deprecated_member_use_from_same_package
       return XFile(path!, name: name, bytes: bytes, length: size);
     }
   }
@@ -142,12 +140,10 @@ class PlatformFile {
       return true;
     }
 
-    // ignore: deprecated_member_use_from_same_package
     return other is PlatformFile &&
         other.path == path &&
         other.name == name &&
         other.bytes == bytes &&
-        // ignore: deprecated_member_use_from_same_package
         other.readStream == readStream &&
         other.identifier == identifier &&
         other.size == size;
@@ -157,13 +153,11 @@ class PlatformFile {
   int get hashCode {
     return kIsWeb
         ? 0
-        // ignore: deprecated_member_use_from_same_package
         : Object.hash(path, name, bytes, readStream, identifier, size);
   }
 
   @override
   String toString() {
-    // ignore: deprecated_member_use_from_same_package
     return 'PlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size)';
   }
 }
@@ -175,9 +169,7 @@ class AndroidPlatformFile extends PlatformFile {
         path: file.path,
         name: file.name,
         size: file.size,
-        // ignore: deprecated_member_use_from_same_package
         bytes: file.bytes,
-        // ignore: deprecated_member_use_from_same_package
         readStream: file.readStream,
         identifier: file.identifier,
       );
@@ -197,7 +189,6 @@ class AndroidPlatformFile extends PlatformFile {
 
   @override
   String toString() {
-    // ignore: deprecated_member_use_from_same_package
     return 'AndroidPlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size, safHandle: $safHandle)';
   }
 }

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -97,6 +97,12 @@ class PlatformFile {
     }
   }
 
+  /// Read the file content as bytes.
+  Future<Uint8List> readAsBytes() => xFile.readAsBytes();
+
+  /// Read the file content as a stream of bytes.
+  Stream<Uint8List> readAsByteStream() => xFile.openRead();
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -61,7 +61,7 @@ class PlatformFile {
   ///
   /// [Check here in the FAQ](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ) an example on how to use it to upload on web.
   @Deprecated(
-    'Use readAsBytes() instead to avoid OOM issues on mobile platforms',
+    'Use readAsBytes() instead to avoid out-of-memory issues with large files.',
   )
   final Uint8List? bytes;
 

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -93,8 +93,10 @@ class PlatformFile {
   /// Retrieves this as a XFile
   XFile get xFile {
     if (kIsWeb) {
+      // ignore: deprecated_member_use_from_same_package
       return XFile.fromData(bytes!, name: name, length: size);
     } else {
+      // ignore: deprecated_member_use_from_same_package
       return XFile(path!, name: name, bytes: bytes, length: size);
     }
   }
@@ -140,10 +142,12 @@ class PlatformFile {
       return true;
     }
 
+    // ignore: deprecated_member_use_from_same_package
     return other is PlatformFile &&
         other.path == path &&
         other.name == name &&
         other.bytes == bytes &&
+        // ignore: deprecated_member_use_from_same_package
         other.readStream == readStream &&
         other.identifier == identifier &&
         other.size == size;
@@ -153,11 +157,13 @@ class PlatformFile {
   int get hashCode {
     return kIsWeb
         ? 0
+        // ignore: deprecated_member_use_from_same_package
         : Object.hash(path, name, bytes, readStream, identifier, size);
   }
 
   @override
   String toString() {
+    // ignore: deprecated_member_use_from_same_package
     return 'PlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size)';
   }
 }
@@ -169,7 +175,9 @@ class AndroidPlatformFile extends PlatformFile {
         path: file.path,
         name: file.name,
         size: file.size,
+        // ignore: deprecated_member_use_from_same_package
         bytes: file.bytes,
+        // ignore: deprecated_member_use_from_same_package
         readStream: file.readStream,
         identifier: file.identifier,
       );
@@ -189,6 +197,7 @@ class AndroidPlatformFile extends PlatformFile {
 
   @override
   String toString() {
+    // ignore: deprecated_member_use_from_same_package
     return 'AndroidPlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size, safHandle: $safHandle)';
   }
 }

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -102,9 +102,19 @@ class PlatformFile {
   }
 
   /// Read the file content as bytes.
+  ///
+  /// For large files on mobile and desktop platforms, prefer [readAsByteStream]
+  /// to avoid Out Of Memory (OOM) issues.
   Future<Uint8List> readAsBytes() => xFile.readAsBytes();
 
   /// Read the file content as a stream of bytes.
+  ///
+  /// This is the recommended way to handle large files on mobile and desktop platforms.
+  ///
+  /// **Note on Web:** This method currently requires [FilePicker.pickFiles] or [FilePicker.pickFile]
+  /// to have been called with `withData: true`, otherwise this will fail since `bytes` is required
+  /// to create the stream. This is a limitation that should be addressed in a future version to
+  /// support proper streaming on web without requiring `withData`.
   Stream<Uint8List> readAsByteStream() => xFile.openRead();
 
   @override

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -41,11 +41,9 @@ class PlatformFile {
   /// final File myFile = File(platformFile.path);
   /// ```
   ///
-  /// This property is `null` in the following cases:
-  /// - On Web, where local file paths are not available (it may point to a Blob URL instead).
-  /// - On Android, when picking a directory or using SAF without caching enabled.
-  ///
-  /// On web the path points to a Blob URL, if present, which can be cleaned up using [URL.revokeObjectURL](https://pub.dev/documentation/web/latest/web/URL/revokeObjectURL.html).
+  /// This property is `null` on Android, when using SAF without caching enabled.
+  /// 
+  /// On the web this may or may not point to a Blob URL, which can be cleaned up using [URL.revokeObjectURL](https://pub.dev/documentation/web/latest/web/URL/revokeObjectURL.html).
   /// Read more about it [here](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)
   final String? path;
 

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -40,6 +40,11 @@ class PlatformFile {
   /// ```
   /// final File myFile = File(platformFile.path);
   /// ```
+  ///
+  /// This property is `null` in the following cases:
+  /// - On Web, where local file paths are not available (it may point to a Blob URL instead).
+  /// - On Android, when picking a directory or using SAF without caching enabled.
+  ///
   /// On web the path points to a Blob URL, if present, which can be cleaned up using [URL.revokeObjectURL](https://pub.dev/documentation/web/latest/web/URL/revokeObjectURL.html).
   /// Read more about it [here](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)
   final String? path;
@@ -49,10 +54,19 @@ class PlatformFile {
 
   /// Byte data for this file. Particularly useful if you want to manipulate its data
   /// or easily upload to somewhere else.
+  ///
+  /// This property is `null` unless [FilePicker.pickFiles] (or `pickFile`) was called with
+  /// `withData: true`. Enabling this on mobile platforms for large files may lead to
+  /// Out Of Memory (OOM) issues; use [readStream] instead.
+  ///
   /// [Check here in the FAQ](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ) an example on how to use it to upload on web.
   final Uint8List? bytes;
 
-  /// File content as stream
+  /// File content as a stream of bytes.
+  ///
+  /// This property is `null` unless [FilePicker.pickFiles] (or `pickFile`) was called with
+  /// `withReadStream: true`. This is the recommended way to handle large files on
+  /// mobile and desktop platforms.
   final Stream<List<int>>? readStream;
 
   /// The file size in bytes. Defaults to `0` if the file size could not be
@@ -62,6 +76,10 @@ class PlatformFile {
   /// The platform identifier for the original file, refers to an [Uri](https://developer.android.com/reference/android/net/Uri) on Android and
   /// to a [NSURL](https://developer.apple.com/documentation/foundation/nsurl) on iOS.
   /// Is set to `null` on all other platforms since those are all already referencing the original file content.
+  ///
+  /// This property is `null` in the following cases:
+  /// - On Web, where local file paths are not available (it may point to a Blob URL instead).
+  /// - On Android, when picking a directory or using SAF without caching enabled.
   ///
   /// Note: You can't use this to create a Dart `File` instance since this is a safe-reference for the original platform files, for
   /// that the [path] property should be used instead.

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -56,6 +56,8 @@ abstract final class FilePicker {
   /// Note: This requires the User Selected File Read entitlement on macOS.
   ///
   /// Returns `null` if aborted.
+  /// NOTE: `allowMultiple` is deprecated. Use `pickFile` for single-file
+  /// selection; `pickFiles` now implies multiple selection by default.
   static Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
@@ -63,7 +65,10 @@ abstract final class FilePicker {
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
-    bool allowMultiple = false,
+    @Deprecated(
+      'use pickFile for single-file selection; this parameter will be removed in a future release',
+    )
+    bool allowMultiple = true,
     bool withData = kIsWeb,
     bool withReadStream = false,
     bool lockParentWindow = false,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -39,7 +39,7 @@ abstract final class FilePicker {
   /// [initialDirectory] can be optionally set to an absolute path to specify
   /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   /// On macOS the home directory shortcut (~/) is not necessary and passing it will be ignored.
-  /// On macOS if the [initialDirectory] is invalid the user directory or previously valid directory
+  /// On macOS if the [initialDirectory] is invalid, the user directory or previously valid directory
   /// will be used.
   ///
   /// [readSequential] can be optionally set on web to keep the import file order during import.
@@ -216,7 +216,7 @@ abstract final class FilePicker {
   /// [initialDirectory] can be optionally set to an absolute path to specify
   /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   /// On macOS the home directory shortcut (~/) is not necessary and passing it will be ignored.
-  /// On macOS if the [initialDirectory] is invalid the user directory or previously valid directory
+  /// On macOS if the [initialDirectory] is invalid, the user directory or previously valid directory
   /// will be used.
   ///
   /// Returns a [Future<String?>] which resolves to the absolute path of the selected directory,
@@ -263,7 +263,7 @@ abstract final class FilePicker {
   /// [initialDirectory] can be optionally set to an absolute path to specify
   /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   /// On macOS the home directory shortcut (~/) is not necessary and passing it will be ignored.
-  /// On macOS if the [initialDirectory] is invalid the user directory or previously valid directory
+  /// On macOS if the [initialDirectory] is invalid, the user directory or previously valid directory
   /// will be used.
   ///
   /// The file type filter [type] defaults to [FileType.any]. Optionally,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
+import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 
@@ -85,6 +86,46 @@ abstract final class FilePicker {
       cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
       androidSafOptions: androidSafOptions,
     );
+  }
+
+  /// Opens a native file explorer and lets the user select a single file.
+  ///
+  /// This is a convenience wrapper around [pickFiles] for when you only need to
+  /// pick one file. It returns a [PlatformFile] directly, or `null` if the
+  /// user canceled the operation.
+  ///
+  /// For documentation on the parameters, see [pickFiles].
+  static Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool withData = kIsWeb,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+    AndroidSAFOptions? androidSafOptions,
+  }) async {
+    final result = await pickFiles(
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      allowMultiple: false,
+      withData: withData,
+      withReadStream: withReadStream,
+      lockParentWindow: lockParentWindow,
+      readSequential: readSequential,
+      cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
+      androidSafOptions: androidSafOptions,
+    );
+
+    return result?.files.firstOrNull;
   }
 
   /// Displays a dialog that allows the user to select both files and

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -136,7 +136,7 @@ abstract final class FilePicker {
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
   }) async {
-    final result = await pickFiles(
+    final result = await FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -58,6 +58,10 @@ abstract final class FilePicker {
   /// Returns `null` if aborted.
   /// NOTE: `allowMultiple` is deprecated. Use `pickFile` for single-file
   /// selection; `pickFiles` now implies multiple selection by default.
+  /// NOTE: `withData`, `withReadStream` and `readSequential` are deprecated.
+  /// Call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` on
+  /// the returned `PlatformFile` to load data on demand. These parameters
+  /// will be removed in a future release.
   static Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
@@ -69,9 +73,18 @@ abstract final class FilePicker {
       'use pickFile for single-file selection; this parameter will be removed in a future release',
     )
     bool allowMultiple = true,
+    @Deprecated(
+      'Use PlatformFile.readAsBytes(); this parameter will be removed in a future release',
+    )
     bool withData = kIsWeb,
+    @Deprecated(
+      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
+    )
     bool withReadStream = false,
     bool lockParentWindow = false,
+    @Deprecated(
+      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
+    )
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
@@ -107,9 +120,18 @@ abstract final class FilePicker {
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
+    @Deprecated(
+      'Use PlatformFile.readAsBytes(); this parameter will be removed in a future release',
+    )
     bool withData = kIsWeb,
+    @Deprecated(
+      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
+    )
     bool withReadStream = false,
     bool lockParentWindow = false,
+    @Deprecated(
+      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
+    )
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -243,25 +243,21 @@ abstract final class FilePicker {
     );
   }
 
-  /// Opens a save file dialog which lets the user select a file path and a file
-  /// name to save a file.
+  /// Opens a save file dialog to let the user select a location and a file name to
+  /// save [bytes] to.
   ///
-  /// For mobile, this function will save a file with the given [fileName] and [bytes] and return the path where the file was saved.
+  /// Returns a [Future<String?>] which resolves to the absolute path of the
+  /// saved file, or `null` if the user canceled the operation.
   ///
-  /// For desktop platforms, this function opens a dialog to let the user choose a location for the file and returns the selected path.
-  /// If the bytes are provided, then the bytes are written to a file at the chosen path.
-  ///
-  /// On the web, this function will start a download for the file with [bytes] and [fileName].
-  /// If the [bytes] or [fileName] are omitted, this will throw an [ArgumentError].
-  /// The returned path for the downloaded file will always be `null`, as the browser handles the download.
+  /// On the web, this starts a download and always returns `null`.
   ///
   /// The User Selected File Read/Write entitlement is required on macOS.
   ///
   /// [dialogTitle] can be set to display a custom title on desktop platforms.
   /// Not supported on macOS.
   ///
-  /// [fileName] can be set to a non-empty string to provide a default file
-  /// name. Throws an `IllegalCharacterInFileNameException` under Windows if the
+  /// [fileName] should be set to provide a default file name.
+  /// Throws an `IllegalCharacterInFileNameException` under Windows if the
   /// given [fileName] contains forbidden characters.
   ///
   /// [initialDirectory] can be optionally set to an absolute path to specify
@@ -279,15 +275,14 @@ abstract final class FilePicker {
   /// stay in front of the Flutter window until it is closed (like a modal
   /// window). This parameter works only on Windows desktop.
   ///
-  /// Returns `null` if aborted. Returns a [Future<String?>] which resolves to
-  /// the absolute path of the selected file, if the user selected a file.
+  /// Returns `null` if aborted.
   static Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) {

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -119,19 +119,7 @@ abstract final class FilePicker {
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
-    @Deprecated(
-      'Use PlatformFile.readAsBytes(); this parameter will be removed in a future release',
-    )
-    bool withData = kIsWeb,
-    @Deprecated(
-      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
-    )
-    bool withReadStream = false,
     bool lockParentWindow = false,
-    @Deprecated(
-      'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
-    )
-    bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
   }) async {
@@ -143,10 +131,10 @@ abstract final class FilePicker {
       onFileLoading: onFileLoading,
       compressionQuality: compressionQuality,
       allowMultiple: false,
-      withData: withData,
-      withReadStream: withReadStream,
+      withData: false,
+      withReadStream: false,
       lockParentWindow: lockParentWindow,
-      readSequential: readSequential,
+      readSequential: false,
       cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
       androidSafOptions: androidSafOptions,
     );

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -56,7 +56,6 @@ abstract final class FilePicker {
   /// Note: This requires the User Selected File Read entitlement on macOS.
   ///
   /// Returns `null` if aborted.
-  /// NOTE: `allowMultiple` is deprecated. Use `pickFile` for single-file
   /// selection; `pickFiles` now implies multiple selection by default.
   /// NOTE: `withData`, `withReadStream` and `readSequential` are deprecated.
   /// Call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` on

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -160,20 +160,14 @@ class MethodChannelFilePicker extends FilePickerPlatform {
   @override
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes == null) {
-      throw ArgumentError(
-        'The "bytes" parameter is required on Android & iOS when calling "saveFile".',
-      );
-    }
-
     try {
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.picking);

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -84,11 +84,11 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// name to save a file.
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -159,17 +159,17 @@ class FilePickerLinux extends FilePickerPlatform {
   @override
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
-      'current_name': DBusString(fileName ?? ''),
+      'current_name': DBusString(fileName),
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -99,11 +99,11 @@ class FilePickerMacOS extends FilePickerPlatform {
   @override
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -212,21 +212,21 @@ class FilePickerWeb extends FilePickerPlatform {
   @override
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes == null || bytes.isEmpty) {
+    if (bytes.isEmpty) {
       throw ArgumentError(
         'The bytes are required when saving a file on the web.',
       );
     }
 
-    if (fileName == null || fileName.isEmpty) {
+    if (fileName.isEmpty) {
       throw ArgumentError(
         'A file name is required when saving a file on the web.',
       );

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -180,11 +180,11 @@ class FilePickerWindows extends FilePickerPlatform {
   @override
   Future<String?> saveFile({
     String? dialogTitle,
-    String? fileName,
+    required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -43,8 +43,10 @@ void main() {
         readStream,
       );
 
+      // ignore: deprecated_member_use_from_same_package
       expect(platformFile.bytes, equals(bytes));
       expect(platformFile.name, equals('test_utils.jpg'));
+      // ignore: deprecated_member_use_from_same_package
       expect(platformFile.readStream, equals(readStream));
       expect(platformFile.size, equals(bytes.length));
     });
@@ -62,6 +64,7 @@ void main() {
 
         expect(platformFile.bytes, equals(null));
         expect(platformFile.name, equals('test_utils.app'));
+        // ignore: deprecated_member_use_from_same_package
         expect(platformFile.readStream, equals(null));
         expect(
           platformFile.size,

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -43,10 +43,8 @@ void main() {
         readStream,
       );
 
-      // ignore: deprecated_member_use_from_same_package
       expect(platformFile.bytes, equals(bytes));
       expect(platformFile.name, equals('test_utils.jpg'));
-      // ignore: deprecated_member_use_from_same_package
       expect(platformFile.readStream, equals(readStream));
       expect(platformFile.size, equals(bytes.length));
     });
@@ -64,7 +62,6 @@ void main() {
 
         expect(platformFile.bytes, equals(null));
         expect(platformFile.name, equals('test_utils.app'));
-        // ignore: deprecated_member_use_from_same_package
         expect(platformFile.readStream, equals(null));
         expect(
           platformFile.size,


### PR DESCRIPTION
This PR implements the suggestions from issue #1469 to improve the Developer Experience (DX). 
## Changes: 
- Added FilePicker.pickFile() convenience method for single selections. 
- Improved PlatformFile documentation regarding nullability and memory usage. 
- Updated example app and README.md.