### PR TITLE
Fix iOS picker stuck state on fast swipe dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 12.0.0-beta.5
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
+### iOS
+- Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
 
 ## 12.0.0-beta.4
 ### General

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -162,17 +162,17 @@ final class IOSFilePickerHandler: NSObject,
     }
 
     func documentPickerWasCancelled(_: UIDocumentPickerViewController) {
-        result?(nil)
-        result = nil
+        finishCurrentRequest(nil)
+    }
+
+    func presentationControllerWillDismiss(_: UIPresentationController) {
+        finishCurrentRequest(nil)
     }
 
     func presentationControllerDidDismiss(
         _: UIPresentationController
     ) {
-        if result != nil {
-            result?(nil)
-            result = nil
-        }
+        finishCurrentRequest(nil)
     }
 
     func documentPicker(
@@ -348,6 +348,15 @@ final class IOSFilePickerHandler: NSObject,
         } catch {
             return nil
         }
+    }
+
+    private func finishCurrentRequest(_ value: Any?) {
+        guard let currentResult = result else {
+            return
+        }
+
+        result = nil
+        currentResult(value)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Fix the iOS picker state cleanup when the user dismisses the picker with a fast swipe.
- Prevent `multiple_request` from persisting until app restart.
- Add a changelog entry under `12.0.0-beta.5`.

## Related issue
- Fixes #2021