### PR TITLE
 [WEB] - Fix `PlatformFile.xFile` getter on web when bytes are null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 ## 12.0.0-beta.7
 ## Web
 - Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.
-- 
+
 ## 12.0.0-beta.6
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
-
 
 ## 12.0.0-beta.5
 ### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
 
+## Web
+- Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.
+
 ## 12.0.0-beta.5
 ### Android
 - `saveFile` now writes file data using Kotlin Coroutines (`CoroutineScope(Dispatchers.IO).launch`), keeping all I/O off the main thread and preventing UI freezes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## 12.0.0-beta.7
+## Web
+- Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.
+- 
 ## 12.0.0-beta.6
 ### General
 - Improved `PlatformFile.readAsBytes()` so picked files can be read even when `withData` was not used and the file only has a local `path` or a stream source.
 - `FileType.custom` now shares a consistent `allowedExtensions` validation across platforms, throwing `ArgumentError` when filters are missing or used with a non-custom file type.
 
-## Web
-- Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.
 
 ## 12.0.0-beta.5
 ### Android

--- a/lib/src/api/platform_file.dart
+++ b/lib/src/api/platform_file.dart
@@ -96,7 +96,7 @@ class PlatformFile {
 
   /// Retrieves this as a XFile
   XFile get xFile {
-    if (kIsWeb) {
+    if (kIsWeb && bytes != null) {
       return XFile.fromData(bytes!, name: name, length: size);
     } else {
       return XFile(path!, name: name, bytes: bytes, length: size);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.6
+version: 12.0.0-beta.7
 
 dependencies:
   flutter:


### PR DESCRIPTION
Ensures `XFile.fromData` is only used on the web if `bytes` is not null, preventing potential null check errors and allowing fallback to the default `XFile` constructor.