### PR TITLE
Feature/save file refactor - centralize filename and extension resolution in Dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,12 @@ if (selectedDirectory == null) {
 ```
 #### Save-file / save-as dialog
 ```dart
+final Uint8List pdfBytes = await File('source-file.pdf').readAsBytes();
+
 String? outputFile = await FilePicker.saveFile(
   dialogTitle: 'Please select an output file:',
   fileName: 'output-file.pdf',
+  bytes: pdfBytes,
 );
 
 if (outputFile == null) {

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -11,6 +11,9 @@ import com.mr.flutter.plugin.filepicker.FileUtils.processFiles
 import io.flutter.plugin.common.EventChannel.EventSink
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.IOException
 
 class FilePickerDelegate(
@@ -72,15 +75,26 @@ class FilePickerDelegate(
         uri ?: return false
         dispatchEventStatus(true)
         return try {
-            val savedUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
-            val renamedUri = maybeRenameGenericMimeDuplicate(
-                context = activity,
-                uri = savedUri,
-                originalFileName = saveFileName,
-                mimeType = saveMimeType
-            )
-            finishWithSuccess(renamedUri.path)
-            true
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val savedUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
+                    val renamedUri = maybeRenameGenericMimeDuplicate(
+                        context = activity,
+                        uri = savedUri,
+                        originalFileName = saveFileName,
+                        mimeType = saveMimeType
+                    )
+                    Handler(Looper.getMainLooper()).post {
+                        finishWithSuccess(renamedUri.path)
+                    }
+                } catch (e: IOException) {
+                    Log.e(TAG, "Error while saving file", e)
+                    Handler(Looper.getMainLooper()).post {
+                        finishWithError("Error while saving file", e.message)
+                    }
+                }
+            }
+            return true
         } catch (e: IOException) {
             Log.e(TAG, "Error while saving file", e)
             finishWithError("Error while saving file", e.message)

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mr.flutter.plugin.filepicker.FileUtils.clearCache
-import com.mr.flutter.plugin.filepicker.FileUtils.getFileExtension
 import com.mr.flutter.plugin.filepicker.FileUtils.getMimeTypes
 import com.mr.flutter.plugin.filepicker.FileUtils.saveFile
 import com.mr.flutter.plugin.filepicker.FileUtils.startFileExplorer
@@ -153,12 +152,8 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
                 val type = resolveType(arguments?.get("fileType") as String)
                 val initialDirectory = arguments?.get("initialDirectory") as String?
                 val bytes = arguments?.get("bytes") as ByteArray?
-                val fileNameWithoutExtension = "${arguments?.get("fileName")}"
-                val fileName =
-                    if (fileNameWithoutExtension.isNotEmpty() && !fileNameWithoutExtension.contains(
-                            "."
-                        )
-                    ) "$fileNameWithoutExtension.${getFileExtension(bytes)}" else fileNameWithoutExtension
+                val providedName = (arguments?.get("fileName") as? String)?.trim()
+                val fileName = if (providedName.isNullOrEmpty()) "file" else providedName
                 delegate?.saveFile(fileName, type, initialDirectory, bytes, result)
             }
 

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -250,7 +250,7 @@ final class IOSFilePickerHandler: NSObject,
 
         let bytes = arguments["bytes"] as? FlutterStandardTypedData
 
-        let finalFileName = inferFileName(from: arguments, bytes: bytes)
+        let finalFileName = inferFileName(from: arguments)
 
         do {
             let tempFile = try writeTempFile(named: finalFileName, data: bytes?.data)
@@ -272,55 +272,11 @@ final class IOSFilePickerHandler: NSObject,
         }
     }
 
-    private func inferFileName(from arguments: [String: Any], bytes: FlutterStandardTypedData?) -> String {
-        var name = (arguments["fileName"] as? String) ?? ""
-
-        if !(name as NSString).pathExtension.isEmpty {
-            return name
-        }
-
-        if let fileType = arguments["fileType"] as? String, let ext = inferExtensionFromFileType(fileType) {
-            return name + "." + ext
-        }
-
-        if let data = bytes?.data, let ext = inferExtensionFromBytes(data) {
-            return name + "." + ext
-        }
-
-        return name
-    }
-
-    private func inferExtensionFromFileType(_ fileType: String) -> String? {
-        switch fileType {
-        case "image": return "jpg"
-        case "video": return "mp4"
-        case "audio": return "mp3"
-        default: return nil
-        }
-    }
-
-    private func inferExtensionFromBytes(_ data: Data) -> String? {
-        if data.count >= 4, let header = String(data: data.subdata(in: 0..<4), encoding: .utf8), header == "%PDF" {
-            return "pdf"
-        }
-
-        let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
-        if data.count >= 4 && data.starts(with: Data(pngSignature)) {
-            return "png"
-        }
-
-        if data.count >= 2 {
-            let bytes = [UInt8](data.prefix(2))
-            if bytes[0] == 0xFF && bytes[1] == 0xD8 {
-                return "jpg"
-            }
-        }
-
-        if data.count >= 6, let gifHeader = String(data: data.subdata(in: 0..<6), encoding: .ascii), gifHeader.hasPrefix("GIF") {
-            return "gif"
-        }
-
-        return nil
+    private func inferFileName(from arguments: [String: Any]) -> String {
+        let rawName = ((arguments["fileName"] as? String) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let safeName = URL(fileURLWithPath: rawName).lastPathComponent
+        return safeName.isEmpty ? "file" : safeName
     }
 
     private func writeTempFile(named fileName: String, data: Data?) throws -> URL {

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -279,10 +279,6 @@ final class IOSFilePickerHandler: NSObject,
             return name
         }
 
-        if let ext = inferExtensionFromAllowed(arguments) {
-            return name + "." + ext
-        }
-
         if let fileType = arguments["fileType"] as? String, let ext = inferExtensionFromFileType(fileType) {
             return name + "." + ext
         }
@@ -292,13 +288,6 @@ final class IOSFilePickerHandler: NSObject,
         }
 
         return name
-    }
-
-    private func inferExtensionFromAllowed(_ arguments: [String: Any]) -> String? {
-        guard let allowed = arguments["allowedExtensions"] as? [String], let first = allowed.first, !first.isEmpty else {
-            return nil
-        }
-        return sanitizeExtension(first)
     }
 
     private func inferExtensionFromFileType(_ fileType: String) -> String? {
@@ -332,11 +321,6 @@ final class IOSFilePickerHandler: NSObject,
         }
 
         return nil
-    }
-
-    private func sanitizeExtension(_ ext: String) -> String {
-        let e = ext.hasPrefix(".") ? String(ext.dropFirst()) : ext
-        return e.lowercased()
     }
 
     private func writeTempFile(named fileName: String, data: Data?) throws -> URL {

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -247,36 +247,112 @@ final class IOSFilePickerHandler: NSObject,
 
     private func saveFile(_ arguments: [String: Any]) {
         isSaveFile = true
-        let fileName = (arguments["fileName"] as? String) ?? ""
+
         let bytes = arguments["bytes"] as? FlutterStandardTypedData
 
-        let tempFile = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(fileName)
+        let finalFileName = inferFileName(from: arguments, bytes: bytes)
 
         do {
-            if FileManager.default.fileExists(atPath: tempFile.path) {
-                try FileManager.default.removeItem(at: tempFile)
-            }
-            if let data = bytes?.data {
-                try data.write(to: tempFile, options: .atomic)
-            }
+            let tempFile = try writeTempFile(named: finalFileName, data: bytes?.data)
+
+            let picker = UIDocumentPickerViewController(
+                forExporting: [tempFile],
+                asCopy: true)
+            picker.delegate = self
+            picker.presentationController?.delegate = self
+            topViewController()?.present(picker, animated: true)
         } catch {
-            result?(
-                FlutterError(
-                    code: "Failed to write file",
-                    message: error.localizedDescription,
-                    details: nil))
+            result?(FlutterError(
+                code: "Failed to write file",
+                message: error.localizedDescription,
+                details: nil))
             result = nil
             isSaveFile = false
             return
         }
+    }
 
-        let picker = UIDocumentPickerViewController(
-            forExporting: [tempFile],
-            asCopy: true)
-        picker.delegate = self
-        picker.presentationController?.delegate = self
-        topViewController()?.present(picker, animated: true)
+    private func inferFileName(from arguments: [String: Any], bytes: FlutterStandardTypedData?) -> String {
+        var name = (arguments["fileName"] as? String) ?? ""
+
+        if !(name as NSString).pathExtension.isEmpty {
+            return name
+        }
+
+        if let ext = inferExtensionFromAllowed(arguments) {
+            return name + "." + ext
+        }
+
+        if let fileType = arguments["fileType"] as? String, let ext = inferExtensionFromFileType(fileType) {
+            return name + "." + ext
+        }
+
+        if let data = bytes?.data, let ext = inferExtensionFromBytes(data) {
+            return name + "." + ext
+        }
+
+        return name
+    }
+
+    private func inferExtensionFromAllowed(_ arguments: [String: Any]) -> String? {
+        guard let allowed = arguments["allowedExtensions"] as? [String], let first = allowed.first, !first.isEmpty else {
+            return nil
+        }
+        return sanitizeExtension(first)
+    }
+
+    private func inferExtensionFromFileType(_ fileType: String) -> String? {
+        switch fileType {
+        case "image": return "jpg"
+        case "video": return "mp4"
+        case "audio": return "mp3"
+        default: return nil
+        }
+    }
+
+    private func inferExtensionFromBytes(_ data: Data) -> String? {
+        if data.count >= 4, let header = String(data: data.subdata(in: 0..<4), encoding: .utf8), header == "%PDF" {
+            return "pdf"
+        }
+
+        let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+        if data.count >= 4 && data.starts(with: Data(pngSignature)) {
+            return "png"
+        }
+
+        if data.count >= 2 {
+            let bytes = [UInt8](data.prefix(2))
+            if bytes[0] == 0xFF && bytes[1] == 0xD8 {
+                return "jpg"
+            }
+        }
+
+        if data.count >= 6, let gifHeader = String(data: data.subdata(in: 0..<6), encoding: .ascii), gifHeader.hasPrefix("GIF") {
+            return "gif"
+        }
+
+        return nil
+    }
+
+    private func sanitizeExtension(_ ext: String) -> String {
+        let e = ext.hasPrefix(".") ? String(ext.dropFirst()) : ext
+        return e.lowercased()
+    }
+
+    private func writeTempFile(named fileName: String, data: Data?) throws -> URL {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+
+        if FileManager.default.fileExists(atPath: tempURL.path) {
+            try FileManager.default.removeItem(at: tempURL)
+        }
+
+        if let d = data {
+            try d.write(to: tempURL, options: .atomic)
+        } else {
+            FileManager.default.createFile(atPath: tempURL.path, contents: nil, attributes: nil)
+        }
+
+        return tempURL
     }
 
     private func resolveCustomContentTypes(_ allowedExtensions: [String]) -> [UTType] {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,5 +2,3 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.newDsl=false
 android.enableJetifier=true
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,3 +2,5 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 android.newDsl=false
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -273,12 +273,6 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _resetState();
 
     try {
-      final webPath = kIsWeb &&
-              file.path != null &&
-              (file.path!.startsWith('blob:') || file.path!.startsWith('data:'))
-          ? file.path
-          : null;
-
       pickedSaveFilePath = await FilePicker.saveFile(
         allowedExtensions: _allowedExtensionsFromInput(),
         type: FileType.custom,
@@ -286,8 +280,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         fileName: fileName,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
-        path: webPath,
-        bytes: webPath == null ? await file.readAsBytes() : null,
+        bytes: await file.readAsBytes(),
       );
 
       hasUserAborted = pickedSaveFilePath == null;
@@ -318,8 +311,9 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
 
     final originalName = file?.name ?? '';
     final dotIndex = originalName.lastIndexOf('.');
-    final originalExtension =
-        dotIndex >= 0 ? originalName.substring(dotIndex) : '';
+    final originalExtension = dotIndex >= 0
+        ? originalName.substring(dotIndex)
+        : '';
 
     if (inputFileName.contains('.') || originalExtension.isEmpty) {
       return inputFileName;

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -261,7 +261,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     bool hasUserAborted = true;
 
     final file = pickedFiles?.firstOrNull;
-    final fileName = _defaultFileNameController.text;
+    final fileName = _resolveSaveFileName(file);
 
     if (file == null || fileName.isEmpty) {
       _logException(
@@ -270,11 +270,15 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       return;
     }
 
-    final bytes = await file.readAsBytes();
-
     _resetState();
 
     try {
+      final webPath = kIsWeb &&
+              file.path != null &&
+              (file.path!.startsWith('blob:') || file.path!.startsWith('data:'))
+          ? file.path
+          : null;
+
       pickedSaveFilePath = await FilePicker.saveFile(
         allowedExtensions: _allowedExtensionsFromInput(),
         type: FileType.custom,
@@ -282,8 +286,10 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         fileName: fileName,
         initialDirectory: _initialDirectoryController.text,
         lockParentWindow: _lockParentWindow,
-        bytes: bytes,
+        path: webPath,
+        bytes: webPath == null ? await file.readAsBytes() : null,
       );
+
       hasUserAborted = pickedSaveFilePath == null;
     } on PlatformException catch (e) {
       _logException('Unsupported operation: $e');
@@ -292,19 +298,34 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     }
     if (!mounted) return;
 
+    if (pickedSaveFilePath != null) {
+      _scaffoldMessengerKey.currentState?.showSnackBar(
+        SnackBar(content: Text('Saved file: $pickedSaveFilePath')),
+      );
+    }
+
     setState(() {
       _isLoading = false;
       _userAborted = hasUserAborted;
-      _resultsWidget = FilePickerResultsList(
-        itemCount: pickedSaveFilePath != null ? 1 : 0,
-        itemBuilder: (BuildContext context, int index) {
-          return ListTile(
-            title: const Text('Save file path:'),
-            subtitle: Text(pickedSaveFilePath ?? ''),
-          );
-        },
-      );
     });
+  }
+
+  String _resolveSaveFileName(PlatformFile? file) {
+    final inputFileName = _defaultFileNameController.text.trim();
+    if (inputFileName.isEmpty) {
+      return '';
+    }
+
+    final originalName = file?.name ?? '';
+    final dotIndex = originalName.lastIndexOf('.');
+    final originalExtension =
+        dotIndex >= 0 ? originalName.substring(dotIndex) : '';
+
+    if (inputFileName.contains('.') || originalExtension.isEmpty) {
+      return inputFileName;
+    }
+
+    return '$inputFileName$originalExtension';
   }
 
   void _logException(String message) {

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -4,6 +4,9 @@ import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 
 import 'android_saf_handle.dart';
+// Conditional import: web implementation will be used only on web builds.
+import '../platform/web/platform_file_web_fetch_stub.dart'
+    if (dart.library.js_interop) '../platform/web/platform_file_web_fetch.dart';
 
 class PlatformFile {
   PlatformFile({
@@ -93,6 +96,14 @@ class PlatformFile {
   /// Retrieves this as a XFile
   XFile get xFile {
     if (kIsWeb) {
+      if (bytes == null) {
+        throw StateError(
+          'PlatformFile.xFile: missing file bytes on Web. '
+          'Call FilePicker.pickFiles(withData: true) (or pickFile with withData: true) '
+          'so that file bytes are available, or access the file via its `path`/blob URL and fetch the data manually.',
+        );
+      }
+
       return XFile.fromData(bytes!, name: name, length: size);
     } else {
       return XFile(path!, name: name, bytes: bytes, length: size);
@@ -103,7 +114,27 @@ class PlatformFile {
   ///
   /// For large files on mobile and desktop platforms, prefer [readAsByteStream]
   /// to avoid Out Of Memory (OOM) issues.
-  Future<Uint8List> readAsBytes() => xFile.readAsBytes();
+  Future<Uint8List> readAsBytes() async {
+    if (kIsWeb) {
+      // If bytes are already present return them.
+      if (bytes != null) return bytes!;
+
+      // Try to fetch bytes automatically from the provided `path` (may be
+      // a blob: URL or data: URL). The helper is a no-op on non-web
+      // platforms thanks to conditional imports.
+      final fetched = await fetchBytesFromWebPath(path);
+      if (fetched != null) return fetched;
+
+      // Fallback: clear and descriptive error.
+      throw StateError(
+        'PlatformFile.readAsBytes(): file data is not available on Web. '
+        'Either call FilePicker.pickFiles(withData: true) so that `bytes` are populated, '
+        'or ensure the file `path` is a fetchable blob/data URL. Automatic fetch from `path` failed.',
+      );
+    }
+
+    return xFile.readAsBytes();
+  }
 
   /// Read the file content as a stream of bytes.
   ///

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -236,7 +236,7 @@ abstract final class FilePicker {
   /// Returns a [Future<String?>] which resolves to the absolute path of the
   /// saved file, or `null` if the user canceled the operation.
   ///
-  /// On the web, this starts a download and always returns `null`.
+  /// On the web, this starts a browser-managed save flow/download.
   ///
   /// The User Selected File Read/Write entitlement is required on macOS.
   ///
@@ -269,8 +269,7 @@ abstract final class FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) {
@@ -281,7 +280,6 @@ abstract final class FilePicker {
       type: type,
       allowedExtensions: allowedExtensions,
       bytes: bytes,
-      path: path,
       onFileLoading: onFileLoading,
       lockParentWindow: lockParentWindow,
     );

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -131,7 +131,7 @@ abstract final class FilePicker {
       onFileLoading: onFileLoading,
       compressionQuality: compressionQuality,
       allowMultiple: false,
-      withData: false,
+      withData: kIsWeb,
       withReadStream: false,
       lockParentWindow: lockParentWindow,
       readSequential: false,
@@ -269,7 +269,8 @@ abstract final class FilePicker {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) {
@@ -280,6 +281,7 @@ abstract final class FilePicker {
       type: type,
       allowedExtensions: allowedExtensions,
       bytes: bytes,
+      path: path,
       onFileLoading: onFileLoading,
       lockParentWindow: lockParentWindow,
     );

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:isolate';
-import 'dart:typed_data';
+
 
 import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -114,7 +114,7 @@ class FilePickerUtils {
 
   static Future<String> resolveSaveFileName({
     required String fileName,
-    required Uint8List bytes,
+    Uint8List? bytes,
   }) async {
     final sanitizedName = basename(fileName.trim());
     final safeName = sanitizedName.isEmpty ? 'file' : sanitizedName;
@@ -122,6 +122,9 @@ class FilePickerUtils {
     if (extension(safeName).isNotEmpty) {
       return safeName;
     }
+    // If bytes are not provided we can't infer the extension; return the
+    // base name as-is and let the native save dialog or caller decide.
+    if (bytes == null) return safeName;
 
     final ext = await _inferExtensionFromBytes(bytes);
     if (ext == null || ext.isEmpty) {

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -4,7 +4,9 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:mime/mime.dart';
 import 'package:path/path.dart';
+import 'package:tika/tika.dart';
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -108,6 +110,74 @@ class FilePickerUtils {
       receivePort.close();
       if (result is Exception) {
         throw result;
+      }
+    }
+  }
+
+  static Future<String> resolveSaveFileName({
+    required String fileName,
+    required Uint8List bytes,
+  }) async {
+    final sanitizedName = basename(fileName.trim());
+    final safeName = sanitizedName.isEmpty ? 'file' : sanitizedName;
+
+    if (extension(safeName).isNotEmpty) {
+      return safeName;
+    }
+
+    final ext = await _inferExtensionFromBytes(bytes);
+    if (ext == null || ext.isEmpty) {
+      return safeName;
+    }
+
+    return '$safeName.$ext';
+  }
+
+  static Future<String?> _inferExtensionFromBytes(Uint8List bytes) async {
+    if (bytes.isEmpty) return null;
+
+    final tikaMimeType = await _detectMimeTypeWithTika(bytes);
+    final fallbackMimeType = lookupMimeType('', headerBytes: bytes);
+    final mimeType = tikaMimeType ?? fallbackMimeType;
+
+    if (mimeType == null || mimeType.isEmpty) return null;
+    return extensionFromMime(mimeType)?.toLowerCase();
+  }
+
+  static Future<String?> _detectMimeTypeWithTika(Uint8List bytes) async {
+    if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
+      return null;
+    }
+
+    if (!await TikaClient.isSupported()) {
+      return null;
+    }
+
+    File? tempFile;
+    try {
+      tempFile = File(
+        '${Directory.systemTemp.path}${Platform.pathSeparator}${DateTime.now().microsecondsSinceEpoch}-file-picker.bin',
+      );
+      await tempFile.writeAsBytes(bytes, flush: true);
+
+      final result = await Process.run('tika', ['--mime-type', tempFile.path]);
+      if (result.exitCode != 0) {
+        return null;
+      }
+
+      final mimeType = result.stdout?.toString().trim();
+      if (mimeType == null || mimeType.isEmpty) {
+        return null;
+      }
+
+      return mimeType;
+    } catch (_) {
+      return null;
+    } finally {
+      if (tempFile != null && tempFile.existsSync()) {
+        try {
+          tempFile.deleteSync();
+        } catch (_) {}
       }
     }
   }

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -141,7 +141,6 @@ class FilePickerUtils {
     return extensionFromMime(mimeType)?.toLowerCase();
   }
 
-
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///
   /// Returns true if the first character of [x] is a letter.

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -141,6 +141,25 @@ class FilePickerUtils {
     return extensionFromMime(mimeType)?.toLowerCase();
   }
 
+  /// If [savedPath] returned by the native dialog has no extension, append
+  /// the extension inferred from [resolvedFileName] (if any). If the user
+  /// explicitly provided an extension in the native dialog, we keep it — the
+  /// user's choice always wins.
+  static String? applyResolvedExtensionIfMissing(
+    String? savedPath,
+    String resolvedFileName,
+  ) {
+    if (savedPath == null) return null;
+
+    final savedExt = extension(savedPath);
+    if (savedExt.isNotEmpty) return savedPath; // user already chose an ext
+
+    final resolvedExt = extension(resolvedFileName);
+    if (resolvedExt.isEmpty) return savedPath;
+
+    return '$savedPath$resolvedExt';
+  }
+
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///
   /// Returns true if the first character of [x] is a letter.

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -1,9 +1,8 @@
 import 'dart:io';
 import 'dart:isolate';
 
-
-import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart';
 import 'package:tika/tika.dart';

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -5,7 +5,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart';
-import 'package:tika/tika.dart';
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -135,51 +134,13 @@ class FilePickerUtils {
   static Future<String?> _inferExtensionFromBytes(Uint8List bytes) async {
     if (bytes.isEmpty) return null;
 
-    final tikaMimeType = await _detectMimeTypeWithTika(bytes);
     final fallbackMimeType = lookupMimeType('', headerBytes: bytes);
-    final mimeType = tikaMimeType ?? fallbackMimeType;
+    final mimeType = fallbackMimeType;
 
     if (mimeType == null || mimeType.isEmpty) return null;
     return extensionFromMime(mimeType)?.toLowerCase();
   }
 
-  static Future<String?> _detectMimeTypeWithTika(Uint8List bytes) async {
-    if (kIsWeb || Platform.isAndroid || Platform.isIOS) {
-      return null;
-    }
-
-    if (!await TikaClient.isSupported()) {
-      return null;
-    }
-
-    File? tempFile;
-    try {
-      tempFile = File(
-        '${Directory.systemTemp.path}${Platform.pathSeparator}${DateTime.now().microsecondsSinceEpoch}-file-picker.bin',
-      );
-      await tempFile.writeAsBytes(bytes, flush: true);
-
-      final result = await Process.run('tika', ['--mime-type', tempFile.path]);
-      if (result.exitCode != 0) {
-        return null;
-      }
-
-      final mimeType = result.stdout?.toString().trim();
-      if (mimeType == null || mimeType.isEmpty) {
-        return null;
-      }
-
-      return mimeType;
-    } catch (_) {
-      return null;
-    } finally {
-      if (tempFile != null && tempFile.existsSync()) {
-        try {
-          tempFile.deleteSync();
-        } catch (_) {}
-      }
-    }
-  }
 
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -185,11 +185,14 @@ class MethodChannelFilePicker extends FilePickerPlatform {
           .invokeMethod<String>("save", {
             "fileName": fileName,
             "fileType": type.name,
+            "bytes": bytes,
             "initialDirectory": initialDirectory,
             "allowedExtensions": allowedExtensions,
           });
 
-      await FilePickerUtils.saveBytesToFile(bytes, savedPath);
+      if (!Platform.isAndroid) {
+        await FilePickerUtils.saveBytesToFile(bytes, savedPath);
+      }
 
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.done);

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -181,9 +181,14 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         }, onError: (error) => throw Exception(error));
       }
 
+      final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
+        fileName: fileName,
+        bytes: bytes,
+      );
+
       final String? savedPath = await methodChannel
           .invokeMethod<String>("save", {
-            "fileName": fileName,
+            "fileName": resolvedFileName,
             "fileType": type.name,
             "bytes": bytes,
             "initialDirectory": initialDirectory,

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -186,14 +186,21 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         bytes: bytes,
       );
 
-      final String? savedPath = await methodChannel
-          .invokeMethod<String>("save", {
-            "fileName": resolvedFileName,
-            "fileType": type.name,
-            "bytes": bytes,
-            "initialDirectory": initialDirectory,
-            "allowedExtensions": allowedExtensions,
-          });
+      String? savedPath = await methodChannel.invokeMethod<String>("save", {
+        "fileName": resolvedFileName,
+        "fileType": type.name,
+        "bytes": bytes,
+        "initialDirectory": initialDirectory,
+        "allowedExtensions": allowedExtensions,
+      });
+
+      // If the native dialog returned a path without extension, append the
+      // extension we inferred before saving. If the user explicitly chose an
+      // extension in the native dialog, prefer it (user wins).
+      savedPath = FilePickerUtils.applyResolvedExtensionIfMissing(
+        savedPath,
+        resolvedFileName,
+      );
 
       if (!Platform.isAndroid) {
         await FilePickerUtils.saveBytesToFile(bytes, savedPath);

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -164,8 +164,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
@@ -182,10 +181,6 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         }, onError: (error) => throw Exception(error));
       }
 
-      if (bytes == null && (path == null || path.isEmpty)) {
-        throw ArgumentError('Either bytes or path must be provided to saveFile.');
-      }
-
       final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
         fileName: fileName,
         bytes: bytes,
@@ -194,8 +189,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       String? savedPath = await methodChannel.invokeMethod<String>("save", {
         "fileName": resolvedFileName,
         "fileType": type.name,
-        if (bytes != null) "bytes": bytes,
-        if (path != null) "path": path,
+        "bytes": bytes,
         "initialDirectory": initialDirectory,
         "allowedExtensions": allowedExtensions,
       });
@@ -207,7 +201,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
 
       // If the platform returned a path for the saved file and we have bytes
       // then persist them locally (native implementations may expect this).
-      if (bytes != null && !Platform.isAndroid) {
+      if (!Platform.isAndroid) {
         await FilePickerUtils.saveBytesToFile(bytes, savedPath);
       }
 

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -164,7 +164,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
@@ -181,6 +182,10 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         }, onError: (error) => throw Exception(error));
       }
 
+      if (bytes == null && (path == null || path.isEmpty)) {
+        throw ArgumentError('Either bytes or path must be provided to saveFile.');
+      }
+
       final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
         fileName: fileName,
         bytes: bytes,
@@ -189,7 +194,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
       String? savedPath = await methodChannel.invokeMethod<String>("save", {
         "fileName": resolvedFileName,
         "fileType": type.name,
-        "bytes": bytes,
+        if (bytes != null) "bytes": bytes,
+        if (path != null) "path": path,
         "initialDirectory": initialDirectory,
         "allowedExtensions": allowedExtensions,
       });
@@ -199,7 +205,9 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         resolvedFileName,
       );
 
-      if (!Platform.isAndroid) {
+      // If the platform returned a path for the saved file and we have bytes
+      // then persist them locally (native implementations may expect this).
+      if (bytes != null && !Platform.isAndroid) {
         await FilePickerUtils.saveBytesToFile(bytes, savedPath);
       }
 

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -194,9 +194,6 @@ class MethodChannelFilePicker extends FilePickerPlatform {
         "allowedExtensions": allowedExtensions,
       });
 
-      // If the native dialog returned a path without extension, append the
-      // extension we inferred before saving. If the user explicitly chose an
-      // extension in the native dialog, prefer it (user wins).
       savedPath = FilePickerUtils.applyResolvedExtensionIfMissing(
         savedPath,
         resolvedFileName,

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -82,13 +82,19 @@ abstract class FilePickerPlatform extends PlatformInterface {
 
   /// Opens a save file dialog which lets the user select a file path and a file
   /// name to save a file.
+  ///
+  /// This unified method accepts either [bytes] (file contents) or a [path]
+  /// (e.g. a blob/data URL on web or a file URL). At least one of [bytes] or
+  /// [path] must be provided. Implementations should prefer [path] when it is
+  /// supplied and only use [bytes] when necessary.
   Future<String?> saveFile({
     String? dialogTitle,
     required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -83,18 +83,14 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// Opens a save file dialog which lets the user select a file path and a file
   /// name to save a file.
   ///
-  /// This unified method accepts either [bytes] (file contents) or a [path]
-  /// (e.g. a blob/data URL on web or a file URL). At least one of [bytes] or
-  /// [path] must be provided. Implementations should prefer [path] when it is
-  /// supplied and only use [bytes] when necessary.
+  /// The file contents are provided through [bytes].
   Future<String?> saveFile({
     String? dialogTitle,
     required String fileName,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -163,14 +163,10 @@ class FilePickerLinux extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes == null) {
-      throw ArgumentError('The bytes are required when saving a file on Linux.');
-    }
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,
       bytes: bytes,
@@ -218,7 +214,7 @@ class FilePickerLinux extends FilePickerPlatform {
     final savedFilePaths = saveUris.map((uri) => uri.toFilePath()).toList();
     String? savedFilePath = savedFilePaths.firstOrNull;
 
-   savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
       savedFilePath,
       resolvedFileName,
     );

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -163,10 +163,14 @@ class FilePickerLinux extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
+    if (bytes == null) {
+      throw ArgumentError('The bytes are required when saving a file on Linux.');
+    }
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,
       bytes: bytes,

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -167,9 +167,14 @@ class FilePickerLinux extends FilePickerPlatform {
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
+    final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
+      fileName: fileName,
+      bytes: bytes,
+    );
+
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
-      'current_name': DBusString(fileName),
+      'current_name': DBusString(resolvedFileName),
       'modal': DBusBoolean(lockParentWindow),
     };
     if (initialDirectory != null) {

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -214,10 +214,7 @@ class FilePickerLinux extends FilePickerPlatform {
     final savedFilePaths = saveUris.map((uri) => uri.toFilePath()).toList();
     String? savedFilePath = savedFilePaths.firstOrNull;
 
-    // If the native dialog returned a path without extension, append the
-    // inferred extension we computed previously. If the user explicitly chose
-    // an extension in the native dialog, prefer it.
-    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+   savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
       savedFilePath,
       resolvedFileName,
     );

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -212,7 +212,15 @@ class FilePickerLinux extends FilePickerPlatform {
     }
 
     final savedFilePaths = saveUris.map((uri) => uri.toFilePath()).toList();
-    final savedFilePath = savedFilePaths.firstOrNull;
+    String? savedFilePath = savedFilePaths.firstOrNull;
+
+    // If the native dialog returned a path without extension, append the
+    // inferred extension we computed previously. If the user explicitly chose
+    // an extension in the native dialog, prefer it.
+    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+      savedFilePath,
+      resolvedFileName,
+    );
 
     await FilePickerUtils.saveBytesToFile(bytes, savedFilePath);
 

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -103,10 +103,14 @@ class FilePickerMacOS extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
+    if (bytes == null) {
+      throw ArgumentError('The bytes are required when saving a file on macOS.');
+    }
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -108,13 +108,17 @@ class FilePickerMacOS extends FilePickerPlatform {
     bool lockParentWindow = false,
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
+    final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
+      fileName: fileName,
+      bytes: bytes,
+    );
 
     final String? savedFilePath = await methodChannel
         .invokeMethod<String>('saveFile', <String, dynamic>{
           'dialogTitle': escapeDialogTitle(
             dialogTitle ?? FilePickerUtils.defaultDialogTitle,
           ),
-          'fileName': fileName,
+          'fileName': resolvedFileName,
           'initialDirectory': escapeInitialDirectory(initialDirectory),
           'allowedExtensions': fileFilter,
         });

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -103,14 +103,10 @@ class FilePickerMacOS extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes == null) {
-      throw ArgumentError('The bytes are required when saving a file on macOS.');
-    }
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -113,7 +113,7 @@ class FilePickerMacOS extends FilePickerPlatform {
       bytes: bytes,
     );
 
-    final String? savedFilePath = await methodChannel
+    String? savedFilePath = await methodChannel
         .invokeMethod<String>('saveFile', <String, dynamic>{
           'dialogTitle': escapeDialogTitle(
             dialogTitle ?? FilePickerUtils.defaultDialogTitle,
@@ -122,6 +122,13 @@ class FilePickerMacOS extends FilePickerPlatform {
           'initialDirectory': escapeInitialDirectory(initialDirectory),
           'allowedExtensions': fileFilter,
         });
+
+    // Prefer user's chosen extension. If native returned a path without
+    // extension, append the inferred one from resolvedFileName.
+    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+      savedFilePath,
+      resolvedFileName,
+    );
 
     await FilePickerUtils.saveBytesToFile(bytes, savedFilePath);
     return savedFilePath;

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -2,15 +2,40 @@ import 'dart:async';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
-import 'package:file_picker/src/api/file_picker_types.dart';
-import 'package:file_picker/src/api/file_picker_result.dart';
-import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/file_picker_result.dart';
+import 'package:file_picker/src/api/file_picker_types.dart';
+import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:path/path.dart' as p;
 import 'package:web/web.dart';
 
+// ---------------------------------------------------------------------------
+// JS interop for the File System Access API (showSaveFilePicker).
+// Available in Chrome/Edge. Falls back to anchor download on other browsers.
+// ---------------------------------------------------------------------------
+
+@JS('showSaveFilePicker')
+external JSPromise<JSAny?> _showSaveFilePickerJs(JSAny options);
+
+extension type _FileHandle(JSObject _) implements JSObject {
+  external JSPromise<JSAny?> createWritable();
+}
+
+extension type _WritableStream(JSObject _) implements JSObject {
+  external JSPromise<JSAny?> write(JSAny data);
+  external JSPromise<JSAny?> close();
+}
+
+// fetch() interop for reading bytes from a blob: URL.
+@JS('fetch')
+external JSPromise<JSObject> _fetchJs(JSString url);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+}
+
+// ---------------------------------------------------------------------------
 class FilePickerWeb extends FilePickerPlatform {
   late Element _target;
   final String _kFilePickerInputsDomId = '__file_picker_web-file-input';
@@ -40,16 +65,6 @@ class FilePickerWeb extends FilePickerPlatform {
   }
 
   @override
-  Future<String?> getDirectoryPath({
-    String? dialogTitle,
-    bool lockParentWindow = false,
-    String? initialDirectory,
-    AndroidSAFOptions? androidSafOptions,
-  }) async {
-    throw UnimplementedError('getDirectoryPath() has not been implemented.');
-  }
-
-  @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
@@ -74,95 +89,36 @@ class FilePickerWeb extends FilePickerPlatform {
     Completer<List<PlatformFile>?>? filesCompleter =
         Completer<List<PlatformFile>?>();
 
-    String accept = _fileType(type, allowedExtensions);
-    HTMLInputElement uploadInput = HTMLInputElement();
-    uploadInput.type = 'file';
-    uploadInput.draggable = true;
-    uploadInput.multiple = allowMultiple;
-    uploadInput.accept = accept;
-    uploadInput.style.display = 'none';
+    final uploadInput = HTMLInputElement()
+      ..type = 'file'
+      ..draggable = true
+      ..multiple = allowMultiple
+      ..accept = _fileType(type, allowedExtensions)
+      ..style.display = 'none';
 
     bool changeEventTriggered = false;
-
-    if (onFileLoading != null) {
-      onFileLoading(FilePickerStatus.picking);
-    }
+    onFileLoading?.call(FilePickerStatus.picking);
 
     void changeEventListener(Event e) async {
-      if (changeEventTriggered) {
-        return;
-      }
+      if (changeEventTriggered) return;
       changeEventTriggered = true;
 
-      final FileList files = uploadInput.files!;
-      final List<PlatformFile> pickedFiles = [];
-
-      void addPickedFile(
-        File file,
-        Uint8List? bytes,
-        String? path,
-        Stream<List<int>>? readStream,
-      ) {
-        String? blobUrl;
-        if (bytes != null && bytes.isNotEmpty) {
-          final blob = Blob(
-            [bytes.toJS].toJS,
-            BlobPropertyBag(type: file.type),
-          );
-
-          blobUrl = URL.createObjectURL(blob);
-        }
-        pickedFiles.add(
-          PlatformFile(
-            name: file.name,
-            path: path ?? blobUrl,
-            size: bytes != null ? bytes.length : file.size,
-            bytes: bytes,
-            readStream: readStream,
-          ),
-        );
-
-        if (pickedFiles.length >= files.length) {
-          if (onFileLoading != null) {
-            onFileLoading(FilePickerStatus.done);
-          }
-          filesCompleter?.complete(pickedFiles);
-        }
+      final files = uploadInput.files;
+      if (files == null) {
+        onFileLoading?.call(FilePickerStatus.done);
+        filesCompleter?.complete(null);
+        return;
       }
 
-      for (int i = 0; i < files.length; i++) {
-        final File? file = files.item(i);
-        if (file == null) {
-          continue;
-        }
+      final pickedFiles = await _buildPickedFiles(
+        files,
+        withData: withData,
+        withReadStream: withReadStream,
+        readSequential: readSequential,
+      );
 
-        if (withReadStream) {
-          addPickedFile(file, null, null, _openFileReadStream(file));
-          continue;
-        }
-
-        if (!withData) {
-          final FileReader reader = FileReader();
-          reader.onLoadEnd.listen((e) {
-            String? result = (reader.result as JSString?)?.toDart;
-            addPickedFile(file, null, result, null);
-          });
-          reader.readAsDataURL(file);
-          continue;
-        }
-
-        final syncCompleter = Completer<void>();
-        final FileReader reader = FileReader();
-        reader.onLoadEnd.listen((e) {
-          ByteBuffer? byteBuffer = (reader.result as JSArrayBuffer?)?.toDart;
-          addPickedFile(file, byteBuffer?.asUint8List(), null, null);
-          syncCompleter.complete();
-        });
-        reader.readAsArrayBuffer(file);
-        if (readSequential) {
-          await syncCompleter.future;
-        }
-      }
+      onFileLoading?.call(FilePickerStatus.done);
+      filesCompleter?.complete(pickedFiles);
     }
 
     void cancelledEventListener(Event _) {
@@ -171,7 +127,7 @@ class FilePickerWeb extends FilePickerPlatform {
       // This listener is called before the input changed event,
       // and the `uploadInput.files` value is still null
       // Wait for results from js to dart
-      Future.delayed(Duration(seconds: 1)).then((value) {
+      Future.delayed(const Duration(seconds: 1)).then((value) {
         if (!changeEventTriggered) {
           changeEventTriggered = true;
           filesCompleter?.complete(null);
@@ -188,20 +144,11 @@ class FilePickerWeb extends FilePickerPlatform {
       window.addEventListener('focus', cancelledEventListener.toJS);
     }
 
-    //Add input element to the page body
-    Node? firstChild = _target.firstChild;
-    while (firstChild != null) {
-      _target.removeChild(firstChild);
-      firstChild = _target.firstChild;
-    }
+    _clearTarget();
     _target.children.add(uploadInput);
     uploadInput.click();
 
-    firstChild = _target.firstChild;
-    while (firstChild != null) {
-      _target.removeChild(firstChild);
-      firstChild = _target.firstChild;
-    }
+    _clearTarget();
 
     final List<PlatformFile>? files = await filesCompleter.future;
     filesCompleter = null;
@@ -216,42 +163,188 @@ class FilePickerWeb extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes.isEmpty) {
-      throw ArgumentError(
-        'The bytes are required when saving a file on the web.',
-      );
+    // Ensure the file name has an extension.
+    final name = _ensureExtension(fileName, allowedExtensions);
+
+    // Resolve bytes from the provided data or by fetching the blob/data URL.
+    final resolvedBytes = await _resolveBytes(bytes, path);
+
+    if (resolvedBytes == null) {
+      throw ArgumentError('Either bytes or a valid blob:/data: path must be provided.');
     }
 
-    if (fileName.isEmpty) {
-      throw ArgumentError(
-        'A file name is required when saving a file on the web.',
-      );
-    }
+    final blob = Blob([resolvedBytes.toJS].toJS);
 
-    if (p.extension(fileName).isEmpty) {
-      throw ArgumentError(
-        'The file name should include a valid file extension.',
-      );
-    }
+    // Try the native "Save As" picker (Chrome/Edge).
+    // Returns true=saved, false=cancelled, null=unsupported.
+    final pickerResult = await _trySaveWithPicker(blob, name);
+    if (pickerResult == true) return name;
+    if (pickerResult == false) return null;
 
-    final blob = Blob([bytes.toJS].toJS);
+    // Fallback: standard browser download.
+    _downloadBlob(blob, name);
+    return name;
+  }
+
+  // ---------------------------------------------------------------------------
+  // saveFile helpers
+  // ---------------------------------------------------------------------------
+
+  /// Appends a single allowed extension when the file name has none.
+  String _ensureExtension(String fileName, List<String>? allowedExtensions) {
+    if (fileName.contains('.')) return fileName;
+    if (allowedExtensions == null || allowedExtensions.length != 1) {
+      return fileName;
+    }
+    final ext = allowedExtensions.first.trim();
+    if (ext.isEmpty) return fileName;
+    return ext.startsWith('.') ? '$fileName$ext' : '$fileName.$ext';
+  }
+
+  /// Obtains the raw bytes: either directly from [bytes], or by fetching [path].
+  Future<Uint8List?> _resolveBytes(Uint8List? bytes, String? path) async {
+    if (bytes != null && bytes.isNotEmpty) return bytes;
+    if (path == null || path.isEmpty) return null;
+    return _fetchBytesFromUrl(path);
+  }
+
+  /// Returns `true` if saved, `false` if the user cancelled, `null` if the
+  /// browser does not support the native save picker.
+  Future<bool?> _trySaveWithPicker(Blob blob, String fileName) async {
+    try {
+      final handle = _FileHandle(
+        await _showSaveFilePickerJs({'suggestedName': fileName}.jsify()!).toDart as JSObject,
+      );
+      final writable = _WritableStream(
+        await handle.createWritable().toDart as JSObject,
+      );
+      await writable.write(blob as JSAny).toDart;
+      await writable.close().toDart;
+      return true;
+    } catch (e) {
+      // User pressed Cancel → AbortError.
+      return e.toString().contains('Abort') ? false : null;
+    }
+  }
+
+  /// Fetches raw bytes from a blob: or data: URL.
+  Future<Uint8List?> _fetchBytesFromUrl(String url) async {
+    try {
+      if (url.startsWith('data:')) {
+        return Uri.parse(url).data?.contentAsBytes();
+      }
+      if (url.startsWith('blob:')) {
+        final buffer = await _Response(await _fetchJs(url.toJS).toDart).arrayBuffer().toDart;
+        return buffer.toDart.asUint8List();
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// Triggers a browser download for [blob] with [fileName].
+  void _downloadBlob(Blob blob, String fileName) {
     final url = URL.createObjectURL(blob);
-
-    // Start a download by using a click event on an anchor element that contains the Blob.
     HTMLAnchorElement()
       ..href = url
-      // Always open the file in a new tab.
-      ..target = 'blank'
       ..download = fileName
       ..click();
-
-    // Release the Blob URL after the download started.
     URL.revokeObjectURL(url);
-    return null;
+  }
+
+  Future<List<PlatformFile>> _buildPickedFiles(
+    FileList files, {
+    required bool withData,
+    required bool withReadStream,
+    required bool readSequential,
+  }) async {
+    final futures = <Future<PlatformFile>>[];
+    final pickedFiles = <PlatformFile>[];
+
+    for (int i = 0; i < files.length; i++) {
+      final file = files.item(i);
+      if (file == null) continue;
+
+      final pickedFile = _toPlatformFile(
+        file,
+        withData: withData,
+        withReadStream: withReadStream,
+      );
+
+      if (readSequential) {
+        pickedFiles.add(await pickedFile);
+      } else {
+        futures.add(pickedFile);
+      }
+    }
+
+    return readSequential ? pickedFiles : Future.wait(futures);
+  }
+
+  Future<PlatformFile> _toPlatformFile(
+    File file, {
+    required bool withData,
+    required bool withReadStream,
+  }) async {
+    if (withReadStream) {
+      return PlatformFile(
+        name: file.name,
+        path: URL.createObjectURL(file),
+        size: file.size,
+        readStream: _openFileReadStream(file),
+      );
+    }
+
+    if (!withData) {
+      return PlatformFile(
+        name: file.name,
+        path: URL.createObjectURL(file),
+        size: file.size,
+      );
+    }
+
+    final bytes = await _readFileAsBytes(file);
+    return PlatformFile(
+      name: file.name,
+      path: _blobUrlFromBytes(file, bytes),
+      size: bytes?.length ?? file.size,
+      bytes: bytes,
+    );
+  }
+
+  Future<Uint8List?> _readFileAsBytes(File file) {
+    final completer = Completer<Uint8List?>();
+    final reader = FileReader();
+    reader.onLoadEnd.listen((_) {
+      final byteBuffer = (reader.result as JSArrayBuffer?)?.toDart;
+      completer.complete(byteBuffer?.asUint8List());
+    });
+    reader.readAsArrayBuffer(file);
+    return completer.future;
+  }
+
+  String? _blobUrlFromBytes(File file, Uint8List? bytes) {
+    if (bytes == null || bytes.isEmpty) {
+      return null;
+    }
+
+    final blob = Blob(
+      [bytes.toJS].toJS,
+      BlobPropertyBag(type: file.type),
+    );
+    return URL.createObjectURL(blob);
+  }
+
+  void _clearTarget() {
+    Node? firstChild = _target.firstChild;
+    while (firstChild != null) {
+      _target.removeChild(firstChild);
+      firstChild = _target.firstChild;
+    }
   }
 
   static String _fileType(FileType type, List<String>? allowedExtensions) {

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -27,14 +27,6 @@ extension type _WritableStream(JSObject _) implements JSObject {
   external JSPromise<JSAny?> close();
 }
 
-// fetch() interop for reading bytes from a blob: URL.
-@JS('fetch')
-external JSPromise<JSObject> _fetchJs(JSString url);
-
-extension type _Response(JSObject _) implements JSObject {
-  external JSPromise<JSArrayBuffer> arrayBuffer();
-}
-
 // ---------------------------------------------------------------------------
 class FilePickerWeb extends FilePickerPlatform {
   late Element _target;
@@ -163,22 +155,13 @@ class FilePickerWeb extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
     // Ensure the file name has an extension.
     final name = _ensureExtension(fileName, allowedExtensions);
-
-    // Resolve bytes from the provided data or by fetching the blob/data URL.
-    final resolvedBytes = await _resolveBytes(bytes, path);
-
-    if (resolvedBytes == null) {
-      throw ArgumentError('Either bytes or a valid blob:/data: path must be provided.');
-    }
-
-    final blob = Blob([resolvedBytes.toJS].toJS);
+    final blob = Blob([bytes.toJS].toJS);
 
     // Try the native "Save As" picker (Chrome/Edge).
     // Returns true=saved, false=cancelled, null=unsupported.
@@ -206,19 +189,13 @@ class FilePickerWeb extends FilePickerPlatform {
     return ext.startsWith('.') ? '$fileName$ext' : '$fileName.$ext';
   }
 
-  /// Obtains the raw bytes: either directly from [bytes], or by fetching [path].
-  Future<Uint8List?> _resolveBytes(Uint8List? bytes, String? path) async {
-    if (bytes != null && bytes.isNotEmpty) return bytes;
-    if (path == null || path.isEmpty) return null;
-    return _fetchBytesFromUrl(path);
-  }
-
   /// Returns `true` if saved, `false` if the user cancelled, `null` if the
   /// browser does not support the native save picker.
   Future<bool?> _trySaveWithPicker(Blob blob, String fileName) async {
     try {
       final handle = _FileHandle(
-        await _showSaveFilePickerJs({'suggestedName': fileName}.jsify()!).toDart as JSObject,
+        await _showSaveFilePickerJs({'suggestedName': fileName}.jsify()!).toDart
+            as JSObject,
       );
       final writable = _WritableStream(
         await handle.createWritable().toDart as JSObject,
@@ -232,19 +209,6 @@ class FilePickerWeb extends FilePickerPlatform {
     }
   }
 
-  /// Fetches raw bytes from a blob: or data: URL.
-  Future<Uint8List?> _fetchBytesFromUrl(String url) async {
-    try {
-      if (url.startsWith('data:')) {
-        return Uri.parse(url).data?.contentAsBytes();
-      }
-      if (url.startsWith('blob:')) {
-        final buffer = await _Response(await _fetchJs(url.toJS).toDart).arrayBuffer().toDart;
-        return buffer.toDart.asUint8List();
-      }
-    } catch (_) {}
-    return null;
-  }
 
   /// Triggers a browser download for [blob] with [fileName].
   void _downloadBlob(Blob blob, String fileName) {
@@ -332,10 +296,7 @@ class FilePickerWeb extends FilePickerPlatform {
       return null;
     }
 
-    final blob = Blob(
-      [bytes.toJS].toJS,
-      BlobPropertyBag(type: file.type),
-    );
+    final blob = Blob([bytes.toJS].toJS, BlobPropertyBag(type: file.type));
     return URL.createObjectURL(blob);
   }
 

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -209,7 +209,6 @@ class FilePickerWeb extends FilePickerPlatform {
     }
   }
 
-
   /// Triggers a browser download for [blob] with [fileName].
   void _downloadBlob(Blob blob, String fileName) {
     final url = URL.createObjectURL(blob);

--- a/lib/src/platform/web/platform_file_web_fetch.dart
+++ b/lib/src/platform/web/platform_file_web_fetch.dart
@@ -29,5 +29,3 @@ Future<Uint8List?> fetchBytesFromWebPath(String? path) async {
 
   return null;
 }
-
-

--- a/lib/src/platform/web/platform_file_web_fetch.dart
+++ b/lib/src/platform/web/platform_file_web_fetch.dart
@@ -1,0 +1,33 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+@JS('fetch')
+external JSPromise<JSObject> _fetchJs(JSString url);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+}
+
+/// Attempts to fetch bytes from a web-only path (`blob:` or `data:` URL).
+Future<Uint8List?> fetchBytesFromWebPath(String? path) async {
+  if (path == null || path.isEmpty) return null;
+
+  try {
+    if (path.startsWith('data:')) {
+      return Uri.parse(path).data?.contentAsBytes();
+    }
+
+    if (path.startsWith('blob:')) {
+      final buffer = await _Response(
+        await _fetchJs(path.toJS).toDart,
+      ).arrayBuffer().toDart;
+      return buffer.toDart.asUint8List();
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}
+
+

--- a/lib/src/platform/web/platform_file_web_fetch_stub.dart
+++ b/lib/src/platform/web/platform_file_web_fetch_stub.dart
@@ -8,4 +8,3 @@ import 'dart:typed_data';
 ///
 /// This stub is a no-op on non-web platforms and returns null.
 Future<Uint8List?> fetchBytesFromWebPath(String? path) async => null;
-

--- a/lib/src/platform/web/platform_file_web_fetch_stub.dart
+++ b/lib/src/platform/web/platform_file_web_fetch_stub.dart
@@ -1,0 +1,11 @@
+// Stub implementation used when dart:html is not available (non-web platforms).
+// The real implementation lives in `platform_file_web_fetch.dart` which is
+// conditionally imported only on web builds.
+
+import 'dart:typed_data';
+
+/// Attempts to fetch bytes from a web-only path (blob: or data: URL).
+///
+/// This stub is a no-op on non-web platforms and returns null.
+Future<Uint8List?> fetchBytesFromWebPath(String? path) async => null;
+

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -188,12 +188,17 @@ class FilePickerWindows extends FilePickerPlatform {
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
+    final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
+      fileName: fileName,
+      bytes: bytes,
+    );
+
     final port = ReceivePort();
     await Isolate.spawn(
       _callSaveFile,
       _OpenSaveFileArgs(
         port: port.sendPort,
-        defaultFileName: fileName,
+        defaultFileName: resolvedFileName,
         dialogTitle: dialogTitle,
         initialDirectory: initialDirectory,
         type: type,

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -184,10 +184,15 @@ class FilePickerWindows extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    String? path,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
+    // Non-web platforms expect bytes to actually write the file contents.
+    if (bytes == null) {
+      throw ArgumentError('The bytes are required when saving a file on Windows.');
+    }
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,
       bytes: bytes,

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -207,7 +207,16 @@ class FilePickerWindows extends FilePickerPlatform {
         confirmOverwrite: true,
       ),
     );
-    final savedFilePath = (await port.first) as String?;
+    String? savedFilePath = (await port.first) as String?;
+
+    // If the user explicitly provided an extension via the dialog, prefer
+    // that. If the returned path doesn't include an extension, append the
+    // inferred one we resolved earlier.
+    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+      savedFilePath,
+      resolvedFileName,
+    );
+
     await FilePickerUtils.saveBytesToFile(bytes, savedFilePath);
     return savedFilePath;
   }

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -209,10 +209,7 @@ class FilePickerWindows extends FilePickerPlatform {
     );
     String? savedFilePath = (await port.first) as String?;
 
-    // If the user explicitly provided an extension via the dialog, prefer
-    // that. If the returned path doesn't include an extension, append the
-    // inferred one we resolved earlier.
-    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+   savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
       savedFilePath,
       resolvedFileName,
     );

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -184,15 +184,10 @@ class FilePickerWindows extends FilePickerPlatform {
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
-    Uint8List? bytes,
-    String? path,
+    required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    // Non-web platforms expect bytes to actually write the file contents.
-    if (bytes == null) {
-      throw ArgumentError('The bytes are required when saving a file on Windows.');
-    }
     final resolvedFileName = await FilePickerUtils.resolveSaveFileName(
       fileName: fileName,
       bytes: bytes,
@@ -214,7 +209,7 @@ class FilePickerWindows extends FilePickerPlatform {
     );
     String? savedFilePath = (await port.first) as String?;
 
-   savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
+    savedFilePath = FilePickerUtils.applyResolvedExtensionIfMissing(
       savedFilePath,
       resolvedFileName,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.0"
 
 formatter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   cross_file: ^0.3.5+2
   web: ^1.1.1
   dbus: ^0.7.12
-  tika: ^1.0.1
   mime: ^2.0.0
 
 dev_dependencies:
@@ -28,7 +27,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.0"
 
 formatter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   win32: ^6.2.0
   cross_file: ^0.3.5+2
   web: ^1.1.1
+  js: ^0.6.5
   dbus: ^0.7.12
   mime: ^2.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   cross_file: ^0.3.5+2
   web: ^1.1.1
   dbus: ^0.7.12
+  tika: ^1.0.1
+  mime: ^2.0.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/test/file_picker_method_channel_test.dart
+++ b/test/file_picker_method_channel_test.dart
@@ -61,5 +61,27 @@ void main() {
         );
       },
     );
+
+    test('saveFile sends bytes and save metadata to the platform', () async {
+      final bytes = Uint8List.fromList([1, 2, 3, 4]);
+
+      await picker.saveFile(
+        fileName: 'output',
+        type: FileType.custom,
+        allowedExtensions: ['pdf'],
+        bytes: bytes,
+        initialDirectory: '/tmp',
+      );
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'save');
+      expect(log.first.arguments, {
+        'fileName': 'output',
+        'fileType': 'custom',
+        'bytes': bytes,
+        'initialDirectory': '/tmp',
+        'allowedExtensions': ['pdf'],
+      });
+    });
   });
 }

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -2,6 +2,8 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:file_picker/src/file_picker_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -168,6 +170,66 @@ void main() {
         () async => await FilePickerUtils.isExecutableOnPath(filepath),
         throwsA(isA<Exception>()),
       );
+    });
+  });
+
+  group('resolveSaveFileName()', () {
+    test('keeps existing extension when already present', () async {
+      final fileName = await FilePickerUtils.resolveSaveFileName(
+        fileName: 'document.pdf',
+        bytes: Uint8List.fromList([0x25, 0x50, 0x44, 0x46]),
+      );
+
+      expect(fileName, 'document.pdf');
+    });
+
+    test('infers png extension from signature', () async {
+      final fileName = await FilePickerUtils.resolveSaveFileName(
+        fileName: 'image',
+        bytes: Uint8List.fromList([
+          0x89,
+          0x50,
+          0x4E,
+          0x47,
+          0x0D,
+          0x0A,
+          0x1A,
+          0x0A,
+        ]),
+      );
+
+      expect(fileName, 'image.png');
+    });
+
+    test('infers mp4 family extension from ftyp brand', () async {
+      final fileName = await FilePickerUtils.resolveSaveFileName(
+        fileName: 'video',
+        bytes: Uint8List.fromList([
+          0x00,
+          0x00,
+          0x00,
+          0x18,
+          0x66,
+          0x74,
+          0x79,
+          0x70,
+          0x6D,
+          0x70,
+          0x34,
+          0x32,
+        ]),
+      );
+
+      expect(fileName, 'video.mp4');
+    });
+
+    test('falls back to original safe name when type is unknown', () async {
+      final fileName = await FilePickerUtils.resolveSaveFileName(
+        fileName: 'archive',
+        bytes: Uint8List.fromList([0x00, 0x11, 0x22, 0x33]),
+      );
+
+      expect(fileName, 'archive');
     });
   });
 


### PR DESCRIPTION
refactor: require `bytes` in `saveFile` and improve Web byte fetching

- Update `FilePicker.saveFile` and the underlying platform interface to require the `bytes` parameter and remove the optional `path` parameter.
- Enhance `PlatformFile.readAsBytes()` on Web to automatically fetch content from `blob:` and `data:` URLs if `bytes` are not already cached.
- Implement `fetchBytesFromWebPath` using `js_interop` for Web, with a corresponding stub for non-web platforms to support conditional importing.
- Improve error messaging in `PlatformFile` when file data is missing on Web, providing guidance on using `withData: true`.
- Simplify platform-specific implementations for Windows, macOS, and Linux by removing redundant null checks for file bytes.
- Update the example application, README documentation, and unit tests to reflect the updated `saveFile` API.
- Add `android.builtInKotlin=false` to the example project's Gradle properties.