### PR TITLE
feat(windows): add parentWindowHandle parameter to override window handle lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
 
 ### Desktop & Web
-- Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
+- Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `parentWindow` and `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
 - Deprecated top-level `lockParentWindow` parameter in favor of `WindowsOptions.lockParentWindow` and `LinuxOptions.lockParentWindow`.
 - Deprecated top-level `cancelUploadOnWindowBlur` parameter in favor of `WebOptions.cancelUploadOnWindowBlur`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 ### Android
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
 
-### Windows & Linux
-- Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`) and `LinuxOptions` (with `lockParentWindow`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
+### Desktop & Web
+- Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
 - Deprecated top-level `lockParentWindow` parameter in favor of `WindowsOptions.lockParentWindow` and `LinuxOptions.lockParentWindow`.
+- Deprecated top-level `cancelUploadOnWindowBlur` parameter in favor of `WebOptions.cancelUploadOnWindowBlur`.
 
 ## 12.0.0-beta.7
 ### Web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Desktop & Web
 - Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `parentWindow` and `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
+- `LinuxOptions.parentWindow` automatically formats raw decimal and hex X11 window IDs as `x11:0x...`, while preserving Wayland handle strings.
 - Deprecated top-level `lockParentWindow` parameter in favor of `WindowsOptions.lockParentWindow` and `LinuxOptions.lockParentWindow`.
 - Deprecated top-level `cancelUploadOnWindowBlur` parameter in favor of `WebOptions.cancelUploadOnWindowBlur`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Android
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
 
+### Windows & Linux
+- Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`) and `LinuxOptions` (with `lockParentWindow`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
+- Deprecated top-level `lockParentWindow` parameter in favor of `WindowsOptions.lockParentWindow` and `LinuxOptions.lockParentWindow`.
+
 ## 12.0.0-beta.7
 ### Web
 - Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,34 @@ if (outputFile == null) {
   // User canceled the picker
 }
 ```
+
+### Platform Specific Options
+
+You can configure platform-specific behavior using dedicated configuration classes:
+
+#### Desktop Modal & Parent Window Locking (`LinuxOptions` & `WindowsOptions`)
+```dart
+FilePickerResult? result = await FilePicker.pickFiles(
+  linuxOptions: LinuxOptions(
+    lockParentWindow: true,
+    parentWindow: 'x11:0x3a00001', // Accepts 'x11:0x...', hex '0x...', raw decimal X11 window IDs ('60817409', converted to X11), or 'wayland:handle_123'
+  ),
+  windowsOptions: WindowsOptions(
+    lockParentWindow: true,
+    parentWindowHandle: 123456, // Win32 HWND as int
+  ),
+);
+```
+
+#### Web Options (`WebOptions`)
+```dart
+FilePickerResult? result = await FilePicker.pickFiles(
+  webOptions: WebOptions(
+    cancelUploadOnWindowBlur: false,
+  ),
+);
+```
+
 ### Load result and file details
 ```dart
 FilePickerResult? result = await FilePicker.pickFiles();

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -27,6 +27,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   final _defaultFileNameController = TextEditingController();
   final _dialogTitleController = TextEditingController();
   final _initialDirectoryController = TextEditingController();
+  final _parentWindowController = TextEditingController();
   final _fileExtensionController = TextEditingController();
   String? _extension;
   bool _isLoading = false;
@@ -43,6 +44,15 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
   String? _pickedFileBytesSource;
   FileType _pickingType = FileType.any;
   List<PlatformFile>? pickedFiles;
+
+  String? get _customParentWindow =>
+      _parentWindowController.text.trim().isNotEmpty
+      ? _parentWindowController.text.trim()
+      : null;
+
+  int? get _customWindowsHwnd =>
+      int.tryParse(_parentWindowController.text.trim());
+
   bool get _isSaveFileDisabled => _multiPick;
   Widget _resultsWidget = const Row(
     children: [
@@ -81,6 +91,7 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _defaultFileNameController.dispose();
     _dialogTitleController.dispose();
     _initialDirectoryController.dispose();
+    _parentWindowController.dispose();
     _fileExtensionController.dispose();
     super.dispose();
   }
@@ -91,6 +102,9 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
     _clearPickedFileBytes();
 
     try {
+      printInDebug(
+        "lockParentWindow: $_lockParentWindow, parentWindow: $_customParentWindow",
+      );
       if (_multiPick) {
         final result = await FilePicker.pickFiles(
           type: _pickingType,
@@ -99,8 +113,14 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
           allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
-          windowsOptions: WindowsOptions(lockParentWindow: _lockParentWindow),
-          linuxOptions: LinuxOptions(lockParentWindow: _lockParentWindow),
+          windowsOptions: WindowsOptions(
+            lockParentWindow: _lockParentWindow,
+            parentWindowHandle: _customWindowsHwnd,
+          ),
+          linuxOptions: LinuxOptions(
+            lockParentWindow: _lockParentWindow,
+            parentWindow: _customParentWindow,
+          ),
           withData: _withData,
           androidSafOptions: _androidSafOptionsFromFlags(),
         );
@@ -113,8 +133,14 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
           allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
-          windowsOptions: WindowsOptions(lockParentWindow: _lockParentWindow),
-          linuxOptions: LinuxOptions(lockParentWindow: _lockParentWindow),
+          windowsOptions: WindowsOptions(
+            lockParentWindow: _lockParentWindow,
+            parentWindowHandle: _customWindowsHwnd,
+          ),
+          linuxOptions: LinuxOptions(
+            lockParentWindow: _lockParentWindow,
+            parentWindow: _customParentWindow,
+          ),
           androidSafOptions: _androidSafOptionsFromFlags(),
         );
         printInDebug("pickedFile: $file");
@@ -235,7 +261,14 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
       pickedDirectoryPath = await FilePicker.getDirectoryPath(
         dialogTitle: _dialogTitleController.text,
         initialDirectory: _initialDirectoryController.text,
-        lockParentWindow: _lockParentWindow,
+        windowsOptions: WindowsOptions(
+          lockParentWindow: _lockParentWindow,
+          parentWindowHandle: _customWindowsHwnd,
+        ),
+        linuxOptions: LinuxOptions(
+          lockParentWindow: _lockParentWindow,
+          parentWindow: _customParentWindow,
+        ),
         androidSafOptions: _androidSafOptionsFromFlags(),
       );
       hasUserAborted = pickedDirectoryPath == null;
@@ -310,7 +343,14 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
         dialogTitle: _dialogTitleController.text,
         fileName: targetFileName,
         initialDirectory: _initialDirectoryController.text,
-        lockParentWindow: _lockParentWindow,
+        windowsOptions: WindowsOptions(
+          lockParentWindow: _lockParentWindow,
+          parentWindowHandle: _customWindowsHwnd,
+        ),
+        linuxOptions: LinuxOptions(
+          lockParentWindow: _lockParentWindow,
+          parentWindow: _customParentWindow,
+        ),
         bytes: bytes,
       );
       hasUserAborted = pickedSaveFilePath == null;
@@ -527,6 +567,16 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
             labelText: 'Initial Directory',
           ),
           controller: _initialDirectoryController,
+        ),
+      ),
+      SizedBox(
+        width: 400,
+        child: TextField(
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Custom Parent Window (e.g. x11:0x... or HWND int)',
+          ),
+          controller: _parentWindowController,
         ),
       ),
       SizedBox(

--- a/example/lib/src/file_picker_demo.dart
+++ b/example/lib/src/file_picker_demo.dart
@@ -99,7 +99,8 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
           allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
-          lockParentWindow: _lockParentWindow,
+          windowsOptions: WindowsOptions(lockParentWindow: _lockParentWindow),
+          linuxOptions: LinuxOptions(lockParentWindow: _lockParentWindow),
           withData: _withData,
           androidSafOptions: _androidSafOptionsFromFlags(),
         );
