### PR TITLE
feat: offload Android file saving to background thread

### DIFF
--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -11,6 +11,9 @@ import com.mr.flutter.plugin.filepicker.FileUtils.processFiles
 import io.flutter.plugin.common.EventChannel.EventSink
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.IOException
 
 class FilePickerDelegate(
@@ -72,15 +75,26 @@ class FilePickerDelegate(
         uri ?: return false
         dispatchEventStatus(true)
         return try {
-            val savedUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
-            val renamedUri = maybeRenameGenericMimeDuplicate(
-                context = activity,
-                uri = savedUri,
-                originalFileName = saveFileName,
-                mimeType = saveMimeType
-            )
-            finishWithSuccess(renamedUri.path)
-            true
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val savedUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
+                    val renamedUri = maybeRenameGenericMimeDuplicate(
+                        context = activity,
+                        uri = savedUri,
+                        originalFileName = saveFileName,
+                        mimeType = saveMimeType
+                    )
+                    Handler(Looper.getMainLooper()).post {
+                        finishWithSuccess(renamedUri.path)
+                    }
+                } catch (e: IOException) {
+                    Log.e(TAG, "Error while saving file", e)
+                    Handler(Looper.getMainLooper()).post {
+                        finishWithError("Error while saving file", e.message)
+                    }
+                }
+            }
+            return true
         } catch (e: IOException) {
             Log.e(TAG, "Error while saving file", e)
             finishWithError("Error while saving file", e.message)

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -279,10 +279,6 @@ final class IOSFilePickerHandler: NSObject,
             return name
         }
 
-        if let ext = inferExtensionFromAllowed(arguments) {
-            return name + "." + ext
-        }
-
         if let fileType = arguments["fileType"] as? String, let ext = inferExtensionFromFileType(fileType) {
             return name + "." + ext
         }
@@ -292,13 +288,6 @@ final class IOSFilePickerHandler: NSObject,
         }
 
         return name
-    }
-
-    private func inferExtensionFromAllowed(_ arguments: [String: Any]) -> String? {
-        guard let allowed = arguments["allowedExtensions"] as? [String], let first = allowed.first, !first.isEmpty else {
-            return nil
-        }
-        return sanitizeExtension(first)
     }
 
     private func inferExtensionFromFileType(_ fileType: String) -> String? {
@@ -332,11 +321,6 @@ final class IOSFilePickerHandler: NSObject,
         }
 
         return nil
