### PR TITLE
[All platforms][IOS] - feature: Refactor code in example & ios image order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 12.0.0-beta.5
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
+
 ### iOS
 - Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
 - iOS now preserves the selection order when picking multiple files: the list of returned files will match the order in which the user selected them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 ### iOS
 - Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
 - `saveFile` is now disabled when multi-pick mode is active (`allowMultipleSelection = true`), preventing ambiguous or conflicting save behaviour.
-- File selection order is now preserved when returning results from multi-pick on iOS; files are returned in the same order the user selected them.
 
 ## 12.0.0-beta.4
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
 ### iOS
 - Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
+- iOS now preserves the selection order when picking multiple files: the list of returned files will match the order in which the user selected them.
 
 ## 12.0.0-beta.4
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-## NEXT
-### iOS
-- `saveFile` is now disabled when multi-pick mode is active (`allowMultipleSelection = true`), preventing ambiguous or conflicting save behaviour.
-- File selection order is now preserved when returning results from multi-pick on iOS; files are returned in the same order the user selected them.
-
 ## 12.0.0-beta.5
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
 ### iOS
 - Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
+- `saveFile` is now disabled when multi-pick mode is active (`allowMultipleSelection = true`), preventing ambiguous or conflicting save behaviour.
+- File selection order is now preserved when returning results from multi-pick on iOS; files are returned in the same order the user selected them.
 
 ## 12.0.0-beta.4
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+### iOS
+- `saveFile` is now disabled when multi-pick mode is active (`allowMultipleSelection = true`), preventing ambiguous or conflicting save behaviour.
+- File selection order is now preserved when returning results from multi-pick on iOS; files are returned in the same order the user selected them.
+
 ## 12.0.0-beta.5
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.
 ### iOS
 - Fixed a race condition when dismissing the file picker with a fast swipe, preventing the picker from getting stuck in a `multiple_request` state until app restart. [#2021](https://github.com/miguelpruivo/flutter_file_picker/issues/2021)
-- `saveFile` is now disabled when multi-pick mode is active (`allowMultipleSelection = true`), preventing ambiguous or conflicting save behaviour.
 
 ## 12.0.0-beta.4
 ### General

--- a/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
+++ b/darwin/file_picker/Sources/file_picker/IOSFilePickerHandler.swift
@@ -132,9 +132,10 @@ final class IOSFilePickerHandler: NSObject,
 
         eventSink?(true)
         let group = DispatchGroup()
-        var resolved: [[String: Any]] = []
+        var resolved = Array<[String: Any]?>(repeating: nil, count: results.count)
+        let resolvedLock = NSLock()
 
-        for item in results {
+        for (index, item) in results.enumerated() {
             group.enter()
             item.itemProvider.loadFileRepresentation(
                 forTypeIdentifier: UTType.item.identifier
@@ -146,7 +147,9 @@ final class IOSFilePickerHandler: NSObject,
                     return
                 }
                 if let fileInfo = self.makeFileInfo(from: copiedURL) {
-                    resolved.append(fileInfo)
+                    resolvedLock.lock()
+                    resolved[index] = fileInfo
+                    resolvedLock.unlock()
                 }
             }
         }
@@ -156,7 +159,8 @@ final class IOSFilePickerHandler: NSObject,
                 return
             }
             eventSink?(false)
-            currentResult(resolved.isEmpty ? nil : resolved)
+            let orderedResolved = resolved.compactMap { $0 }
+            currentResult(orderedResolved.isEmpty ? nil : orderedResolved)
             result = nil
         }
     }
