### PR TITLE
Export `IllegalCharacterInFileNameException` Fixes #2076

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 12.0.0-beta.8
+### General
+- Exported `IllegalCharacterInFileNameException` in `file_picker.dart` so exception handling can be performed by callers. [#2077](https://github.com/miguelpruivo/flutter_file_picker/pull/2077)
+
 ### Android
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
 

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -11,7 +11,9 @@ export 'src/file_picker.dart';
 export 'src/platform/file_picker_platform_interface.dart';
 // Platform-specific implementations are exported only for plugin registration.
 // These exports are hidden on Web to avoid dart:ffi and dart:io compatibility issues.
-export 'src/platform/linux/file_picker_linux.dart' if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
-export 'src/platform/macos/file_picker_macos.dart' if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
+export 'src/platform/linux/file_picker_linux.dart'
+    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
+export 'src/platform/macos/file_picker_macos.dart'
+    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/windows/file_picker_windows.dart'
     if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -3,13 +3,12 @@ export 'src/api/file_picker_types.dart';
 export 'src/api/platform_file.dart';
 export 'src/api/android_saf_options.dart';
 export 'src/api/android_saf_handle.dart';
+export 'src/api/exceptions.dart';
 export 'src/file_picker.dart';
 export 'src/platform/file_picker_platform_interface.dart';
 // Platform-specific implementations are exported only for plugin registration.
 // These exports are hidden on Web to avoid dart:ffi and dart:io compatibility issues.
-export 'src/platform/linux/file_picker_linux.dart'
-    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
-export 'src/platform/macos/file_picker_macos.dart'
-    if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
+export 'src/platform/linux/file_picker_linux.dart' if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
+export 'src/platform/macos/file_picker_macos.dart' if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';
 export 'src/platform/windows/file_picker_windows.dart'
     if (dart.library.js_interop) 'src/platform/web/file_picker_web.dart';


### PR DESCRIPTION
Export `IllegalCharacterInFileNameException`  so it can be caught explicitly in user code.