### PR TITLE
Fix readAsBytes fallback for path-based files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.0-beta.6
+### General
+- Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
+
 ## 12.0.0-beta.5
 ### Android / Darwin
 - Fixed `saveFile(bytes: ...)` so native byte handling is preserved on Android and iOS, avoiding the duplicate Dart-side write that could break SAF/content URI saves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 12.0.0-beta.6
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
-
-### Windows
-- `FileType.custom` now falls back to `FileType.any` when no `allowedExtensions` are provided, avoiding a null check crash in the Windows file filter builder.
+- `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
 
 ## 12.0.0-beta.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 
+### Windows
+- `FileType.custom` now falls back to `FileType.any` when no `allowedExtensions` are provided, avoiding a null check crash in the Windows file filter builder.
+
 ## 12.0.0-beta.5
 ### Android
 - `saveFile` now writes file data using Kotlin Coroutines (`CoroutineScope(Dispatchers.IO).launch`), keeping all I/O off the main thread and preventing UI freezes.

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -304,7 +304,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     try {
       pickedSaveFilePath = await FilePicker.saveFile(
         allowedExtensions: _allowedExtensionsFromInput(),
-        type: FileType.custom,
+        type: _pickingType,
         dialogTitle: _dialogTitleController.text,
         fileName: targetFileName,
         initialDirectory: _initialDirectoryController.text,

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
@@ -110,11 +111,11 @@ class PlatformFile {
     if (bytes != null) return bytes!;
 
     if (readStream != null) {
-      final buffer = <int>[];
+      final builder = BytesBuilder();
       await for (final chunk in readStream!) {
-        buffer.addAll(chunk);
+        builder.add(chunk);
       }
-      return Uint8List.fromList(buffer);
+      return builder.takeBytes();
     }
 
     if (kIsWeb) {

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -109,9 +109,19 @@ class PlatformFile {
   Future<Uint8List> readAsBytes() async {
     if (bytes != null) return bytes!;
 
+    if (readStream != null) {
+      final buffer = <int>[];
+      await for (final chunk in readStream!) {
+        buffer.addAll(chunk);
+      }
+      return Uint8List.fromList(buffer);
+    }
+
     if (kIsWeb) {
       final fetchedBytes = await fetchBytesFromWebPath(path);
       if (fetchedBytes != null) return fetchedBytes;
+    } else if (path != null) {
+      return xFile.readAsBytes();
     }
 
     throw StateError(

--- a/lib/src/file_picker_utils.dart
+++ b/lib/src/file_picker_utils.dart
@@ -121,6 +121,34 @@ class FilePickerUtils {
     return (codeUnit >= 65 && codeUnit <= 90) || // A-Z
         (codeUnit >= 97 && codeUnit <= 122); // a-z
   }
+
+  /// Validates the `allowedExtensions` parameter against the provided [type].
+  ///
+  /// Throws an [ArgumentError] if extension filters are provided while the
+  /// `type` is not `FileType.custom`. Uses a consistent error message across
+  /// platforms.
+  static void validateAllowedExtensions(
+    FileType type,
+    List<String>? allowedExtensions,
+  ) {
+    if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
+      throw ArgumentError.value(
+        allowedExtensions,
+        'allowedExtensions',
+        'Custom extension filters are only allowed with FileType.custom. '
+            'Remove the extension filter or change the FileType to FileType.custom.',
+      );
+    }
+
+    if (type == FileType.custom &&
+        (allowedExtensions == null || allowedExtensions.isEmpty)) {
+      throw ArgumentError.value(
+        allowedExtensions,
+        'allowedExtensions',
+        'When using FileType.custom you must provide a non-empty list of allowedExtensions.',
+      );
+    }
+  }
 }
 
 /// Save the given bytes to a file, using a separate [Isolate].

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -9,7 +9,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 
 /// An implementation of [FilePickerPlatform] that uses method channels.
 class MethodChannelFilePicker extends FilePickerPlatform {

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -9,6 +9,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:file_picker/src/file_picker_utils.dart';
 
 /// An implementation of [FilePickerPlatform] that uses method channels.
 class MethodChannelFilePicker extends FilePickerPlatform {
@@ -101,14 +102,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
   ) async {
     final String type = fileType.name;
-    if (type != 'custom' && (allowedExtensions?.isNotEmpty ?? false)) {
-      throw ArgumentError.value(
-        allowedExtensions,
-        'allowedExtensions',
-        'Custom extension filters are only allowed with FileType.custom. '
-            'Remove the extension filter or change the FileType to FileType.custom.',
-      );
-    }
+    FilePickerUtils.validateAllowedExtensions(fileType, allowedExtensions);
     try {
       if (onFileLoading != null) {
         _eventSubscription = eventChannel.receiveBroadcastStream().listen((

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -94,8 +94,8 @@ class FilePickerLinux extends FilePickerPlatform {
     final List<PlatformFile> platformFiles =
         await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          withReadStream,
-          withData,
+          withReadStream: withReadStream,
+          withData: withData,
         );
 
     return FilePickerResult(platformFiles);
@@ -151,7 +151,7 @@ class FilePickerLinux extends FilePickerPlatform {
     final filePaths = uriPaths.map((uri) => uri.toFilePath()).toList();
 
     final List<PlatformFile> platformFiles =
-        await FilePickerUtils.filePathsToPlatformFiles(filePaths, false, false);
+        await FilePickerUtils.filePathsToPlatformFiles(filePaths);
 
     return platformFiles.firstOrNull?.path;
   }

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -7,7 +7,7 @@ import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:file_picker/src/platform/linux/xdp_filechooser.dart';
 import 'package:file_picker/src/platform/linux/xdp_request.dart';
 import 'package:file_picker/src/platform/linux/filters.dart';

--- a/lib/src/platform/linux/filters.dart
+++ b/lib/src/platform/linux/filters.dart
@@ -1,5 +1,5 @@
 import 'package:file_picker/src/api/file_picker_types.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:dbus/dbus.dart';
 
 typedef FilterInfo = Map<String, List<(int, String)>>;

--- a/lib/src/platform/linux/filters.dart
+++ b/lib/src/platform/linux/filters.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/src/api/file_picker_types.dart';
+import 'package:file_picker/src/file_picker_utils.dart';
 import 'package:dbus/dbus.dart';
 
 typedef FilterInfo = Map<String, List<(int, String)>>;
@@ -6,14 +7,7 @@ typedef FilterInfo = Map<String, List<(int, String)>>;
 class Filter {
   FilterInfo info = {};
   Filter(FileType type, List<String>? allowedExtensions) {
-    if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
-      throw ArgumentError.value(
-        allowedExtensions,
-        'allowedExtensions',
-        'Custom extension filters are only allowed with FileType.custom. '
-            'Remove the extension filter or change the FileType to FileType.custom.',
-      );
-    }
+    FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
     switch (type) {
       case FileType.any:
         return;

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -72,8 +72,8 @@ class FilePickerMacOS extends FilePickerPlatform {
     final List<PlatformFile> platformFiles =
         await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          withReadStream,
-          withData,
+          withReadStream: withReadStream,
+          withData: withData,
         );
 
     return FilePickerResult(platformFiles);

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -3,7 +3,7 @@ import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -132,14 +132,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     FileType type,
     List<String>? allowedExtensions,
   ) {
-    if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
-      throw ArgumentError.value(
-        allowedExtensions,
-        'allowedExtensions',
-        'Custom extension filters are only allowed with FileType.custom. '
-            'Remove the extension filter or change the FileType to FileType.custom.',
-      );
-    }
+    FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
     switch (type) {
       case FileType.any:
         return [];

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -7,6 +7,7 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:file_picker/src/file_picker_utils.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:path/path.dart' as p;
 import 'package:web/web.dart';
@@ -65,11 +66,7 @@ class FilePickerWeb extends FilePickerPlatform {
     int compressionQuality = 0,
     AndroidSAFOptions? androidSafOptions,
   }) async {
-    if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
-      throw Exception(
-        'You are setting a type [$type]. Custom extension filters are only allowed with FileType.custom, please change it or remove filters.',
-      );
-    }
+    FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
 
     Completer<List<PlatformFile>?>? filesCompleter =
         Completer<List<PlatformFile>?>();

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -7,7 +7,7 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:path/path.dart' as p;
 import 'package:web/web.dart';

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -12,7 +12,7 @@ import 'package:file_picker/src/api/android_saf_options.dart';
 
 import 'package:file_picker/src/api/exceptions.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:file_picker/src/platform/windows/file_picker_windows_ffi_types.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -58,8 +58,8 @@ class FilePickerWindows extends FilePickerPlatform {
       final filePaths = fileNames;
       final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
         filePaths,
-        withReadStream,
-        withData,
+        withReadStream: withReadStream,
+        withData: withData,
       );
 
       returnValue = FilePickerResult(platformFiles);

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -234,16 +234,14 @@ class FilePickerWindows extends FilePickerPlatform {
   }
 
   String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
+    FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
     switch (type) {
       case FileType.any:
         return 'All Files (*.*)\x00*.*\x00\x00';
       case FileType.audio:
         return 'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
       case FileType.custom:
-        if (allowedExtensions == null || allowedExtensions.isEmpty) {
-          return 'All Files (*.*)\x00*.*\x00\x00';
-        }
-        return 'Files (*.${allowedExtensions.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
+        return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
       case FileType.image:
         return 'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
       case FileType.media:

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -240,7 +240,10 @@ class FilePickerWindows extends FilePickerPlatform {
       case FileType.audio:
         return 'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
       case FileType.custom:
-        return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
+        if (allowedExtensions == null || allowedExtensions.isEmpty) {
+          return 'All Files (*.*)\x00*.*\x00\x00';
+        }
+        return 'Files (*.${allowedExtensions.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
       case FileType.image:
         return 'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
       case FileType.media:

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -6,10 +6,10 @@ import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart';
 
 Future<List<PlatformFile>> filePathsToPlatformFiles(
-  List<String> filePaths,
-  bool withReadStream,
-  bool withData,
-) {
+  List<String> filePaths, {
+  bool withReadStream = false,
+  bool withData = false,
+}) {
   return Future.wait(
     filePaths.where((String filePath) => filePath.isNotEmpty).map((
       String filePath,

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -69,21 +69,23 @@ Future<String> isExecutableOnPath(String executable) async {
 }
 
 Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
-  if (path != null && bytes != null && bytes.isNotEmpty) {
-    final receivePort = ReceivePort();
-    final transferable = TransferableTypedData.fromList([bytes]);
+  if (path == null || bytes == null || bytes.isEmpty) {
+    return;
+  }
 
-    await Isolate.spawn(_saveBytesIsolateEntry, [
-      receivePort.sendPort,
-      path,
-      transferable,
-    ]);
+  final receivePort = ReceivePort();
+  final transferable = TransferableTypedData.fromList([bytes]);
 
-    final result = await receivePort.first;
-    receivePort.close();
-    if (result is Exception) {
-      throw result;
-    }
+  await Isolate.spawn(_saveBytesIsolateEntry, [
+    receivePort.sendPort,
+    path,
+    transferable,
+  ]);
+
+  final result = await receivePort.first;
+  receivePort.close();
+  if (result is Exception) {
+    throw result;
   }
 }
 

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -31,7 +31,7 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
 }
 
 Future<PlatformFile> createPlatformFile(
-  dynamic file,
+  Object file,
   Uint8List? bytes,
   Stream<List<int>>? readStream,
 ) async {

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -35,14 +35,17 @@ Future<PlatformFile> createPlatformFile(
   Uint8List? bytes,
   Stream<List<int>>? readStream,
 ) async {
-  final f = file as File;
-  return PlatformFile(
-    bytes: bytes,
-    name: basename(f.path),
-    path: f.path,
-    readStream: readStream,
-    size: f.existsSync() ? f.lengthSync() : 0,
-  );
+  if (file case final File nativeFile) {
+    return PlatformFile(
+      bytes: bytes,
+      name: basename(nativeFile.path),
+      path: nativeFile.path,
+      readStream: readStream,
+      size: nativeFile.existsSync() ? nativeFile.lengthSync() : 0,
+    );
+  }
+
+  throw ArgumentError('Expected file to be a File.');
 }
 
 Future<String?> runExecutableWithArguments(

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart';
+
+Future<List<PlatformFile>> filePathsToPlatformFiles(
+  List<String> filePaths,
+  bool withReadStream,
+  bool withData,
+) {
+  return Future.wait(
+    filePaths
+        .where((String filePath) => filePath.isNotEmpty)
+        .map((String filePath) async {
+          final file = File(filePath);
+
+          if (withReadStream) {
+            return createPlatformFile(file, null, file.openRead());
+          }
+
+          if (!withData) {
+            return createPlatformFile(file, null, null);
+          }
+
+          final bytes = await file.readAsBytes();
+          return createPlatformFile(file, bytes, null);
+        })
+        .toList(),
+  );
+}
+
+Future<PlatformFile> createPlatformFile(
+  dynamic file,
+  Uint8List? bytes,
+  Stream<List<int>>? readStream,
+) async {
+  final f = file as File;
+  return PlatformFile(
+    bytes: bytes,
+    name: basename(f.path),
+    path: f.path,
+    readStream: readStream,
+    size: f.existsSync() ? f.lengthSync() : 0,
+  );
+}
+
+Future<String?> runExecutableWithArguments(
+  String executable,
+  List<String> arguments,
+) async {
+  final processResult = await Process.run(executable, arguments);
+  final path = processResult.stdout?.toString().trim();
+  if (processResult.exitCode != 0 || path == null || path.isEmpty) {
+    return null;
+  }
+  return path;
+}
+
+Future<String> isExecutableOnPath(String executable) async {
+  final path = await runExecutableWithArguments('which', [executable]);
+  if (path == null) {
+    throw Exception('Couldn\'t find the executable $executable in the path.');
+  }
+  return path;
+}
+
+Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
+  if (path != null && bytes != null && bytes.isNotEmpty) {
+    final receivePort = ReceivePort();
+    final transferable = TransferableTypedData.fromList([bytes]);
+
+    await Isolate.spawn(_saveBytesIsolateEntry, [
+      receivePort.sendPort,
+      path,
+      transferable,
+    ]);
+
+    final result = await receivePort.first;
+    receivePort.close();
+    if (result is Exception) {
+      throw result;
+    }
+  }
+}
+
+Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
+  if (args
+      case [
+        SendPort send,
+        String path,
+        TransferableTypedData transferable,
+      ]) {
+    try {
+      final Uint8List bytes = transferable.materialize().asUint8List();
+      final file = File(path);
+      await file.writeAsBytes(bytes);
+      send.send(null);
+    } catch (e) {
+      send.send(e);
+    }
+    return;
+  }
+
+  if (args case [final SendPort port, ...]) {
+    port.send(Exception('Invalid isolate arguments'));
+  }
+}

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -11,23 +11,22 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   bool withData,
 ) {
   return Future.wait(
-    filePaths
-        .where((String filePath) => filePath.isNotEmpty)
-        .map((String filePath) async {
-          final file = File(filePath);
+    filePaths.where((String filePath) => filePath.isNotEmpty).map((
+      String filePath,
+    ) async {
+      final file = File(filePath);
 
-          if (withReadStream) {
-            return createPlatformFile(file, null, file.openRead());
-          }
+      if (withReadStream) {
+        return createPlatformFile(file, null, file.openRead());
+      }
 
-          if (!withData) {
-            return createPlatformFile(file, null, null);
-          }
+      if (!withData) {
+        return createPlatformFile(file, null, null);
+      }
 
-          final bytes = await file.readAsBytes();
-          return createPlatformFile(file, bytes, null);
-        })
-        .toList(),
+      final bytes = await file.readAsBytes();
+      return createPlatformFile(file, bytes, null);
+    }).toList(),
   );
 }
 
@@ -86,12 +85,11 @@ Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
 }
 
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-  if (args
-      case [
-        SendPort send,
-        String path,
-        TransferableTypedData transferable,
-      ]) {
+  if (args case [
+    SendPort send,
+    String path,
+    TransferableTypedData transferable,
+  ]) {
     try {
       final Uint8List bytes = transferable.materialize().asUint8List();
       final file = File(path);

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -5,32 +5,28 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   List<String> filePaths,
   bool withReadStream,
   bool withData,
-) =>
-    throw UnsupportedError(
-      'filePathsToPlatformFiles is only supported on native platforms',
-    );
+) => throw UnsupportedError(
+  'filePathsToPlatformFiles is only supported on native platforms',
+);
 
 Future<PlatformFile> createPlatformFile(
   dynamic file,
   Uint8List? bytes,
   Stream<List<int>>? readStream,
-) =>
-    throw UnsupportedError(
-      'createPlatformFile is only supported on native platforms',
-    );
+) => throw UnsupportedError(
+  'createPlatformFile is only supported on native platforms',
+);
 
 Future<String?> runExecutableWithArguments(
   String executable,
   List<String> arguments,
-) =>
-    throw UnsupportedError(
-      'runExecutableWithArguments is only supported on native platforms',
-    );
+) => throw UnsupportedError(
+  'runExecutableWithArguments is only supported on native platforms',
+);
 
-Future<String> isExecutableOnPath(String executable) =>
-    throw UnsupportedError(
-      'isExecutableOnPath is only supported on native platforms',
-    );
+Future<String> isExecutableOnPath(String executable) => throw UnsupportedError(
+  'isExecutableOnPath is only supported on native platforms',
+);
 
 Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
     throw UnsupportedError(

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -1,0 +1,38 @@
+import 'dart:typed_data';
+import 'package:file_picker/file_picker.dart';
+
+Future<List<PlatformFile>> filePathsToPlatformFiles(
+  List<String> filePaths,
+  bool withReadStream,
+  bool withData,
+) =>
+    throw UnsupportedError(
+      'filePathsToPlatformFiles is only supported on native platforms',
+    );
+
+Future<PlatformFile> createPlatformFile(
+  dynamic file,
+  Uint8List? bytes,
+  Stream<List<int>>? readStream,
+) =>
+    throw UnsupportedError(
+      'createPlatformFile is only supported on native platforms',
+    );
+
+Future<String?> runExecutableWithArguments(
+  String executable,
+  List<String> arguments,
+) =>
+    throw UnsupportedError(
+      'runExecutableWithArguments is only supported on native platforms',
+    );
+
+Future<String> isExecutableOnPath(String executable) =>
+    throw UnsupportedError(
+      'isExecutableOnPath is only supported on native platforms',
+    );
+
+Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
+    throw UnsupportedError(
+      'saveBytesToFile is only supported on native platforms',
+    );

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -10,7 +10,7 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
 );
 
 Future<PlatformFile> createPlatformFile(
-  dynamic file,
+  Object file,
   Uint8List? bytes,
   Stream<List<int>>? readStream,
 ) => throw UnsupportedError(

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -2,10 +2,10 @@ import 'dart:typed_data';
 import 'package:file_picker/file_picker.dart';
 
 Future<List<PlatformFile>> filePathsToPlatformFiles(
-  List<String> filePaths,
-  bool withReadStream,
-  bool withData,
-) => throw UnsupportedError(
+  List<String> filePaths, {
+  bool withReadStream = false,
+  bool withData = false,
+}) => throw UnsupportedError(
   'filePathsToPlatformFiles is only supported on native platforms',
 );
 

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -20,10 +20,14 @@ class FilePickerUtils {
   /// [withReadStream] if true, the [PlatformFile] will contain a read stream.
   /// [withData] if true, the [PlatformFile] will contain the file bytes (use carefully with large files).
   static Future<List<PlatformFile>> filePathsToPlatformFiles(
-    List<String> filePaths,
-    bool withReadStream,
-    bool withData,
-  ) => impl.filePathsToPlatformFiles(filePaths, withReadStream, withData);
+    List<String> filePaths, {
+    bool withReadStream = false,
+    bool withData = false,
+  }) => impl.filePathsToPlatformFiles(
+    filePaths,
+    withReadStream: withReadStream,
+    withData: withData,
+  );
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -1,10 +1,8 @@
-import 'dart:io';
-import 'dart:isolate';
-import 'dart:typed_data';
-
-import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:path/path.dart';
+import 'package:flutter/foundation.dart';
+
+import '_file_utils_web.dart'
+    if (dart.library.io) '_file_utils_io.dart' as impl;
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -24,43 +22,21 @@ class FilePickerUtils {
     List<String> filePaths,
     bool withReadStream,
     bool withData,
-  ) {
-    return Future.wait(
-      filePaths.where((String filePath) => filePath.isNotEmpty).map((
-        String filePath,
-      ) async {
-        final file = File(filePath);
-
-        if (withReadStream) {
-          return createPlatformFile(file, null, file.openRead());
-        }
-
-        if (!withData) {
-          return createPlatformFile(file, null, null);
-        }
-
-        final bytes = await file.readAsBytes();
-        return createPlatformFile(file, bytes, null);
-      }).toList(),
-    );
-  }
+  ) =>
+      impl.filePathsToPlatformFiles(filePaths, withReadStream, withData);
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
   /// [file] is the source file.
   /// [bytes] are the file bytes (optional).
   /// [readStream] is a stream of the file content (optional).
+  @visibleForTesting
   static Future<PlatformFile> createPlatformFile(
-    File file,
+    dynamic file,
     Uint8List? bytes,
     Stream<List<int>>? readStream,
-  ) async => PlatformFile(
-    bytes: bytes,
-    name: basename(file.path),
-    path: file.path,
-    readStream: readStream,
-    size: file.existsSync() ? file.lengthSync() : 0,
-  );
+  ) =>
+      impl.createPlatformFile(file, bytes, readStream);
 
   /// Runs an executable with the given arguments and returns the output.
   ///
@@ -69,48 +45,21 @@ class FilePickerUtils {
   static Future<String?> runExecutableWithArguments(
     String executable,
     List<String> arguments,
-  ) async {
-    final processResult = await Process.run(executable, arguments);
-    final path = processResult.stdout?.toString().trim();
-    if (processResult.exitCode != 0 || path == null || path.isEmpty) {
-      return null;
-    }
-    return path;
-  }
+  ) =>
+      impl.runExecutableWithArguments(executable, arguments);
 
   /// Checks if an executable exists on the system path using `which`.
   ///
   /// Returns the absolute path to the executable if found.
   /// Throws an [Exception] if the executable is not found.
-  static Future<String> isExecutableOnPath(String executable) async {
-    final path = await runExecutableWithArguments('which', [executable]);
-    if (path == null) {
-      throw Exception('Couldn\'t find the executable $executable in the path.');
-    }
-    return path;
-  }
+  static Future<String> isExecutableOnPath(String executable) =>
+      impl.isExecutableOnPath(executable);
 
   /// Saves the given [bytes] to a file at [path].
   ///
   /// Does nothing if [path] or [bytes] is null or empty.
-  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
-    if (path != null && bytes != null && bytes.isNotEmpty) {
-      final receivePort = ReceivePort();
-      final transferable = TransferableTypedData.fromList([bytes]);
-
-      await Isolate.spawn(_saveBytesIsolateEntry, [
-        receivePort.sendPort,
-        path,
-        transferable,
-      ]);
-
-      final result = await receivePort.first;
-      receivePort.close();
-      if (result is Exception) {
-        throw result;
-      }
-    }
-  }
+  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
+      impl.saveBytesToFile(bytes, path);
 
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///
@@ -148,31 +97,5 @@ class FilePickerUtils {
         'When using FileType.custom you must provide a non-empty list of allowedExtensions.',
       );
     }
-  }
-}
-
-/// Save the given bytes to a file, using a separate [Isolate].
-///
-/// The [args] is expected to contain a [SendPort], the [String] file path
-/// and the [TransferableTypedData] bytes, in this order.
-Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-  if (args case [
-    SendPort send,
-    String path,
-    TransferableTypedData transferable,
-  ]) {
-    try {
-      final Uint8List bytes = transferable.materialize().asUint8List();
-      final file = File(path);
-      await file.writeAsBytes(bytes);
-      send.send(null);
-    } catch (e) {
-      send.send(e);
-    }
-    return;
-  }
-
-  if (args case [final SendPort port, ...]) {
-    port.send(Exception('Invalid isolate arguments'));
   }
 }

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -2,7 +2,8 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 
 import '_file_utils_web.dart'
-    if (dart.library.io) '_file_utils_io.dart' as impl;
+    if (dart.library.io) '_file_utils_io.dart'
+    as impl;
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -22,8 +23,7 @@ class FilePickerUtils {
     List<String> filePaths,
     bool withReadStream,
     bool withData,
-  ) =>
-      impl.filePathsToPlatformFiles(filePaths, withReadStream, withData);
+  ) => impl.filePathsToPlatformFiles(filePaths, withReadStream, withData);
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
@@ -35,8 +35,7 @@ class FilePickerUtils {
     dynamic file,
     Uint8List? bytes,
     Stream<List<int>>? readStream,
-  ) =>
-      impl.createPlatformFile(file, bytes, readStream);
+  ) => impl.createPlatformFile(file, bytes, readStream);
 
   /// Runs an executable with the given arguments and returns the output.
   ///
@@ -45,8 +44,7 @@ class FilePickerUtils {
   static Future<String?> runExecutableWithArguments(
     String executable,
     List<String> arguments,
-  ) =>
-      impl.runExecutableWithArguments(executable, arguments);
+  ) => impl.runExecutableWithArguments(executable, arguments);
 
   /// Checks if an executable exists on the system path using `which`.
   ///

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -32,8 +32,8 @@ class FilePickerUtils {
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
   /// [file] is the source file.
-  /// [bytes] are the file bytes (optional).
-  /// [readStream] is a stream of the file content (optional).
+  /// [bytes] are the file bytes.
+  /// [readStream] is a stream of the file content.
   @visibleForTesting
   static Future<PlatformFile> createPlatformFile(
     Object file,

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -13,12 +13,10 @@ class FilePickerUtils {
 
   /// Converts a list of file paths into a list of [PlatformFile]s.
   ///
-  /// This method is useful when the platform file picker returns a list of paths
-  /// and we need to convert them into the plugin's internal representation.
-  ///
-  /// [filePaths] is the list of absolute paths to the selected files.
-  /// [withReadStream] if true, the [PlatformFile] will contain a read stream.
-  /// [withData] if true, the [PlatformFile] will contain the file bytes (use carefully with large files).
+  /// The [filePaths] is the list of absolute paths to the selected files.
+  /// If [withReadStream] is true, the [PlatformFile] will contain a readable [Stream] of the file contents.
+  /// If [withData] is true, the [PlatformFile] will contain the file bytes.
+  /// This option should be used with caution, due to potentially loading large files in one [Uint8List].
   static Future<List<PlatformFile>> filePathsToPlatformFiles(
     List<String> filePaths, {
     bool withReadStream = false,
@@ -31,9 +29,10 @@ class FilePickerUtils {
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
-  /// [file] is the source file.
-  /// [bytes] are the file bytes.
-  /// [readStream] is a stream of the file content.
+  /// The [file] is the source file.
+  /// This is typed as [Object] to satisfy restrictions around conditional imports.
+  /// The [bytes] are the file bytes.
+  /// The [readStream] is a [Stream] of the file content.
   @visibleForTesting
   static Future<PlatformFile> createPlatformFile(
     Object file,
@@ -73,10 +72,10 @@ class FilePickerUtils {
         (codeUnit >= 97 && codeUnit <= 122); // a-z
   }
 
-  /// Validates the `allowedExtensions` parameter against the provided [type].
+  /// Validates the [allowedExtensions] parameter against the provided [type].
   ///
   /// Throws an [ArgumentError] if extension filters are provided while the
-  /// `type` is not `FileType.custom`.
+  /// [type] is not [FileType.custom].
   static void validateAllowedExtensions(
     FileType type,
     List<String>? allowedExtensions,

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -76,8 +76,7 @@ class FilePickerUtils {
   /// Validates the `allowedExtensions` parameter against the provided [type].
   ///
   /// Throws an [ArgumentError] if extension filters are provided while the
-  /// `type` is not `FileType.custom`. Uses a consistent error message across
-  /// platforms.
+  /// `type` is not `FileType.custom`.
   static void validateAllowedExtensions(
     FileType type,
     List<String>? allowedExtensions,

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -32,7 +32,7 @@ class FilePickerUtils {
   /// [readStream] is a stream of the file content (optional).
   @visibleForTesting
   static Future<PlatformFile> createPlatformFile(
-    dynamic file,
+    Object file,
     Uint8List? bytes,
     Stream<List<int>>? readStream,
   ) => impl.createPlatformFile(file, bytes, readStream);

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -44,7 +44,7 @@ class FilePickerUtils {
   /// Runs an executable with the given arguments and returns the output.
   ///
   /// Returns the trimmed stdout as a [String], or null if the process fails
-  /// (exit code != 0) or produces no output.
+  /// or produces no output.
   static Future<String?> runExecutableWithArguments(
     String executable,
     List<String> arguments,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.5
+version: 12.0.0-beta.6
 
 dependencies:
   flutter:

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -100,8 +100,6 @@ void main() {
 
         final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          false,
-          false,
         );
 
         expect(platformFiles.length, equals(filePaths.length));
@@ -139,8 +137,6 @@ void main() {
 
         final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          false,
-          false,
         );
 
         expect(platformFiles.length, equals(filePaths.length));
@@ -154,8 +150,7 @@ void main() {
 
         final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          true,
-          false,
+          withReadStream: true,
         );
 
         expect(platformFiles.length, equals(filePaths.length));
@@ -169,8 +164,7 @@ void main() {
 
         final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
           filePaths,
-          false,
-          true,
+          withData: true,
         );
 
         expect(platformFiles.length, equals(filePaths.length));

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -2,7 +2,7 @@
 library;
 
 import 'dart:io';
-import 'package:file_picker/src/file_picker_utils.dart';
+import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'common.dart';

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -52,6 +52,24 @@ void main() {
     });
 
     test(
+      'should read bytes from the file path when bytes are not available',
+      () async {
+        final imageFile = File(imageTestFile);
+        final expectedBytes = imageFile.readAsBytesSync();
+
+        final platformFile = await FilePickerUtils.createPlatformFile(
+          imageFile,
+          null,
+          null,
+        );
+
+        final bytes = await platformFile.readAsBytes();
+
+        expect(bytes, equals(expectedBytes));
+      },
+    );
+
+    test(
       'should not throw an exception when picking .app files on macOS (.app files on macOS are actually directories but they are treated as files, similar to .exe files on Windows)',
       () async {
         final appFile = File(appTestFilePath);

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -66,6 +66,20 @@ void main() {
         );
       },
     );
+
+    test('should fall back to any when FileType.custom has no extensions', () {
+      final picker = FilePickerWindows();
+
+      expect(
+        picker.fileTypeToFileFilter(FileType.custom, null),
+        equals('All Files (*.*)\x00*.*\x00\x00'),
+      );
+
+      expect(
+        picker.fileTypeToFileFilter(FileType.custom, []),
+        equals('All Files (*.*)\x00*.*\x00\x00'),
+      );
+    });
   });
 
   group('validateFileName()', () {

--- a/test/file_picker_windows_test.dart
+++ b/test/file_picker_windows_test.dart
@@ -67,17 +67,17 @@ void main() {
       },
     );
 
-    test('should fall back to any when FileType.custom has no extensions', () {
+    test('should throw when FileType.custom has no extensions', () {
       final picker = FilePickerWindows();
 
       expect(
-        picker.fileTypeToFileFilter(FileType.custom, null),
-        equals('All Files (*.*)\x00*.*\x00\x00'),
+        () => picker.fileTypeToFileFilter(FileType.custom, null),
+        throwsArgumentError,
       );
 
       expect(
-        picker.fileTypeToFileFilter(FileType.custom, []),
-        equals('All Files (*.*)\x00*.*\x00\x00'),
+        () => picker.fileTypeToFileFilter(FileType.custom, []),
+        throwsArgumentError,
       );
     });
   });


### PR DESCRIPTION
This PR makes `PlatformFile.readAsBytes()` work even when a file was picked without `withData` and only has a local `path` or a read stream.

Impact:
- Desktop callers can now safely use `readAsBytes()` after picking files without preloading bytes.
- Keeps the web blob/data URL fallback intact.
- Adds a regression test to cover the path-only case.
- Updates the changelog and version to `12.0.0-beta.6`.

Before this change there was an issue on Desktop platform using `readAsBytes()`:

```sh
Bad state: PlatformFile.readAsBytes(): file data is not available. Consume the file via PlatformFile.readAsByteStream(), or on Web ensure the file path is a fetchable blob/data URL that can be retrieved.
```

After this change:

https://github.com/user-attachments/assets/c49d9a44-0449-4873-b826-6c7712114f47
