### PR TITLE
Fix web readAsBytes fallback for blob URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
 
+### Web
+- Fixed `PlatformFile.readAsBytes()` so files picked on Web can recover data from `blob:` and `data:` URLs when `withData` was not used.
+
 ## 12.0.0-beta.4
 ### General
 - Added `pickFile()` static method as a convenience wrapper for single file selection, returning `PlatformFile?` directly. [#1469](https://github.com/miguelpruivo/flutter_file_picker/issues/1469)

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -4,7 +4,9 @@ import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 
 import 'android_saf_handle.dart';
+import '../platform/web/platform_file_web_fetch.dart';
 
+/// Represents a file returned by the file picker across all supported platforms.
 class PlatformFile {
   PlatformFile({
     this.path,
@@ -103,7 +105,20 @@ class PlatformFile {
   ///
   /// For large files on mobile and desktop platforms, prefer [readAsByteStream]
   /// to avoid Out Of Memory (OOM) issues.
-  Future<Uint8List> readAsBytes() => xFile.readAsBytes();
+  Future<Uint8List> readAsBytes() async {
+    if (bytes != null) return bytes!;
+
+    if (kIsWeb) {
+      final fetchedBytes = await fetchBytesFromWebPath(path);
+      if (fetchedBytes != null) return fetchedBytes;
+    }
+
+    throw StateError(
+      'PlatformFile.readAsBytes(): file data is not available on Web. '
+      'Call FilePicker.pickFiles(withData: true) or ensure the file path is a '
+      'fetchable blob/data URL.',
+    );
+  }
 
   /// Read the file content as a stream of bytes.
   ///

--- a/lib/src/platform/web/platform_file_web_fetch.dart
+++ b/lib/src/platform/web/platform_file_web_fetch.dart
@@ -1,0 +1,30 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+@JS('fetch')
+external JSPromise<JSObject> _fetchJs(JSString url);
+
+extension type _Response(JSObject _) implements JSObject {
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+}
+
+/// Attempts to fetch bytes from a web-only path (`blob:` or `data:` URL).
+Future<Uint8List?> fetchBytesFromWebPath(String? path) async {
+  if (path == null || path.isEmpty) return null;
+
+  try {
+    if (path.startsWith('data:')) {
+      return Uri.parse(path).data?.contentAsBytes();
+    }
+
+    if (path.startsWith('blob:')) {
+      final response = _Response(await _fetchJs(path.toJS).toDart);
+      final buffer = await response.arrayBuffer().toDart;
+      return buffer.toDart.asUint8List();
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Make `PlatformFile.readAsBytes()` on Web recover bytes from `blob:` and `data:` URLs when `bytes` is not cached.
- Keep the fallback scoped to web via `kIsWeb`.
- Add a changelog entry under `12.0.0-beta.5`.

## Notes
- This keeps the helper separate from the class body while avoiding a stub file https://github.com/miguelpruivo/flutter_file_picker/pull/2035