### PR TITLE
feat: summarize file bytes in debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improved documentation for `PlatformFile` properties (`path`, `bytes`, `readStream`) to clarify nullability and usage across platforms. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)
 - **BREAKING CHANGE**: The `allowMultiple` parameter on `pickFiles()` now defaults to `true`. Use `pickFile()` for single-file selection. (`allowMultiple` is deprecated and will be removed in a future release.)
 - Deprecated `withData`, `withReadStream`, and `readSequential` on `pickFiles()`/`pickFile()`. Users should call `PlatformFile.readAsBytes()` or `PlatformFile.readAsByteStream()` to load file data on demand. These parameters will be removed in a future release.
+- Improved `PlatformFile.toString()` output to display byte length instead of full content.
 
 ### Android
 - Fixed an issue where `FileType.any` would prevent subdirectories from being listed in the system file explorer by ensuring `EXTRA_MIME_TYPES` is correctly passed as an array. [#2013](https://github.com/miguelpruivo/flutter_file_picker/issues/2013)

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -153,7 +153,7 @@ class PlatformFile {
 
   @override
   String toString() {
-    return 'PlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size)';
+    return 'PlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytesLength: ${bytes?.lengthInBytes}, readStream: ${readStream != null}, size: $size)';
   }
 }
 
@@ -184,6 +184,6 @@ class AndroidPlatformFile extends PlatformFile {
 
   @override
   String toString() {
-    return 'AndroidPlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytes: $bytes, readStream: $readStream, size: $size, safHandle: $safHandle)';
+    return 'AndroidPlatformFile(${kIsWeb ? '' : 'path $path'}, name: $name, bytesLength: ${bytes?.lengthInBytes}, readStream: ${readStream != null}, size: $size, safHandle: $safHandle)';
   }
 }

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -200,6 +200,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       rethrow;
     } finally {
       await _eventSubscription?.cancel();
+      _eventSubscription = null;
     }
   }
 }

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -47,6 +47,8 @@ void main() {
       expect(platformFile.name, equals('test_utils.jpg'));
       expect(platformFile.readStream, equals(readStream));
       expect(platformFile.size, equals(bytes.length));
+      expect(platformFile.toString(), contains('bytesLength: ${bytes.length}'));
+      expect(platformFile.toString(), isNot(contains('Uint8List')));
     });
 
     test(


### PR DESCRIPTION
This PR follows up on the maintainer discussion here: https://github.com/miguelpruivo/flutter_file_picker/pull/2018#issuecomment-4499914223

Summary:
- Ensure the native event subscription is properly cleared in the finally block
- Updates PlatformFile.toString() / AndroidPlatformFile.toString() to show byte length instead of dumping the full payload
- Adds a changelog entry for the change
- Adds a test to ensure the debug output no longer prints full byte content
