### PR TITLE
fix(darwin): add missing FlutterFramework dependency to Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)
 
+### Darwin
+- Added missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager (SPM) compatibility.
+
 ## 12.0.0-beta.3
 ### General
 - Added `onFileLoading` callback to `saveFile` and implemented status tracking via an event channel. `saveFile` now reports loading status (for example `FilePickerStatus.loading` and `FilePickerStatus.done`).

--- a/darwin/file_picker/Package.swift
+++ b/darwin/file_picker/Package.swift
@@ -12,11 +12,15 @@ let package = Package(
     products: [
         .library(name: "file-picker", targets: ["file_picker"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "file_picker",
-            dependencies: [],
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
             ]


### PR DESCRIPTION
This PR adds the missing FlutterFramework dependency to the shared Darwin Package.swift to fix Swift Package Manager (SPM) build warnings when running the macOS/iOS apps.

Before:
```sh
Try `flutter pub outdated` for more information.
Plugin file_picker has a Package.swift for ios but is missing a dependency on FlutterFramework. Add the following to your Package.swift dependencies:
    .package(name: "FlutterFramework", path: "../FlutterFramework")
And add FlutterFramework as a target dependency:
    .product(name: "FlutterFramework", package: "FlutterFramework")
See https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors for more information.
Plugin file_picker has a Package.swift for macos but is missing a dependency on FlutterFramework. Add the following to your Package.swift dependencies:
    .package(name: "FlutterFramework", path: "../FlutterFramework")
And add FlutterFramework as a target dependency:
    .product(name: "FlutterFramework", package: "FlutterFramework")
See https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors for more information.
Launching lib/main.dart on macOS in debug mode...
warning: Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Flutter Assemble' from project 'Runner')
✓ Built build/macos/Build/Products/Debug/file_picker_example.app
2026-05-20 17:28:51.997 file_picker_example[31957:3146073] Running with merged UI and platform thread. Experimental.
Failed to foreground app; open returned 1
Connecting to VM Service at ws://127.0.0.1:64153/i_EW8R4RJjo=/ws
Connected to the VM Service.
Lost connection to device.
```

After:
```sh
Launching lib/main.dart on macOS in debug mode...
✓ Built build/macos/Build/Products/Debug/file_picker_example.app
2026-05-20 17:36:58.274 file_picker_example[34985:3171120] Running with merged UI and platform thread. Experimental.
Failed to foreground app; open returned 1
Connecting to VM Service at ws://127.0.0.1:64952/gwZ7Ct7Gjvk=/ws
Connected to the VM Service.
```