### PR TITLE
feat: move web save file and byte handling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## NEXT
+
+### General
+- Restored `pickFile()` default data loading on web so single-file picks include bytes by default.
+- Improved `PlatformFile.readAsBytes()` on web to read from blob/data URLs when file bytes were not loaded eagerly, with clearer error messages when data is unavailable.
+
+### Web
+- Updated `saveFile()` to use the browser's native save dialog when supported, while keeping the download fallback for unsupported browsers.
+- `saveFile()` now appends the file extension automatically when the file name has none and a single allowed extension is provided.
+
 ## 12.0.0-beta.4
 ### General
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)

--- a/README.md
+++ b/README.md
@@ -131,9 +131,12 @@ if (selectedDirectory == null) {
 ```
 #### Save-file / save-as dialog
 ```dart
+final Uint8List pdfBytes = await File('source-file.pdf').readAsBytes();
+
 String? outputFile = await FilePicker.saveFile(
   dialogTitle: 'Please select an output file:',
   fileName: 'output-file.pdf',
+  bytes: pdfBytes,
 );
 
 if (outputFile == null) {

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -4,6 +4,9 @@ import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 
 import 'android_saf_handle.dart';
+// Conditional import: web implementation will be used only on web builds.
+import '../platform/web/platform_file_web_fetch_stub.dart'
+    if (dart.library.js_interop) '../platform/web/platform_file_web_fetch.dart';
 
 class PlatformFile {
   PlatformFile({
@@ -93,6 +96,14 @@ class PlatformFile {
   /// Retrieves this as a XFile
   XFile get xFile {
     if (kIsWeb) {
+      if (bytes == null) {
+        throw StateError(
+          'PlatformFile.xFile: missing file bytes on Web. '
+          'Call FilePicker.pickFiles(withData: true) (or pickFile with withData: true) '
+          'so that file bytes are available, or access the file via its `path`/blob URL and fetch the data manually.',
+        );
+      }
+
       return XFile.fromData(bytes!, name: name, length: size);
     } else {
       return XFile(path!, name: name, bytes: bytes, length: size);
@@ -103,7 +114,27 @@ class PlatformFile {
   ///
   /// For large files on mobile and desktop platforms, prefer [readAsByteStream]
   /// to avoid Out Of Memory (OOM) issues.
-  Future<Uint8List> readAsBytes() => xFile.readAsBytes();
+  Future<Uint8List> readAsBytes() async {
+    if (kIsWeb) {
+      // If bytes are already present return them.
+      if (bytes != null) return bytes!;
+
+      // Try to fetch bytes automatically from the provided `path` (may be
+      // a blob: URL or data: URL). The helper is a no-op on non-web
+      // platforms thanks to conditional imports.
+      final fetched = await fetchBytesFromWebPath(path);
+      if (fetched != null) return fetched;
+
+      // Fallback: clear and descriptive error.
+      throw StateError(
+        'PlatformFile.readAsBytes(): file data is not available on Web. '
+        'Either call FilePicker.pickFiles(withData: true) so that `bytes` are populated, '
+        'or ensure the file `path` is a fetchable blob/data URL. Automatic fetch from `path` failed.',
+      );
+    }
+
+    return xFile.readAsBytes();
+  }
 
   /// Read the file content as a stream of bytes.
   ///

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -131,7 +131,7 @@ abstract final class FilePicker {
       onFileLoading: onFileLoading,
       compressionQuality: compressionQuality,
       allowMultiple: false,
-      withData: false,
+      withData: kIsWeb,
       withReadStream: false,
       lockParentWindow: lockParentWindow,
       readSequential: false,
@@ -236,7 +236,7 @@ abstract final class FilePicker {
   /// Returns a [Future<String?>] which resolves to the absolute path of the
   /// saved file, or `null` if the user canceled the operation.
   ///
-  /// On the web, this starts a download and always returns `null`.
+  /// On the web, this starts a browser-managed save flow/download.
   ///
   /// The User Selected File Read/Write entitlement is required on macOS.
   ///

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -2,15 +2,32 @@ import 'dart:async';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
-import 'package:file_picker/src/api/file_picker_types.dart';
-import 'package:file_picker/src/api/file_picker_result.dart';
-import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/file_picker_result.dart';
+import 'package:file_picker/src/api/file_picker_types.dart';
+import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:path/path.dart' as p;
 import 'package:web/web.dart';
 
+// ---------------------------------------------------------------------------
+// JS interop for the File System Access API (showSaveFilePicker).
+// Available in Chrome/Edge. Falls back to anchor download on other browsers.
+// ---------------------------------------------------------------------------
+
+@JS('showSaveFilePicker')
+external JSPromise<JSAny?> _showSaveFilePickerJs(JSAny options);
+
+extension type _FileHandle(JSObject _) implements JSObject {
+  external JSPromise<JSAny?> createWritable();
+}
+
+extension type _WritableStream(JSObject _) implements JSObject {
+  external JSPromise<JSAny?> write(JSAny data);
+  external JSPromise<JSAny?> close();
+}
+
+// ---------------------------------------------------------------------------
 class FilePickerWeb extends FilePickerPlatform {
   late Element _target;
   final String _kFilePickerInputsDomId = '__file_picker_web-file-input';
@@ -40,16 +57,6 @@ class FilePickerWeb extends FilePickerPlatform {
   }
 
   @override
-  Future<String?> getDirectoryPath({
-    String? dialogTitle,
-    bool lockParentWindow = false,
-    String? initialDirectory,
-    AndroidSAFOptions? androidSafOptions,
-  }) async {
-    throw UnimplementedError('getDirectoryPath() has not been implemented.');
-  }
-
-  @override
   Future<FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
@@ -74,95 +81,36 @@ class FilePickerWeb extends FilePickerPlatform {
     Completer<List<PlatformFile>?>? filesCompleter =
         Completer<List<PlatformFile>?>();
 
-    String accept = _fileType(type, allowedExtensions);
-    HTMLInputElement uploadInput = HTMLInputElement();
-    uploadInput.type = 'file';
-    uploadInput.draggable = true;
-    uploadInput.multiple = allowMultiple;
-    uploadInput.accept = accept;
-    uploadInput.style.display = 'none';
+    final uploadInput = HTMLInputElement()
+      ..type = 'file'
+      ..draggable = true
+      ..multiple = allowMultiple
+      ..accept = _fileType(type, allowedExtensions)
+      ..style.display = 'none';
 
     bool changeEventTriggered = false;
-
-    if (onFileLoading != null) {
-      onFileLoading(FilePickerStatus.picking);
-    }
+    onFileLoading?.call(FilePickerStatus.picking);
 
     void changeEventListener(Event e) async {
-      if (changeEventTriggered) {
-        return;
-      }
+      if (changeEventTriggered) return;
       changeEventTriggered = true;
 
-      final FileList files = uploadInput.files!;
-      final List<PlatformFile> pickedFiles = [];
-
-      void addPickedFile(
-        File file,
-        Uint8List? bytes,
-        String? path,
-        Stream<List<int>>? readStream,
-      ) {
-        String? blobUrl;
-        if (bytes != null && bytes.isNotEmpty) {
-          final blob = Blob(
-            [bytes.toJS].toJS,
-            BlobPropertyBag(type: file.type),
-          );
-
-          blobUrl = URL.createObjectURL(blob);
-        }
-        pickedFiles.add(
-          PlatformFile(
-            name: file.name,
-            path: path ?? blobUrl,
-            size: bytes != null ? bytes.length : file.size,
-            bytes: bytes,
-            readStream: readStream,
-          ),
-        );
-
-        if (pickedFiles.length >= files.length) {
-          if (onFileLoading != null) {
-            onFileLoading(FilePickerStatus.done);
-          }
-          filesCompleter?.complete(pickedFiles);
-        }
+      final files = uploadInput.files;
+      if (files == null) {
+        onFileLoading?.call(FilePickerStatus.done);
+        filesCompleter?.complete(null);
+        return;
       }
 
-      for (int i = 0; i < files.length; i++) {
-        final File? file = files.item(i);
-        if (file == null) {
-          continue;
-        }
+      final pickedFiles = await _buildPickedFiles(
+        files,
+        withData: withData,
+        withReadStream: withReadStream,
+        readSequential: readSequential,
+      );
 
-        if (withReadStream) {
-          addPickedFile(file, null, null, _openFileReadStream(file));
-          continue;
-        }
-
-        if (!withData) {
-          final FileReader reader = FileReader();
-          reader.onLoadEnd.listen((e) {
-            String? result = (reader.result as JSString?)?.toDart;
-            addPickedFile(file, null, result, null);
-          });
-          reader.readAsDataURL(file);
-          continue;
-        }
-
-        final syncCompleter = Completer<void>();
-        final FileReader reader = FileReader();
-        reader.onLoadEnd.listen((e) {
-          ByteBuffer? byteBuffer = (reader.result as JSArrayBuffer?)?.toDart;
-          addPickedFile(file, byteBuffer?.asUint8List(), null, null);
-          syncCompleter.complete();
-        });
-        reader.readAsArrayBuffer(file);
-        if (readSequential) {
-          await syncCompleter.future;
-        }
-      }
+      onFileLoading?.call(FilePickerStatus.done);
+      filesCompleter?.complete(pickedFiles);
     }
 
     void cancelledEventListener(Event _) {
@@ -171,7 +119,7 @@ class FilePickerWeb extends FilePickerPlatform {
       // This listener is called before the input changed event,
       // and the `uploadInput.files` value is still null
       // Wait for results from js to dart
-      Future.delayed(Duration(seconds: 1)).then((value) {
+      Future.delayed(const Duration(seconds: 1)).then((value) {
         if (!changeEventTriggered) {
           changeEventTriggered = true;
           filesCompleter?.complete(null);
@@ -188,20 +136,11 @@ class FilePickerWeb extends FilePickerPlatform {
       window.addEventListener('focus', cancelledEventListener.toJS);
     }
 
-    //Add input element to the page body
-    Node? firstChild = _target.firstChild;
-    while (firstChild != null) {
-      _target.removeChild(firstChild);
-      firstChild = _target.firstChild;
-    }
+    _clearTarget();
     _target.children.add(uploadInput);
     uploadInput.click();
 
-    firstChild = _target.firstChild;
-    while (firstChild != null) {
-      _target.removeChild(firstChild);
-      firstChild = _target.firstChild;
-    }
+    _clearTarget();
 
     final List<PlatformFile>? files = await filesCompleter.future;
     filesCompleter = null;
@@ -220,38 +159,152 @@ class FilePickerWeb extends FilePickerPlatform {
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
   }) async {
-    if (bytes.isEmpty) {
-      throw ArgumentError(
-        'The bytes are required when saving a file on the web.',
-      );
-    }
-
-    if (fileName.isEmpty) {
-      throw ArgumentError(
-        'A file name is required when saving a file on the web.',
-      );
-    }
-
-    if (p.extension(fileName).isEmpty) {
-      throw ArgumentError(
-        'The file name should include a valid file extension.',
-      );
-    }
-
+    // Ensure the file name has an extension.
+    final name = _ensureExtension(fileName, allowedExtensions);
     final blob = Blob([bytes.toJS].toJS);
-    final url = URL.createObjectURL(blob);
 
-    // Start a download by using a click event on an anchor element that contains the Blob.
+    // Try the native "Save As" picker (Chrome/Edge).
+    // Returns true=saved, false=cancelled, null=unsupported.
+    final pickerResult = await _trySaveWithPicker(blob, name);
+    if (pickerResult == true) return name;
+    if (pickerResult == false) return null;
+
+    // Fallback: standard browser download.
+    _downloadBlob(blob, name);
+    return name;
+  }
+
+  // ---------------------------------------------------------------------------
+  // saveFile helpers
+  // ---------------------------------------------------------------------------
+
+  /// Appends a single allowed extension when the file name has none.
+  String _ensureExtension(String fileName, List<String>? allowedExtensions) {
+    if (fileName.contains('.')) return fileName;
+    if (allowedExtensions == null || allowedExtensions.length != 1) {
+      return fileName;
+    }
+    final ext = allowedExtensions.first.trim();
+    if (ext.isEmpty) return fileName;
+    return ext.startsWith('.') ? '$fileName$ext' : '$fileName.$ext';
+  }
+
+  /// Returns `true` if saved, `false` if the user cancelled, `null` if the
+  /// browser does not support the native save picker.
+  Future<bool?> _trySaveWithPicker(Blob blob, String fileName) async {
+    try {
+      final handle = _FileHandle(
+        await _showSaveFilePickerJs({'suggestedName': fileName}.jsify()!).toDart
+            as JSObject,
+      );
+      final writable = _WritableStream(
+        await handle.createWritable().toDart as JSObject,
+      );
+      await writable.write(blob as JSAny).toDart;
+      await writable.close().toDart;
+      return true;
+    } catch (e) {
+      // User pressed Cancel → AbortError.
+      return e.toString().contains('Abort') ? false : null;
+    }
+  }
+
+  /// Triggers a browser download for [blob] with [fileName].
+  void _downloadBlob(Blob blob, String fileName) {
+    final url = URL.createObjectURL(blob);
     HTMLAnchorElement()
       ..href = url
-      // Always open the file in a new tab.
-      ..target = 'blank'
       ..download = fileName
       ..click();
-
-    // Release the Blob URL after the download started.
     URL.revokeObjectURL(url);
-    return null;
+  }
+
+  Future<List<PlatformFile>> _buildPickedFiles(
+    FileList files, {
+    required bool withData,
+    required bool withReadStream,
+    required bool readSequential,
+  }) async {
+    final futures = <Future<PlatformFile>>[];
+    final pickedFiles = <PlatformFile>[];
+
+    for (int i = 0; i < files.length; i++) {
+      final file = files.item(i);
+      if (file == null) continue;
+
+      final pickedFile = _toPlatformFile(
+        file,
+        withData: withData,
+        withReadStream: withReadStream,
+      );
+
+      if (readSequential) {
+        pickedFiles.add(await pickedFile);
+      } else {
+        futures.add(pickedFile);
+      }
+    }
+
+    return readSequential ? pickedFiles : Future.wait(futures);
+  }
+
+  Future<PlatformFile> _toPlatformFile(
+    File file, {
+    required bool withData,
+    required bool withReadStream,
+  }) async {
+    if (withReadStream) {
+      return PlatformFile(
+        name: file.name,
+        path: URL.createObjectURL(file),
+        size: file.size,
+        readStream: _openFileReadStream(file),
+      );
+    }
+
+    if (!withData) {
+      return PlatformFile(
+        name: file.name,
+        path: URL.createObjectURL(file),
+        size: file.size,
+      );
+    }
+
+    final bytes = await _readFileAsBytes(file);
+    return PlatformFile(
+      name: file.name,
+      path: _blobUrlFromBytes(file, bytes),
+      size: bytes?.length ?? file.size,
+      bytes: bytes,
+    );
+  }
+
+  Future<Uint8List?> _readFileAsBytes(File file) {
+    final completer = Completer<Uint8List?>();
+    final reader = FileReader();
+    reader.onLoadEnd.listen((_) {
+      final byteBuffer = (reader.result as JSArrayBuffer?)?.toDart;
+      completer.complete(byteBuffer?.asUint8List());
+    });
+    reader.readAsArrayBuffer(file);
+    return completer.future;
+  }
+
+  String? _blobUrlFromBytes(File file, Uint8List? bytes) {
+    if (bytes == null || bytes.isEmpty) {
+      return null;
+    }
+
+    final blob = Blob([bytes.toJS].toJS, BlobPropertyBag(type: file.type));
+    return URL.createObjectURL(blob);
+  }
+
+  void _clearTarget() {
+    Node? firstChild = _target.firstChild;
+    while (firstChild != null) {
+      _target.removeChild(firstChild);
+      firstChild = _target.firstChild;
+    }
   }
 
   static String _fileType(FileType type, List<String>? allowedExtensions) {

--- a/lib/src/platform/web/platform_file_web_fetch.dart
+++ b/lib/src/platform/web/platform_file_web_fetch.dart
@@ -1,0 +1,31 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+@JS('fetch')
+external JSPromise<JSObject> _fetchJs(JSString url);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+}
+
+/// Attempts to fetch bytes from a web-only path (`blob:` or `data:` URL).
+Future<Uint8List?> fetchBytesFromWebPath(String? path) async {
+  if (path == null || path.isEmpty) return null;
+
+  try {
+    if (path.startsWith('data:')) {
+      return Uri.parse(path).data?.contentAsBytes();
+    }
+
+    if (path.startsWith('blob:')) {
+      final buffer = await _Response(
+        await _fetchJs(path.toJS).toDart,
+      ).arrayBuffer().toDart;
+      return buffer.toDart.asUint8List();
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}

--- a/lib/src/platform/web/platform_file_web_fetch_stub.dart
+++ b/lib/src/platform/web/platform_file_web_fetch_stub.dart
@@ -1,0 +1,10 @@
+// Stub implementation used when dart:html is not available (non-web platforms).
+// The real implementation lives in `platform_file_web_fetch.dart` which is
+// conditionally imported only on web builds.
+
+import 'dart:typed_data';
+
+/// Attempts to fetch bytes from a web-only path (blob: or data: URL).
+///
+/// This stub is a no-op on non-web platforms and returns null.
+Future<Uint8List?> fetchBytesFromWebPath(String? path) async => null;


### PR DESCRIPTION
* Prepare savefile from web to receive the bytes of blob file picked
* Update FilePicker.saveFile and the underlying platform interface to require the bytes parameter and remove the optional path parameter.
* Enhance PlatformFile.readAsBytes() on Web to automatically fetch content from blob: and data: URLs if bytes are not already cached.
* Implement fetchBytesFromWebPath using js_interop for Web, with a corresponding stub for non-web platforms to support conditional importing.
* Improve error messaging in PlatformFile when file data is missing on Web, providing guidance on using withData: true.