### PR TITLE
Export 'src/platform/file_picker_platform_interface.dart'

### DIFF
--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -4,6 +4,7 @@ export 'src/api/platform_file.dart';
 export 'src/api/android_saf_options.dart';
 export 'src/api/android_saf_handle.dart';
 export 'src/file_picker.dart';
+export 'src/platform/file_picker_platform_interface.dart';
 // Platform-specific implementations are exported only for plugin registration.
 // These exports are hidden on Web to avoid dart:ffi and dart:io compatibility issues.
 export 'src/platform/linux/file_picker_linux.dart'

--- a/lib/src/api/android_saf_handle.dart
+++ b/lib/src/api/android_saf_handle.dart
@@ -1,5 +1,4 @@
 import 'package:file_picker/file_picker.dart';
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 
 /// An opaque handle to an Android Storage Access Framework [uri].
 final class AndroidSAFHandle {


### PR DESCRIPTION
When mocking the `FilePickerPlatform`, we currently have to reach into the `src` directory.

```dart
import 'package:file_picker/src/platform/file_picker_platform_interface.dart';

@visibleForTesting
class MockFilePicker extends Mock with MockPlatformInteraceMixin implements FilePickerPlatform {}
```

Please export this so we can mock it without having to reach into `src`