### PR TITLE
Use hardcoded hex values for request codes in `FilePickerDelegate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
+
  ### Android
 - Define REQUEST_CODE = 0x4F50 and SAVE_FILE_CODE = 0x4F51 in FilePickerDelegate.kt so onActivityResult cleanly distinguishes picker vs save flows and to prevent unresolved references when extracting hashCode under a forced JVM version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
+- Change value of both explicit request code constants: REQUEST_CODE (0x4F50) and SAVE_FILE_CODE (0x4F51).
 
 ## 12.0.0-beta.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
 
  ### Android
-- Define REQUEST_CODE = 0x4F50 and SAVE_FILE_CODE = 0x4F51 in FilePickerDelegate.kt so onActivityResult cleanly distinguishes picker vs save flows and to prevent unresolved references when extracting hashCode under a forced JVM version.
+- Prevents unresolved references when extracting hashCode under a forced JVM version. [#2070](https://github.com/miguelpruivo/flutter_file_picker/issues/2070)
 
 ## 12.0.0-beta.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
-- Change value of both explicit request code constants: REQUEST_CODE (0x4F50) and SAVE_FILE_CODE (0x4F51).
+ ### Android
+- Define REQUEST_CODE = 0x4F50 and SAVE_FILE_CODE = 0x4F51 in FilePickerDelegate.kt so onActivityResult cleanly distinguishes picker vs save flows and to prevent unresolved references when extracting hashCode under a forced JVM version.
 
 ## 12.0.0-beta.5
 ### Android

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -23,8 +23,8 @@ class FilePickerDelegate(
 
     companion object {
         const val TAG = "FilePickerDelegate"
-        val REQUEST_CODE = (FilePickerPlugin::class.java.hashCode() + 43) and 0x0000ffff
-        val SAVE_FILE_CODE = (FilePickerPlugin::class.java.hashCode() + 83) and 0x0000ffff
+        const val REQUEST_CODE = 0x4F50
+        const val SAVE_FILE_CODE = 0x4F51
 
         fun finishWithAlreadyActiveError(result: MethodChannel.Result) {
             result.error("already_active", "File picker is already active", null)


### PR DESCRIPTION
Updates the activity request codes to use static constants instead of dynamic hash-based calculations. This ensures the request codes are stable and predictable.

*   Changed `REQUEST_CODE` and `SAVE_FILE_CODE` from `val` to `const val`.
*   Replaced the `hashCode()`-based logic with explicit hex values `0x4F50` and `0x4F51` respectively.

fixes: https://github.com/miguelpruivo/flutter_file_picker/issues/2070 (proposal)