@@ -112,7 +113,8 @@ class _FilePickerDemoState extends State<FilePickerDemo> {
           allowedExtensions: _allowedExtensionsFromInput(),
           dialogTitle: _dialogTitleController.text,
           initialDirectory: _initialDirectoryController.text,
-          lockParentWindow: _lockParentWindow,
+          windowsOptions: WindowsOptions(lockParentWindow: _lockParentWindow),
+          linuxOptions: LinuxOptions(lockParentWindow: _lockParentWindow),
           androidSafOptions: _androidSafOptionsFromFlags(),
         );
         printInDebug("pickedFile: $file");

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -5,6 +5,7 @@ export 'src/api/android_saf_options.dart';
 export 'src/api/android_saf_handle.dart';
 export 'src/api/windows_options.dart';
 export 'src/api/linux_options.dart';
+export 'src/api/web_options.dart';
 export 'src/file_picker.dart';
 export 'src/platform/file_picker_platform_interface.dart';
 // Platform-specific implementations are exported only for plugin registration.

--- a/lib/file_picker.dart
+++ b/lib/file_picker.dart
@@ -3,6 +3,8 @@ export 'src/api/file_picker_types.dart';
 export 'src/api/platform_file.dart';
 export 'src/api/android_saf_options.dart';
 export 'src/api/android_saf_handle.dart';
+export 'src/api/windows_options.dart';
+export 'src/api/linux_options.dart';
 export 'src/file_picker.dart';
 export 'src/platform/file_picker_platform_interface.dart';
 // Platform-specific implementations are exported only for plugin registration.

--- a/lib/src/api/linux_options.dart
+++ b/lib/src/api/linux_options.dart
@@ -1,9 +1,13 @@
 /// Configuration options specific to the Linux platform.
 final class LinuxOptions {
   /// Creates a set of Linux-specific configuration options for file picker operations.
-  const LinuxOptions({this.lockParentWindow = false});
+  const LinuxOptions({this.lockParentWindow = false, this.parentWindow});
 
   /// Whether the child window (file picker) should stay in front of the parent window
   /// as a modal window until closed.
   final bool lockParentWindow;
+
+  /// An optional X11 or Wayland parent window handle identifier
+  /// (e.g. `"x11:0x3a00001"` or `"wayland:handle"`).
+  final String? parentWindow;
 }