@@ -215,6 +219,9 @@ final class IOSFilePickerHandler: NSObject,
     private func presentMediaPicker(type: String, allowsMultipleSelection: Bool) {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = allowsMultipleSelection ? 0 : 1
+        if #available(iOS 15.0, *) {
+            configuration.selection = .ordered
+        }
 
         switch type {
         case "image":

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -18,6 +18,9 @@ class FilePickerDemo extends StatefulWidget {
 }
 
 class _FilePickerDemoState extends State<FilePickerDemo> {
+  static const _saveFileDisabledMessage =
+      'Save file will be disabled because it is not compatible with multiple file selection.';
+
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
   final _defaultFileNameController = TextEditingController();
@@ -35,6 +38,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   bool _supportsSafOptions = false;
   FileType _pickingType = FileType.any;
   List<PlatformFile>? pickedFiles;
+  bool get _isSaveFileDisabled => _multiPick;
   Widget _resultsWidget = const Row(
     children: [
       Expanded(
@@ -260,6 +264,11 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     String? pickedSaveFilePath;
     bool hasUserAborted = true;
 
+    if (_isSaveFileDisabled) {
+      _showSaveFileDisabledSnackBar();
+      return;
+    }
+
     final file = pickedFiles?.firstOrNull;
     final fileName = _defaultFileNameController.text;
 
@@ -313,6 +322,18 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _scaffoldMessengerKey.currentState?.showSnackBar(
       SnackBar(
         content: Text(message, style: const TextStyle(color: Colors.white)),
+      ),
+    );
+  }
+
+  void _showSaveFileDisabledSnackBar() {
+    _scaffoldMessengerKey.currentState?.hideCurrentSnackBar();
+    _scaffoldMessengerKey.currentState?.showSnackBar(
+      const SnackBar(
+        content: Text(
+          _saveFileDisabledMessage,
+          style: TextStyle(color: Colors.white),
+        ),
       ),
     );
   }
@@ -442,7 +463,12 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         constraints: const BoxConstraints.tightFor(width: 400.0),
         child: SwitchListTile.adaptive(
           title: const Text('Pick multiple files', textAlign: TextAlign.left),
-          onChanged: (value) => setState(() => _multiPick = value),
+          onChanged: (value) {
+            setState(() => _multiPick = value);
+            if (value) {
+              _showSaveFileDisabledSnackBar();
+            }
+          },
           value: _multiPick,
         ),
       ),
@@ -525,7 +551,10 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       SizedBox(
         width: 120,
         child: FloatingActionButton.extended(
-          onPressed: _saveFile,
+          onPressed: _isSaveFileDisabled ? null : _saveFile,
+          backgroundColor: _isSaveFileDisabled ? Colors.grey.shade700 : null,
+          foregroundColor: _isSaveFileDisabled ? Colors.white70 : null,
+          disabledElevation: 0,
           label: const Text('Save file'),
           icon: const Icon(Icons.save_as),
         ),

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -19,7 +19,7 @@ class FilePickerDemo extends StatefulWidget {
 
 class _FilePickerDemoState extends State<FilePickerDemo> {
   static const _saveFileDisabledMessage =
-      'Save file will be disabled because it is not compatible with multiple file selection.';
+      'Save file is disabled because it is not compatible with multiple file selection.';
 
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();

--- a/example/test/file_picker_demo_test.dart
+++ b/example/test/file_picker_demo_test.dart
@@ -11,30 +11,29 @@ void main() {
     return find.widgetWithText(SwitchListTile, 'Pick multiple files');
   }
 
-  testWidgets(
-    'enabling multi-pick shows warning and disables save file',
-    (tester) async {
-      await tester.pumpWidget(const FilePickerDemo());
+  testWidgets('enabling multi-pick shows warning and disables save file', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const FilePickerDemo());
 
-      await tester.tap(findMultiPickSwitchTile());
-      await tester.pumpAndSettle();
+    await tester.tap(findMultiPickSwitchTile());
+    await tester.pumpAndSettle();
 
-      expect(
-        find.text(
-          'Save file will be disabled because it is not compatible with multiple file selection.',
-        ),
-        findsOneWidget,
-      );
+    expect(
+      find.text(
+        'Save file will be disabled because it is not compatible with multiple file selection.',
+      ),
+      findsOneWidget,
+    );
 
-      final saveFileButton = tester.widget<FloatingActionButton>(
-        findSaveFileButton(),
-      );
+    final saveFileButton = tester.widget<FloatingActionButton>(
+      findSaveFileButton(),
+    );
 
-      expect(saveFileButton.onPressed, isNull);
-      expect(saveFileButton.backgroundColor, Colors.grey.shade700);
-      expect(saveFileButton.foregroundColor, Colors.white70);
-    },
-  );
+    expect(saveFileButton.onPressed, isNull);
+    expect(saveFileButton.backgroundColor, Colors.grey.shade700);
+    expect(saveFileButton.foregroundColor, Colors.white70);
+  });
 
   testWidgets('disabling multi-pick enables save file again', (tester) async {
     await tester.pumpWidget(const FilePickerDemo());
@@ -54,4 +53,3 @@ void main() {
     expect(saveFileButton.foregroundColor, isNull);
   });
 }
-

--- a/example/test/file_picker_demo_test.dart
+++ b/example/test/file_picker_demo_test.dart
@@ -1,0 +1,57 @@
+import 'package:file_picker_example/src/file_picker_demo.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Finder findSaveFileButton() {
+    return find.widgetWithText(FloatingActionButton, 'Save file');
+  }
+
+  Finder findMultiPickSwitchTile() {
+    return find.widgetWithText(SwitchListTile, 'Pick multiple files');
+  }
+
+  testWidgets(
+    'enabling multi-pick shows warning and disables save file',
+    (tester) async {
+      await tester.pumpWidget(const FilePickerDemo());
+
+      await tester.tap(findMultiPickSwitchTile());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Save file will be disabled because it is not compatible with multiple file selection.',
+        ),
+        findsOneWidget,
+      );
+
+      final saveFileButton = tester.widget<FloatingActionButton>(
+        findSaveFileButton(),
+      );
+
+      expect(saveFileButton.onPressed, isNull);
+      expect(saveFileButton.backgroundColor, Colors.grey.shade700);
+      expect(saveFileButton.foregroundColor, Colors.white70);
+    },
+  );
+
+  testWidgets('disabling multi-pick enables save file again', (tester) async {
+    await tester.pumpWidget(const FilePickerDemo());
+
+    await tester.tap(findMultiPickSwitchTile());
+    await tester.pumpAndSettle();
+
+    await tester.tap(findMultiPickSwitchTile());
+    await tester.pumpAndSettle();
+
+    final saveFileButton = tester.widget<FloatingActionButton>(
+      findSaveFileButton(),
+    );
+
+    expect(saveFileButton.onPressed, isNotNull);
+    expect(saveFileButton.backgroundColor, isNull);
+    expect(saveFileButton.foregroundColor, isNull);
+  });
+}
+

--- a/example/test/file_picker_demo_test.dart
+++ b/example/test/file_picker_demo_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     expect(
       find.text(
-        'Save file will be disabled because it is not compatible with multiple file selection.',
+        'Save file is disabled because it is not compatible with multiple file selection.',
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Disable save file in multi-pick mode and maintain selection order on iOS

fixed: https://github.com/miguelpruivo/flutter_file_picker/issues/1866