-    }
-
-    private func sanitizeExtension(_ ext: String) -> String {
-        let e = ext.hasPrefix(".") ? String(ext.dropFirst()) : ext
-        return e.lowercased()
     }
 
     private func writeTempFile(named fileName: String, data: Data?) throws -> URL {

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -247,36 +247,112 @@ final class IOSFilePickerHandler: NSObject,
 
     private func saveFile(_ arguments: [String: Any]) {
         isSaveFile = true
-        let fileName = (arguments["fileName"] as? String) ?? ""
+
         let bytes = arguments["bytes"] as? FlutterStandardTypedData
 
-        let tempFile = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(fileName)
+        let finalFileName = inferFileName(from: arguments, bytes: bytes)
 
         do {
-            if FileManager.default.fileExists(atPath: tempFile.path) {
-                try FileManager.default.removeItem(at: tempFile)
-            }
-            if let data = bytes?.data {
-                try data.write(to: tempFile, options: .atomic)
-            }
+            let tempFile = try writeTempFile(named: finalFileName, data: bytes?.data)
+
+            let picker = UIDocumentPickerViewController(
+                forExporting: [tempFile],
+                asCopy: true)
+            picker.delegate = self
+            picker.presentationController?.delegate = self
+            topViewController()?.present(picker, animated: true)
         } catch {
-            result?(
-                FlutterError(
-                    code: "Failed to write file",
-                    message: error.localizedDescription,
-                    details: nil))
+            result?(FlutterError(
+                code: "Failed to write file",
+                message: error.localizedDescription,
+                details: nil))
             result = nil
             isSaveFile = false
             return
         }
+    }
 
-        let picker = UIDocumentPickerViewController(
-            forExporting: [tempFile],
-            asCopy: true)
-        picker.delegate = self
-        picker.presentationController?.delegate = self
-        topViewController()?.present(picker, animated: true)
+    private func inferFileName(from arguments: [String: Any], bytes: FlutterStandardTypedData?) -> String {
+        var name = (arguments["fileName"] as? String) ?? ""
+
+        if !(name as NSString).pathExtension.isEmpty {
+            return name
+        }
+
+        if let ext = inferExtensionFromAllowed(arguments) {
+            return name + "." + ext
+        }
+
+        if let fileType = arguments["fileType"] as? String, let ext = inferExtensionFromFileType(fileType) {
+            return name + "." + ext
+        }
+
+        if let data = bytes?.data, let ext = inferExtensionFromBytes(data) {
+            return name + "." + ext
+        }
+
+        return name
+    }
+
+    private func inferExtensionFromAllowed(_ arguments: [String: Any]) -> String? {
+        guard let allowed = arguments["allowedExtensions"] as? [String], let first = allowed.first, !first.isEmpty else {
+            return nil
+        }
+        return sanitizeExtension(first)
+    }
+
+    private func inferExtensionFromFileType(_ fileType: String) -> String? {
+        switch fileType {
+        case "image": return "jpg"
+        case "video": return "mp4"
+        case "audio": return "mp3"
+        default: return nil
+        }
+    }
+
+    private func inferExtensionFromBytes(_ data: Data) -> String? {
+        if data.count >= 4, let header = String(data: data.subdata(in: 0..<4), encoding: .utf8), header == "%PDF" {
+            return "pdf"
+        }
+
+        let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+        if data.count >= 4 && data.starts(with: Data(pngSignature)) {
+            return "png"
+        }
+
+        if data.count >= 2 {
+            let bytes = [UInt8](data.prefix(2))
+            if bytes[0] == 0xFF && bytes[1] == 0xD8 {
+                return "jpg"
+            }
+        }
+
+        if data.count >= 6, let gifHeader = String(data: data.subdata(in: 0..<6), encoding: .ascii), gifHeader.hasPrefix("GIF") {
+            return "gif"
+        }
+
+        return nil
+    }
+
+    private func sanitizeExtension(_ ext: String) -> String {
+        let e = ext.hasPrefix(".") ? String(ext.dropFirst()) : ext
+        return e.lowercased()
+    }
+
+    private func writeTempFile(named fileName: String, data: Data?) throws -> URL {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+
+        if FileManager.default.fileExists(atPath: tempURL.path) {
+            try FileManager.default.removeItem(at: tempURL)
+        }
+
+        if let d = data {
+            try d.write(to: tempURL, options: .atomic)
+        } else {
+            FileManager.default.createFile(atPath: tempURL.path, contents: nil, attributes: nil)
+        }
+
+        return tempURL
     }
 
     private func resolveCustomContentTypes(_ allowedExtensions: [String]) -> [UTType] {

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -185,11 +185,14 @@ class MethodChannelFilePicker extends FilePickerPlatform {
           .invokeMethod<String>("save", {
             "fileName": fileName,
             "fileType": type.name,
+            "bytes": bytes,
             "initialDirectory": initialDirectory,
             "allowedExtensions": allowedExtensions,
           });
 
-      await FilePickerUtils.saveBytesToFile(bytes, savedPath);
+      if (!Platform.isAndroid) {
+        await FilePickerUtils.saveBytesToFile(bytes, savedPath);
+      }
 
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.done);


### PR DESCRIPTION
- Pass file bytes directly to the native Android implementation in `saveFile`
- Use Coroutines and `Dispatchers.IO` on Android to perform file I/O operations without blocking the main thread
- Skip redundant Dart-side file saving when the platform is Android