### PR TITLE
Fix saveFile bytes handling on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.0-beta.5
+### Android / Darwin
+- Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
+
 ## 12.0.0-beta.4
 ### General
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -9,7 +9,6 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
 
 /// An implementation of [FilePickerPlatform] that uses method channels.
 class MethodChannelFilePicker extends FilePickerPlatform {
@@ -187,9 +186,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
             "fileType": type.name,
             "initialDirectory": initialDirectory,
             "allowedExtensions": allowedExtensions,
+            "bytes": bytes,
           });
-
-      await FilePickerUtils.saveBytesToFile(bytes, savedPath);
 
       if (onFileLoading != null) {
         onFileLoading(FilePickerStatus.done);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.4
+version: 12.0.0-beta.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Restore native byte handling for `saveFile(bytes: ...)` on Android and iOS by sending `bytes` through the method channel.
- Remove the redundant Dart-side write that could break SAF/content URI saves.
- Add a release note in `CHANGELOG.md` and bump the package version to `12.0.0-beta.5`.

## Related issues
- Fixes #2033
- Fixes #2024