### PR TITLE
fix(android): remove explicit KGP dependency to resolve warnings under AGP 9.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)
 - Removed explicit Kotlin Gradle Plugin (KGP) application and dependencies from build files to resolve warnings under AGP 9.0+.
+- Updated Android build tooling and dependencies: Android Gradle Plugin bumped to `8.5.2`, `androidx.lifecycle:lifecycle-runtime` updated to `2.10.0`, and `org.apache.tika:tika-core` updated to `3.3.0`.
 
 ### Darwin
 - Added missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager (SPM) compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)
+- Removed explicit Kotlin Gradle Plugin (KGP) application and dependencies from build files to resolve warnings under AGP 9.0+.
 
 ### Darwin
 - Added missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager (SPM) compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)
 - Removed explicit Kotlin Gradle Plugin (KGP) application and dependencies from build files to resolve warnings under AGP 9.0+.
-- Updated Android build tooling and dependencies: Android Gradle Plugin bumped to `8.5.2`, `androidx.lifecycle:lifecycle-runtime` updated to `2.10.0`, and `org.apache.tika:tika-core` updated to `3.3.0`.
+- Updated Android build tooling and dependencies: Android Gradle Plugin bumped to `8.5.2`, `androidx.core:core` and `androidx.core:core-ktx` updated to `1.18.0`, `androidx.lifecycle:lifecycle-runtime` updated to `2.10.0`, and `org.apache.tika:tika-core` updated to `3.3.0`.
 
 ### Darwin
 - Added missing `FlutterFramework` dependency to `Package.swift` for Swift Package Manager (SPM) compatibility.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.1'
+        classpath 'com.android.tools.build:gradle:8.5.2'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,9 +2,6 @@ group 'com.mr.flutter.plugin.filepicker'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext {
-        kotlin_version = '1.8.22'
-    }
     repositories {
         google()
         mavenCentral()
@@ -12,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.5.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -23,15 +19,7 @@ rootProject.allprojects {
     }
 }
 
-def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
-def builtInKotlinProperty = providers.gradleProperty('android.builtInKotlin').orNull
-def isBuiltInKotlinEnabled = isAgp9OrAbove && (builtInKotlinProperty == null || builtInKotlinProperty.toBoolean())
-def shouldApplyKotlinAndroidPlugin = !isAgp9OrAbove || !isBuiltInKotlinEnabled
-
 apply plugin: 'com.android.library'
-if (shouldApplyKotlinAndroidPlugin) {
-    apply plugin: 'org.jetbrains.kotlin.android'
-}
 
 android {
     compileSdk flutter.compileSdkVersion
@@ -50,11 +38,15 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    if (shouldApplyKotlinAndroidPlugin) {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_17.toString()
+    tasks.configureEach { task ->
+        if (task.class.name.contains("KotlinCompile")) {
+            task.kotlinOptions {
+                jvmTarget = "17"
+            }
         }
     }
+
+
     
     dependencies {
         implementation 'androidx.core:core:1.15.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,18 +41,16 @@ android {
     tasks.configureEach { task ->
         if (task.class.name.contains("KotlinCompile")) {
             task.kotlinOptions {
-                jvmTarget = "17"
+                jvmTarget = JavaVersion.VERSION_17.toString()
             }
         }
     }
 
-
-    
     dependencies {
-        implementation 'androidx.core:core:1.15.0'
-        implementation 'androidx.annotation:annotation:1.9.1'
-        implementation "androidx.lifecycle:lifecycle-runtime:2.8.7"
-        implementation "org.apache.tika:tika-core:3.2.3"
+        implementation 'androidx.core:core:1.18.0'
+        implementation 'androidx.annotation:annotation:1.10.0'
+        implementation "androidx.lifecycle:lifecycle-runtime:2.10.0"
+        implementation "org.apache.tika:tika-core:3.3.0"
     }
 
     if (project.android.hasProperty("namespace")) {
@@ -60,5 +58,5 @@ android {
     }
 }
 dependencies {
-    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.core:core-ktx:1.18.0'
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.newDsl=false
 android.enableJetifier=true
+android.builtInKotlin=false


### PR DESCRIPTION
This PR removes the explicit application and dependencies of the Kotlin Gradle Plugin (KGP) in the plugin module to resolve warnings about legacy KGP usage under AGP 9.0+.

Additionally, it adds a dynamic configuration block to align the Kotlin compiler's JVM target bytecode with Java (JVM 17) to prevent target compatibility mismatch errors when compiling.

It also adds `android.builtInKotlin=false` to the example app's gradle.properties to allow compatibility with other third-party dependencies (like `flutter_plugin_android_lifecycle`) that still require external KGP.

Resolves this warning:
```sh
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): file_picker
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.

Please check the changelogs of these plugins and upgrade to a version that supports Built-in Kotlin.
If no such version exists, report the issue to the plugin. If necessary, here is a guide on filing 
an issue against a plugin: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers#report-incompatible-kotlin-gradle-plugin-usage-to-plugin-authors

If you are a plugin author, please migrate your plugin to Built-in Kotlin using this guide: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
```

I have tested this using AGP 8 and AGP 9.