--- a/lib/src/api/linux_options.dart
+++ b/lib/src/api/linux_options.dart
@@ -1,0 +1,9 @@
+/// Configuration options specific to the Linux platform.
+final class LinuxOptions {
+  /// Creates a set of Linux-specific configuration options for file picker operations.
+  const LinuxOptions({this.lockParentWindow = false});
+
+  /// Whether the child window (file picker) should stay in front of the parent window
+  /// as a modal window until closed.
+  final bool lockParentWindow;
+}

--- a/lib/src/api/linux_options.dart
+++ b/lib/src/api/linux_options.dart
@@ -7,7 +7,10 @@ final class LinuxOptions {
   /// as a modal window until closed.
   final bool lockParentWindow;
 
-  /// An optional X11 or Wayland parent window handle identifier
-  /// (e.g. `"x11:0x3a00001"` or `"wayland:handle"`).
+  /// An optional X11 or Wayland parent window handle identifier.
+  ///
+  /// Supports full X11 handles (e.g. `"x11:0x3a00001"`), raw hex X11 strings (e.g. `"0x3a00001"`),
+  /// raw decimal X11 window IDs (e.g. `"60817409"`, automatically formatted as X11 handles),
+  /// or Wayland handle strings (e.g. `"wayland:handle"`).
   final String? parentWindow;
 }

