### PR TITLE
fix(android): decode images with inSampleSize in compressImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 12.0.0-beta.8
+### Android
+- Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
+
 ## 12.0.0-beta.7
-## Web
+### Web
 - Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.
 
 ## 12.0.0-beta.6

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -48,6 +48,13 @@ object FileUtils {
     // (see https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java#439)
     private const val CSV_EXTENSION = "csv"
     private const val CSV_MIME_TYPE = "text/csv"
+    // Maximum dimension (width or height) allowed when decoding an image for
+    // compression. Images larger than this are subsampled via
+    // BitmapFactory.Options.inSampleSize to avoid excessive memory usage
+    // (see https://developer.android.com/topic/performance/graphics/load-bitmap).
+    // 4096 matches the common GPU texture size limit, so regular photos are
+    // decoded at full resolution and only unusually large images are downscaled.
+    private const val MAX_COMPRESSED_IMAGE_DIMENSION = 4096
 
     fun FilePickerDelegate.processFiles(
         activity: Activity,
@@ -617,10 +624,24 @@ object FileUtils {
     fun compressImage(originalImageUri: Uri, compressionQuality: Int, context: Context): Uri {
         val compressedUri: Uri
         try {
+            // First pass: decode only the image bounds so a subsampling factor
+            // can be computed without loading the full bitmap into memory.
+            val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
+                BitmapFactory.decodeStream(imageStream, null, boundsOptions)
+            }
+            val decodeOptions = BitmapFactory.Options().apply {
+                inSampleSize = calculateInSampleSize(
+                    boundsOptions,
+                    MAX_COMPRESSED_IMAGE_DIMENSION,
+                    MAX_COMPRESSED_IMAGE_DIMENSION
+                )
+            }
             context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
                 val compressFormat = getCompressFormat(context, originalImageUri)
                 val compressedFile = createImageFile(context, compressFormat)
-                val originalBitmap = BitmapFactory.decodeStream(imageStream)
+                val originalBitmap = BitmapFactory.decodeStream(imageStream, null, decodeOptions)
+                    ?: throw IOException("Failed to decode image: $originalImageUri")
                 // Compress and save the image
                 val fileOutputStream = FileOutputStream(compressedFile)
                 originalBitmap.compress(compressFormat, compressionQuality, fileOutputStream)
@@ -632,6 +653,29 @@ object FileUtils {
             throw RuntimeException(e)
         }
         return compressedUri
+    }
+
+    /**
+     * Calculates the largest power-of-two [BitmapFactory.Options.inSampleSize]
+     * that keeps both dimensions at least as large as the requested size, as
+     * recommended by https://developer.android.com/topic/performance/graphics/load-bitmap.
+     */
+    private fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+        reqHeight: Int
+    ): Int {
+        val height = options.outHeight
+        val width = options.outWidth
+        var inSampleSize = 1
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight = height / 2
+            val halfWidth = width / 2
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
     }
 
     @Throws(IOException::class)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 12.0.0-beta.7
+version: 12.0.0-beta.8
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

`FileUtils.compressImage` calls `BitmapFactory.decodeStream` without `BitmapFactory.Options`, so very large images are decoded at full resolution before being re-compressed. This can cause excessive memory usage (and `OutOfMemoryError` on low-end devices) when `compressionQuality` is used with large images.

It is also flagged by the Google Play Console as a recommended action on apps that bundle this plugin:

> **Improve app performance with bitmap resolution reduction**
> Your app is using BitmapFactory without resolution reduction in the following places: `FileUtils` — Problem type: missing the `BitmapFactory.Options` parameter.

## Fix

Following the [official guidance on loading large bitmaps efficiently](https://developer.android.com/topic/performance/graphics/load-bitmap):

1. First decode only the image bounds (`inJustDecodeBounds = true`).
2. Compute a power-of-two `inSampleSize` capped at 4096px per dimension (common GPU texture size limit).
3. Decode the bitmap with that `inSampleSize` and compress as before.

Photos whose dimensions are within 4096px (e.g. a 12MP 4000×3000 photo) are unaffected and still decoded at full resolution; only unusually large images are subsampled before compression, which is consistent with the lossy intent of `compressionQuality`.

Also adds an explicit null check on the decoded bitmap, which previously would have thrown an NPE (see #1455 / #1461 for past crashes in this exact spot).