### PR TITLE
Update `ffi`, `win32`, and `flutter_lints` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
 - Update dependencies `ffi`,`win32` and `flutter_lints`
+
  ### Android
 - Prevents unresolved references when extracting hashCode under a forced JVM version. [#2070](https://github.com/miguelpruivo/flutter_file_picker/issues/2070)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
-
+- Update dependencies `ffi`,`win32` and `flutter_lints`
  ### Android
 - Prevents unresolved references when extracting hashCode under a forced JVM version. [#2070](https://github.com/miguelpruivo/flutter_file_picker/issues/2070)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
-- Update dependencies `ffi`,`win32` and `flutter_lints`
+- The `ffi`, `win32`, and `flutter_lints` dependencies have been updated.
 
  ### Android
 - Prevents unresolved references when extracting hashCode under a forced JVM version. [#2070](https://github.com/miguelpruivo/flutter_file_picker/issues/2070)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
 
   flutter_plugin_android_lifecycle: ^2.0.34
   plugin_platform_interface: ^2.1.8
-  ffi: ^2.1.3
+  ffi: ^2.2.0
   path: ^1.9.1
-  win32: ^6.2.0
+  win32: ^6.3.0
   cross_file: ^0.3.5+2
   web: ^1.1.1
   dbus: ^0.7.12
 
 dev_dependencies:
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Updates several project dependencies in `pubspec.yaml` to their latest versions.

*   Updated `ffi` to `^2.2.0`.
*   Updated `win32` to `^6.3.0`.
*   Updated `flutter_lints` to `^6.0.0` in `dev_dependencies`.
fixed: https://github.com/miguelpruivo/flutter_file_picker/issues/2068