--- a/lib/src/api/web_options.dart
+++ b/lib/src/api/web_options.dart
@@ -1,9 +1,7 @@
 /// Configuration options specific to the Web platform.
 final class WebOptions {
   /// Creates a set of Web-specific configuration options for file picker operations.
-  const WebOptions({
-    this.cancelUploadOnWindowBlur = true,
-  });
+  const WebOptions({this.cancelUploadOnWindowBlur = true});
 
   /// Prevents upload cancellation when window focus is lost.
   final bool cancelUploadOnWindowBlur;

--- a/lib/src/api/web_options.dart
+++ b/lib/src/api/web_options.dart
@@ -1,0 +1,10 @@
+/// Configuration options specific to the Web platform.
+final class WebOptions {
+  /// Creates a set of Web-specific configuration options for file picker operations.
+  const WebOptions({
+    this.cancelUploadOnWindowBlur = true,
+  });
+
+  /// Prevents upload cancellation when window focus is lost.
+  final bool cancelUploadOnWindowBlur;
+}

--- a/lib/src/api/windows_options.dart
+++ b/lib/src/api/windows_options.dart
@@ -1,0 +1,16 @@
+/// Configuration options specific to the Windows platform.
+final class WindowsOptions {
+  /// Creates a set of Windows-specific configuration options for file picker operations.
+  const WindowsOptions({
+    this.parentWindowHandle,
+    this.lockParentWindow = false,
+  });
+
+  /// An optional Win32 window handle (`HWND`) to override the default parent
+  /// window lookup when `lockParentWindow` is enabled.
+  final int? parentWindowHandle;
+
+  /// Whether the child window (file picker window) will stay in front of the
+  /// Flutter window until it is closed (like a modal window).
+  final bool lockParentWindow;
+}

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -8,6 +8,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 
 abstract final class FilePicker {
   /// Retrieves the file(s) from the underlying platform
@@ -48,11 +49,13 @@ abstract final class FilePicker {
   /// Not supported on macOS.
   ///
   /// [cancelUploadOnWindowBlur] prevents upload cancellation when window focus is lost.
-  /// Only supported on web.
+  /// This parameter is deprecated; use [WebOptions.cancelUploadOnWindowBlur] instead.
   ///
   /// [windowsOptions] can be optionally set to configure Windows-specific options.
   ///
   /// [linuxOptions] can be optionally set to configure Linux-specific options.
+  ///
+  /// [webOptions] can be optionally set to configure Web-specific options.
   ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
@@ -94,10 +97,14 @@ abstract final class FilePicker {
       'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
     )
     bool readSequential = false,
+    @Deprecated(
+      'Use WebOptions.cancelUploadOnWindowBlur instead; this parameter will be removed in a future release.',
+    )
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) {
     return FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
@@ -115,6 +122,7 @@ abstract final class FilePicker {
       androidSafOptions: androidSafOptions,
       windowsOptions: windowsOptions,
       linuxOptions: linuxOptions,
+      webOptions: webOptions,
     );
   }
 
@@ -136,10 +144,14 @@ abstract final class FilePicker {
       'Use WindowsOptions.lockParentWindow or LinuxOptions.lockParentWindow instead; this parameter will be removed in a future release.',
     )
     bool lockParentWindow = false,
+    @Deprecated(
+      'Use WebOptions.cancelUploadOnWindowBlur instead; this parameter will be removed in a future release.',
+    )
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final result = await FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
@@ -157,6 +169,7 @@ abstract final class FilePicker {
       androidSafOptions: androidSafOptions,
       windowsOptions: windowsOptions,
       linuxOptions: linuxOptions,
+      webOptions: webOptions,
     );
 
     return result?.files.firstOrNull;
@@ -230,6 +243,8 @@ abstract final class FilePicker {
   ///
   /// [linuxOptions] can be optionally set to configure Linux-specific options.
   ///
+  /// [webOptions] can be optionally set to configure Web-specific options.
+  ///
   /// Returns a [Future<String?>] which resolves to the absolute path of the selected directory,
   /// if the user selected a directory. Returns `null` if the user aborted the dialog or if the
   /// folder path couldn't be resolved.
@@ -250,6 +265,7 @@ abstract final class FilePicker {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) {
     return FilePickerPlatform.instance.getDirectoryPath(
       dialogTitle: dialogTitle,
@@ -258,6 +274,7 @@ abstract final class FilePicker {
       androidSafOptions: androidSafOptions,
       windowsOptions: windowsOptions,
       linuxOptions: linuxOptions,
+      webOptions: webOptions,
     );
   }
 
@@ -298,6 +315,8 @@ abstract final class FilePicker {
   ///
   /// [linuxOptions] can be optionally set to configure Linux-specific options.
   ///
+  /// [webOptions] can be optionally set to configure Web-specific options.
+  ///
   /// Returns `null` if aborted.
   static Future<String?> saveFile({
     String? dialogTitle,
@@ -313,6 +332,7 @@ abstract final class FilePicker {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) {
     return FilePickerPlatform.instance.saveFile(
       dialogTitle: dialogTitle,
@@ -325,6 +345,7 @@ abstract final class FilePicker {
       lockParentWindow: lockParentWindow,
       windowsOptions: windowsOptions,
       linuxOptions: linuxOptions,
+      webOptions: webOptions,
     );
   }
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -87,6 +87,7 @@ abstract final class FilePicker {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) {
     return FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
@@ -102,6 +103,7 @@ abstract final class FilePicker {
       readSequential: readSequential,
       cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
       androidSafOptions: androidSafOptions,
+      parentWindowHandle: parentWindowHandle,
     );
   }
 
@@ -221,12 +223,14 @@ abstract final class FilePicker {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) {
     return FilePickerPlatform.instance.getDirectoryPath(
       dialogTitle: dialogTitle,
       lockParentWindow: lockParentWindow,
       initialDirectory: initialDirectory,
       androidSafOptions: androidSafOptions,
+      parentWindowHandle: parentWindowHandle,
     );
   }
 
@@ -272,6 +276,7 @@ abstract final class FilePicker {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    int? parentWindowHandle,
   }) {
     return FilePickerPlatform.instance.saveFile(
       dialogTitle: dialogTitle,
@@ -282,6 +287,7 @@ abstract final class FilePicker {
       bytes: bytes,
       onFileLoading: onFileLoading,
       lockParentWindow: lockParentWindow,
+      parentWindowHandle: parentWindowHandle,
     );
   }
 

--- a/lib/src/file_picker.dart
+++ b/lib/src/file_picker.dart
@@ -6,6 +6,8 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 
 abstract final class FilePicker {
   /// Retrieves the file(s) from the underlying platform
@@ -30,8 +32,8 @@ abstract final class FilePicker {
   ///
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
-  /// window). This parameter works only on Windows desktop.
-  /// On macOS the parent window will be locked and this parameter is ignored.
+  /// window). This parameter is deprecated; use [WindowsOptions.lockParentWindow] or
+  /// [LinuxOptions.lockParentWindow] instead.
   ///
   /// [dialogTitle] can be optionally set on desktop platforms to set the modal window title.
   /// Not supported on macOS. It will be ignored on other platforms.
@@ -47,6 +49,10 @@ abstract final class FilePicker {
   ///
   /// [cancelUploadOnWindowBlur] prevents upload cancellation when window focus is lost.
   /// Only supported on web.
+  ///
+  /// [windowsOptions] can be optionally set to configure Windows-specific options.
+  ///
+  /// [linuxOptions] can be optionally set to configure Linux-specific options.
   ///
   /// The result is wrapped in a [FilePickerResult] which contains helper getters
   /// with useful information regarding the picked [List<PlatformFile>].
@@ -80,6 +86,9 @@ abstract final class FilePicker {
       'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
     )
     bool withReadStream = false,
+    @Deprecated(
+      'Use WindowsOptions.lockParentWindow or LinuxOptions.lockParentWindow instead; this parameter will be removed in a future release.',
+    )
     bool lockParentWindow = false,
     @Deprecated(
       'Use PlatformFile.readAsByteStream(); this parameter will be removed in a future release',
@@ -87,7 +96,8 @@ abstract final class FilePicker {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) {
     return FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
@@ -103,7 +113,8 @@ abstract final class FilePicker {
       readSequential: readSequential,
       cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
       androidSafOptions: androidSafOptions,
-      parentWindowHandle: parentWindowHandle,
+      windowsOptions: windowsOptions,
+      linuxOptions: linuxOptions,
     );
   }
 
@@ -121,9 +132,14 @@ abstract final class FilePicker {
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
+    @Deprecated(
+      'Use WindowsOptions.lockParentWindow or LinuxOptions.lockParentWindow instead; this parameter will be removed in a future release.',
+    )
     bool lockParentWindow = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final result = await FilePickerPlatform.instance.pickFiles(
       dialogTitle: dialogTitle,
@@ -139,6 +155,8 @@ abstract final class FilePicker {
       readSequential: false,
       cancelUploadOnWindowBlur: cancelUploadOnWindowBlur,
       androidSafOptions: androidSafOptions,
+      windowsOptions: windowsOptions,
+      linuxOptions: linuxOptions,
     );
 
     return result?.files.firstOrNull;
@@ -199,14 +217,18 @@ abstract final class FilePicker {
   ///
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
-  /// window). This parameter works only on Windows desktop.
-  /// On macOS the parent window will be locked and this parameter is ignored.
+  /// window). This parameter is deprecated; use [WindowsOptions.lockParentWindow] or
+  /// [LinuxOptions.lockParentWindow] instead.
   ///
   /// [initialDirectory] can be optionally set to an absolute path to specify
   /// where the dialog should open. Only supported on Linux, macOS, and Windows.
   /// On macOS the home directory shortcut (~/) is not necessary and passing it will be ignored.
   /// On macOS if the [initialDirectory] is invalid, the user directory or previously valid directory
   /// will be used.
+  ///
+  /// [windowsOptions] can be optionally set to configure Windows-specific options.
+  ///
+  /// [linuxOptions] can be optionally set to configure Linux-specific options.
   ///
   /// Returns a [Future<String?>] which resolves to the absolute path of the selected directory,
   /// if the user selected a directory. Returns `null` if the user aborted the dialog or if the
@@ -220,17 +242,22 @@ abstract final class FilePicker {
   /// `content://` document tree URI instead of an absolute path.
   static Future<String?> getDirectoryPath({
     String? dialogTitle,
+    @Deprecated(
+      'Use WindowsOptions.lockParentWindow or LinuxOptions.lockParentWindow instead; this parameter will be removed in a future release.',
+    )
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) {
     return FilePickerPlatform.instance.getDirectoryPath(
       dialogTitle: dialogTitle,
       lockParentWindow: lockParentWindow,
       initialDirectory: initialDirectory,
       androidSafOptions: androidSafOptions,
-      parentWindowHandle: parentWindowHandle,
+      windowsOptions: windowsOptions,
+      linuxOptions: linuxOptions,
     );
   }
 
@@ -264,7 +291,12 @@ abstract final class FilePicker {
   ///
   /// If [lockParentWindow] is set, the child window (file picker window) will
   /// stay in front of the Flutter window until it is closed (like a modal
-  /// window). This parameter works only on Windows desktop.
+  /// window). This parameter is deprecated; use [WindowsOptions.lockParentWindow] or
+  /// [LinuxOptions.lockParentWindow] instead.
+  ///
+  /// [windowsOptions] can be optionally set to configure Windows-specific options.
+  ///
+  /// [linuxOptions] can be optionally set to configure Linux-specific options.
   ///
   /// Returns `null` if aborted.
   static Future<String?> saveFile({
@@ -275,8 +307,12 @@ abstract final class FilePicker {
     List<String>? allowedExtensions,
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
+    @Deprecated(
+      'Use WindowsOptions.lockParentWindow or LinuxOptions.lockParentWindow instead; this parameter will be removed in a future release.',
+    )
     bool lockParentWindow = false,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) {
     return FilePickerPlatform.instance.saveFile(
       dialogTitle: dialogTitle,
@@ -287,7 +323,8 @@ abstract final class FilePicker {
       bytes: bytes,
       onFileLoading: onFileLoading,
       lockParentWindow: lockParentWindow,
-      parentWindowHandle: parentWindowHandle,
+      windowsOptions: windowsOptions,
+      linuxOptions: linuxOptions,
     );
   }
 

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -8,6 +8,8 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 
@@ -49,6 +51,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) => _getPath(
     type,
     allowMultiple,
@@ -75,6 +79,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     try {
       return await methodChannel.invokeMethod('dir', {
@@ -160,6 +166,8 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     try {
       if (onFileLoading != null) {

--- a/lib/src/platform/file_picker_method_channel.dart
+++ b/lib/src/platform/file_picker_method_channel.dart
@@ -10,6 +10,7 @@ import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 
@@ -53,6 +54,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) => _getPath(
     type,
     allowMultiple,
@@ -81,6 +83,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     try {
       return await methodChannel.invokeMethod('dir', {
@@ -168,6 +171,7 @@ class MethodChannelFilePicker extends FilePickerPlatform {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     try {
       if (onFileLoading != null) {

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -43,6 +43,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) async {
     throw UnimplementedError('pickFiles() has not been implemented.');
   }
@@ -76,6 +77,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) async {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
@@ -91,6 +93,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    int? parentWindowHandle,
   }) async {
     throw UnimplementedError('saveFile() has not been implemented.');
   }

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 import 'package:file_picker/src/platform/file_picker_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -47,6 +48,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     throw UnimplementedError('pickFiles() has not been implemented.');
   }
@@ -82,6 +84,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
@@ -99,6 +102,7 @@ abstract class FilePickerPlatform extends PlatformInterface {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     throw UnimplementedError('saveFile() has not been implemented.');
   }

--- a/lib/src/platform/file_picker_platform_interface.dart
+++ b/lib/src/platform/file_picker_platform_interface.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 import 'package:file_picker/src/platform/file_picker_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -43,7 +45,8 @@ abstract class FilePickerPlatform extends PlatformInterface {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     throw UnimplementedError('pickFiles() has not been implemented.');
   }
@@ -77,7 +80,8 @@ abstract class FilePickerPlatform extends PlatformInterface {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
@@ -93,7 +97,8 @@ abstract class FilePickerPlatform extends PlatformInterface {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     throw UnimplementedError('saveFile() has not been implemented.');
   }

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
@@ -46,12 +48,14 @@ class FilePickerLinux extends FilePickerPlatform {
     int compressionQuality = 0,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final filter = Filter(type, allowedExtensions);
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
       'multiple': DBusBoolean(allowMultiple),
-      'modal': DBusBoolean(lockParentWindow),
+      'modal': DBusBoolean(linuxOptions.lockParentWindow || lockParentWindow),
       'filters': filter.toDBusArray(),
     };
     if (initialDirectory != null) {
@@ -107,11 +111,13 @@ class FilePickerLinux extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
       'directory': DBusBoolean(true),
-      'modal': DBusBoolean(lockParentWindow),
+      'modal': DBusBoolean(linuxOptions.lockParentWindow || lockParentWindow),
     };
     if (initialDirectory != null) {
       final Uint8List tmp = _encodeDirectory(initialDirectory);
@@ -166,11 +172,13 @@ class FilePickerLinux extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
       'current_name': DBusString(fileName),
-      'modal': DBusBoolean(lockParentWindow),
+      'modal': DBusBoolean(linuxOptions.lockParentWindow || lockParentWindow),
     };
     if (initialDirectory != null) {
       final Uint8List tmp = _encodeDirectory(initialDirectory);

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -66,7 +66,7 @@ class FilePickerLinux extends FilePickerPlatform {
       xdpOption["current_folder"] = directory;
     }
     final replyPath = await _xdpChooser.callOpenFile(
-      linuxOptions.parentWindow ?? "",
+      _formatParentWindow(linuxOptions.parentWindow),
       dialogTitle ?? "flutter picker",
       xdpOption,
     );
@@ -128,7 +128,7 @@ class FilePickerLinux extends FilePickerPlatform {
       xdpOption["current_folder"] = directory;
     }
     final replyPath = await _xdpChooser.callOpenFile(
-      linuxOptions.parentWindow ?? "",
+      _formatParentWindow(linuxOptions.parentWindow),
       dialogTitle ?? "flutter picker",
       xdpOption,
     );
@@ -191,7 +191,7 @@ class FilePickerLinux extends FilePickerPlatform {
     }
 
     final replyPath = await _xdpChooser.callSaveFile(
-      linuxOptions.parentWindow ?? "",
+      _formatParentWindow(linuxOptions.parentWindow),
       dialogTitle ?? "flutter picker",
       xdpOption,
     );
@@ -228,5 +228,23 @@ class FilePickerLinux extends FilePickerPlatform {
 
   Uint8List _encodeDirectory(String initialDirectory) {
     return Uint8List.fromList([...utf8.encode(initialDirectory), 0]);
+  }
+
+  static String _formatParentWindow(String? parentWindow) {
+    if (parentWindow == null || parentWindow.trim().isEmpty) {
+      return '';
+    }
+    final trimmed = parentWindow.trim();
+    if (trimmed.startsWith('x11:') || trimmed.startsWith('wayland:')) {
+      return trimmed;
+    }
+    if (trimmed.startsWith('0x')) {
+      return 'x11:$trimmed';
+    }
+    final intVal = int.tryParse(trimmed);
+    if (intVal != null) {
+      return 'x11:0x${intVal.toRadixString(16)}';
+    }
+    return trimmed;
   }
 }

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -66,7 +66,7 @@ class FilePickerLinux extends FilePickerPlatform {
       xdpOption["current_folder"] = directory;
     }
     final replyPath = await _xdpChooser.callOpenFile(
-      "",
+      linuxOptions.parentWindow ?? "",
       dialogTitle ?? "flutter picker",
       xdpOption,
     );
@@ -128,7 +128,7 @@ class FilePickerLinux extends FilePickerPlatform {
       xdpOption["current_folder"] = directory;
     }
     final replyPath = await _xdpChooser.callOpenFile(
-      "",
+      linuxOptions.parentWindow ?? "",
       dialogTitle ?? "flutter picker",
       xdpOption,
     );
@@ -191,7 +191,7 @@ class FilePickerLinux extends FilePickerPlatform {
     }
 
     final replyPath = await _xdpChooser.callSaveFile(
-      "",
+      linuxOptions.parentWindow ?? "",
       dialogTitle ?? "flutter picker",
       xdpOption,
     );

--- a/lib/src/platform/linux/file_picker_linux.dart
+++ b/lib/src/platform/linux/file_picker_linux.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
@@ -50,6 +51,7 @@ class FilePickerLinux extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final filter = Filter(type, allowedExtensions);
     Map<String, DBusValue> xdpOption = {
@@ -113,6 +115,7 @@ class FilePickerLinux extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
@@ -174,6 +177,7 @@ class FilePickerLinux extends FilePickerPlatform {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter/foundation.dart';
@@ -59,6 +60,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
 
@@ -91,6 +93,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final String? directoryPath = await methodChannel.invokeMethod<String>(
       'getDirectoryPath',
@@ -114,6 +117,7 @@ class FilePickerMacOS extends FilePickerPlatform {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
 

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -2,6 +2,8 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter/foundation.dart';
@@ -55,6 +57,8 @@ class FilePickerMacOS extends FilePickerPlatform {
     bool readSequential = false,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
 
@@ -85,6 +89,8 @@ class FilePickerMacOS extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final String? directoryPath = await methodChannel.invokeMethod<String>(
       'getDirectoryPath',
@@ -106,6 +112,8 @@ class FilePickerMacOS extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final fileFilter = fileTypeToFileFilter(type, allowedExtensions);
 

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -6,6 +6,8 @@ import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -46,6 +48,8 @@ class FilePickerWeb extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
@@ -65,6 +69,8 @@ class FilePickerWeb extends FilePickerPlatform {
     bool cancelUploadOnWindowBlur = true,
     int compressionQuality = 0,
     AndroidSAFOptions? androidSafOptions,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
 
@@ -221,6 +227,8 @@ class FilePickerWeb extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     if (bytes.isEmpty) {
       throw ArgumentError(

--- a/lib/src/platform/web/file_picker_web.dart
+++ b/lib/src/platform/web/file_picker_web.dart
@@ -8,6 +8,7 @@ import 'package:file_picker/src/api/platform_file.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:file_picker/src/utils/file_picker_utils.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -50,6 +51,7 @@ class FilePickerWeb extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
@@ -71,6 +73,7 @@ class FilePickerWeb extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     FilePickerUtils.validateAllowedExtensions(type, allowedExtensions);
 
@@ -191,7 +194,7 @@ class FilePickerWeb extends FilePickerPlatform {
     uploadInput.addEventListener('change', changeEventListener.toJS);
     uploadInput.addEventListener('cancel', cancelledEventListener.toJS);
 
-    if (cancelUploadOnWindowBlur) {
+    if (cancelUploadOnWindowBlur && webOptions.cancelUploadOnWindowBlur) {
       // Listen focus event for cancelled
       window.addEventListener('focus', cancelledEventListener.toJS);
     }
@@ -229,6 +232,7 @@ class FilePickerWeb extends FilePickerPlatform {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     if (bytes.isEmpty) {
       throw ArgumentError(

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -11,6 +11,7 @@ import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
 import 'package:file_picker/src/api/windows_options.dart';
 import 'package:file_picker/src/api/linux_options.dart';
+import 'package:file_picker/src/api/web_options.dart';
 
 import 'package:file_picker/src/api/exceptions.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
@@ -42,6 +43,7 @@ class FilePickerWindows extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(
@@ -111,6 +113,7 @@ class FilePickerWindows extends FilePickerPlatform {
     AndroidSAFOptions? androidSafOptions,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     return compute(_getDirectoryPathIsolate, {
       'dialogTitle': dialogTitle,
@@ -204,6 +207,7 @@ class FilePickerWindows extends FilePickerPlatform {
     bool lockParentWindow = false,
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -38,6 +38,7 @@ class FilePickerWindows extends FilePickerPlatform {
     int compressionQuality = 0,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(
@@ -50,6 +51,7 @@ class FilePickerWindows extends FilePickerPlatform {
         allowedExtensions: allowedExtensions,
         allowMultiple: allowMultiple,
         lockParentWindow: lockParentWindow,
+        parentWindowHandle: parentWindowHandle,
       ),
     );
     final fileNames = (await port.first) as List<String>?;
@@ -104,11 +106,13 @@ class FilePickerWindows extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
+    int? parentWindowHandle,
   }) async {
     return compute(_getDirectoryPathIsolate, {
       'dialogTitle': dialogTitle,
       'initialDirectory': initialDirectory,
       'lockParentWindow': lockParentWindow,
+      'parentWindowHandle': parentWindowHandle,
     });
   }
 
@@ -116,6 +120,7 @@ class FilePickerWindows extends FilePickerPlatform {
     String? dialogTitle = args['dialogTitle'] as String?;
     String? initialDirectory = args['initialDirectory'] as String?;
     bool lockParentWindow = args['lockParentWindow'] as bool? ?? false;
+    int? parentWindowHandle = args['parentWindowHandle'] as int?;
 
     final hr = CoInitializeEx(
       COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE,
@@ -151,7 +156,13 @@ class FilePickerWindows extends FilePickerPlatform {
         }
 
         try {
-          fileDialog.show(lockParentWindow ? GetForegroundWindow() : null);
+          fileDialog.show(
+            lockParentWindow
+                ? (parentWindowHandle != null
+                    ? parentWindowHandle
+                    : GetForegroundWindow())
+                : null,
+          );
         } on WindowsException catch (e) {
           if (e.hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
             return null;
@@ -187,6 +198,7 @@ class FilePickerWindows extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
+    int? parentWindowHandle,
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(
@@ -200,6 +212,7 @@ class FilePickerWindows extends FilePickerPlatform {
         allowedExtensions: allowedExtensions,
         lockParentWindow: lockParentWindow,
         confirmOverwrite: true,
+        parentWindowHandle: parentWindowHandle,
       ),
     );
     final savedFilePath = (await port.first) as String?;
@@ -336,7 +349,9 @@ class FilePickerWindows extends FilePickerPlatform {
         ofnExplorer | ofnFileMustExist | ofnHideReadOnly | ofnNoChangeDir;
 
     if (args.lockParentWindow) {
-      openFileNameW.ref.hwndOwner = _getWindowHandle();
+      openFileNameW.ref.hwndOwner = args.parentWindowHandle != null
+          ? Pointer.fromAddress(args.parentWindowHandle!)
+          : _getWindowHandle();
     }
 
     if (args.allowMultiple) {
@@ -412,6 +427,7 @@ class _OpenSaveFileArgs {
   final bool allowMultiple;
   final bool lockParentWindow;
   final bool confirmOverwrite;
+  final int? parentWindowHandle;
 
   _OpenSaveFileArgs({
     required this.port,
@@ -423,5 +439,6 @@ class _OpenSaveFileArgs {
     this.allowMultiple = false,
     this.lockParentWindow = false,
     this.confirmOverwrite = false,
+    this.parentWindowHandle,
   });
 }

--- a/lib/src/platform/windows/file_picker_windows.dart
+++ b/lib/src/platform/windows/file_picker_windows.dart
@@ -9,6 +9,8 @@ import 'package:ffi/ffi.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
 import 'package:file_picker/src/api/file_picker_result.dart';
 import 'package:file_picker/src/api/android_saf_options.dart';
+import 'package:file_picker/src/api/windows_options.dart';
+import 'package:file_picker/src/api/linux_options.dart';
 
 import 'package:file_picker/src/api/exceptions.dart';
 import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
@@ -38,7 +40,8 @@ class FilePickerWindows extends FilePickerPlatform {
     int compressionQuality = 0,
     bool cancelUploadOnWindowBlur = true,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(
@@ -50,8 +53,8 @@ class FilePickerWindows extends FilePickerPlatform {
         type: type,
         allowedExtensions: allowedExtensions,
         allowMultiple: allowMultiple,
-        lockParentWindow: lockParentWindow,
-        parentWindowHandle: parentWindowHandle,
+        lockParentWindow: windowsOptions.lockParentWindow || lockParentWindow,
+        parentWindowHandle: windowsOptions.parentWindowHandle,
       ),
     );
     final fileNames = (await port.first) as List<String>?;
@@ -106,13 +109,14 @@ class FilePickerWindows extends FilePickerPlatform {
     bool lockParentWindow = false,
     String? initialDirectory,
     AndroidSAFOptions? androidSafOptions,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     return compute(_getDirectoryPathIsolate, {
       'dialogTitle': dialogTitle,
       'initialDirectory': initialDirectory,
-      'lockParentWindow': lockParentWindow,
-      'parentWindowHandle': parentWindowHandle,
+      'lockParentWindow': windowsOptions.lockParentWindow || lockParentWindow,
+      'parentWindowHandle': windowsOptions.parentWindowHandle,
     });
   }
 
@@ -156,13 +160,13 @@ class FilePickerWindows extends FilePickerPlatform {
         }
 
         try {
-          fileDialog.show(
-            lockParentWindow
-                ? (parentWindowHandle != null
-                    ? parentWindowHandle
-                    : GetForegroundWindow())
-                : null,
-          );
+          HWND? parentHwnd;
+          if (lockParentWindow) {
+            parentHwnd = parentWindowHandle != null
+                ? Pointer.fromAddress(parentWindowHandle) as HWND
+                : GetForegroundWindow();
+          }
+          fileDialog.show(parentHwnd);
         } on WindowsException catch (e) {
           if (e.hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
             return null;
@@ -198,7 +202,8 @@ class FilePickerWindows extends FilePickerPlatform {
     required Uint8List bytes,
     Function(FilePickerStatus)? onFileLoading,
     bool lockParentWindow = false,
-    int? parentWindowHandle,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
   }) async {
     final port = ReceivePort();
     await Isolate.spawn(
@@ -210,9 +215,9 @@ class FilePickerWindows extends FilePickerPlatform {
         initialDirectory: initialDirectory,
         type: type,
         allowedExtensions: allowedExtensions,
-        lockParentWindow: lockParentWindow,
+        lockParentWindow: windowsOptions.lockParentWindow || lockParentWindow,
         confirmOverwrite: true,
-        parentWindowHandle: parentWindowHandle,
+        parentWindowHandle: windowsOptions.parentWindowHandle,
       ),
     );
     final savedFilePath = (await port.first) as String?;


### PR DESCRIPTION
**Description:**

Adds an optional `int? parentWindowHandle` parameter to pickFiles, pickFile, saveFile, and getDirectoryPath. When provided alongside lockParentWindow: true, the given handle is used directly as hwndOwner instead of calling FindWindowA internally.

This is useful when the app manages multiple windows or the automatic lookup returns the wrong handle.

**Usage:**

``` dart
await FilePicker.pickFiles(
  lockParentWindow: true,
  parentWindowHandle: myHwnd, // raw HWND as int
);
```

If parentWindowHandle is null, behavior is unchanged — _getWindowHandle() is used as before.