### PR TITLE
fix(macos): pass dialogTitle in getDirectoryPath (#2087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Deprecated top-level `lockParentWindow` parameter in favor of `WindowsOptions.lockParentWindow` and `LinuxOptions.lockParentWindow`.
 - Deprecated top-level `cancelUploadOnWindowBlur` parameter in favor of `WebOptions.cancelUploadOnWindowBlur`.
 
+### macOS
+- Passes the custom `dialogTitle` when selecting a directory via `getDirectoryPath()`. [#2087](https://github.com/miguelpruivo/flutter_file_picker/pull/2087)
+
 ## 12.0.0-beta.7
 ### Web
 - Ensures `XFile.fromData` is only used on the web if bytes is not null, preventing potential null check errors.

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -34,9 +34,7 @@ class FilePickerMacOS extends FilePickerPlatform {
       <String, dynamic>{
         'allowedExtensions': fileFilter,
         'initialDirectory': escapeInitialDirectory(initialDirectory),
-        'dialogTitle': dialogTitle == null
-            ? null
-            : escapeDialogTitle(dialogTitle),
+        'dialogTitle': dialogTitle,
       },
     );
 
@@ -97,9 +95,7 @@ class FilePickerMacOS extends FilePickerPlatform {
   }) async {
     final String? directoryPath = await methodChannel
         .invokeMethod<String>('getDirectoryPath', <String, dynamic>{
-          'dialogTitle': dialogTitle == null
-              ? null
-              : escapeDialogTitle(dialogTitle),
+          'dialogTitle': dialogTitle,
           'initialDirectory': escapeInitialDirectory(initialDirectory),
         });
 
@@ -124,9 +120,7 @@ class FilePickerMacOS extends FilePickerPlatform {
 
     final String? savedFilePath = await methodChannel
         .invokeMethod<String>('saveFile', <String, dynamic>{
-          'dialogTitle': escapeDialogTitle(
-            dialogTitle ?? FilePickerUtils.defaultDialogTitle,
-          ),
+          'dialogTitle': dialogTitle ?? FilePickerUtils.defaultDialogTitle,
           'fileName': fileName,
           'initialDirectory': escapeInitialDirectory(initialDirectory),
           'allowedExtensions': fileFilter,
@@ -200,9 +194,4 @@ class FilePickerMacOS extends FilePickerPlatform {
     }
     return initialDirectory;
   }
-
-  String escapeDialogTitle(String dialogTitle) => dialogTitle
-      .replaceAll('\\', '\\\\')
-      .replaceAll('"', '\\"')
-      .replaceAll('\n', '\\\n');
 }

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -98,6 +98,9 @@ class FilePickerMacOS extends FilePickerPlatform {
     final String? directoryPath = await methodChannel.invokeMethod<String>(
       'getDirectoryPath',
       <String, dynamic>{
+        'dialogTitle': dialogTitle == null
+            ? null
+            : escapeDialogTitle(dialogTitle),
         'initialDirectory': escapeInitialDirectory(initialDirectory),
       },
     );

--- a/lib/src/platform/macos/file_picker_macos.dart
+++ b/lib/src/platform/macos/file_picker_macos.dart
@@ -95,15 +95,13 @@ class FilePickerMacOS extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
-    final String? directoryPath = await methodChannel.invokeMethod<String>(
-      'getDirectoryPath',
-      <String, dynamic>{
-        'dialogTitle': dialogTitle == null
-            ? null
-            : escapeDialogTitle(dialogTitle),
-        'initialDirectory': escapeInitialDirectory(initialDirectory),
-      },
-    );
+    final String? directoryPath = await methodChannel
+        .invokeMethod<String>('getDirectoryPath', <String, dynamic>{
+          'dialogTitle': dialogTitle == null
+              ? null
+              : escapeDialogTitle(dialogTitle),
+          'initialDirectory': escapeInitialDirectory(initialDirectory),
+        });
 
     return directoryPath;
   }

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -160,21 +160,27 @@ void main() {
       log.clear();
     });
 
-    test('should pass dialogTitle and initialDirectory to method channel', () async {
-      final picker = FilePickerMacOS();
+    test(
+      'should pass dialogTitle and initialDirectory to method channel',
+      () async {
+        final picker = FilePickerMacOS();
 
-      final result = await picker.getDirectoryPath(
-        dialogTitle: 'Select Directory',
-        initialDirectory: '~/Documents',
-      );
+        final result = await picker.getDirectoryPath(
+          dialogTitle: 'Select Directory',
+          initialDirectory: '~/Documents',
+        );
 
-      expect(result, equals('/Users/test/Documents'));
-      expect(log, hasLength(1));
-      expect(log.first.method, equals('getDirectoryPath'));
-      expect(log.first.arguments, equals({
-        'dialogTitle': 'Select Directory',
-        'initialDirectory': 'Documents',
-      }));
-    });
+        expect(result, equals('/Users/test/Documents'));
+        expect(log, hasLength(1));
+        expect(log.first.method, equals('getDirectoryPath'));
+        expect(
+          log.first.arguments,
+          equals({
+            'dialogTitle': 'Select Directory',
+            'initialDirectory': 'Documents',
+          }),
+        );
+      },
+    );
   });
 }

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:file_picker/src/platform/macos/file_picker_macos.dart';
 import 'package:file_picker/src/api/file_picker_types.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -139,6 +140,41 @@ void main() {
 
     test('should handle empty string', () {
       expect(picker.escapeInitialDirectory(''), equals(''));
+    });
+  });
+
+  group('getDirectoryPath()', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    final MethodChannel channel = const MethodChannel(
+      'miguelruivo.flutter.plugins.filepicker',
+    );
+    final List<MethodCall> log = <MethodCall>[];
+
+    setUp(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+            log.add(methodCall);
+            return '/Users/test/Documents';
+          });
+      log.clear();
+    });
+
+    test('should pass dialogTitle and initialDirectory to method channel', () async {
+      final picker = FilePickerMacOS();
+
+      final result = await picker.getDirectoryPath(
+        dialogTitle: 'Select Directory',
+        initialDirectory: '~/Documents',
+      );
+
+      expect(result, equals('/Users/test/Documents'));
+      expect(log, hasLength(1));
+      expect(log.first.method, equals('getDirectoryPath'));
+      expect(log.first.arguments, equals({
+        'dialogTitle': 'Select Directory',
+        'initialDirectory': 'Documents',
+      }));
     });
   });
 }

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -76,42 +76,6 @@ void main() {
       },
     );
   });
-
-  group('escapeDialogTitle()', () {
-    test('should escape backslashes in the title of the dialog', () {
-      final picker = FilePickerMacOS();
-
-      final escapedTitle = picker.escapeDialogTitle(
-        'Please select files that contain a \\:',
-      );
-
-      expect(escapedTitle, equals('Please select files that contain a \\\\:'));
-    });
-
-    test('should escape line breaks in the title of the dialog', () {
-      final picker = FilePickerMacOS();
-
-      final escapedTitle = picker.escapeDialogTitle(
-        'Please continue reading\nafter the line break:',
-      );
-
-      expect(
-        escapedTitle,
-        equals('Please continue reading\\\nafter the line break:'),
-      );
-    });
-
-    test('should escape double quotes in the title of the dialog', () {
-      final picker = FilePickerMacOS();
-
-      final escapedTitle = picker.escapeDialogTitle(
-        'Please select a "quoted" file:',
-      );
-
-      expect(escapedTitle, equals('Please select a \\"quoted\\" file:'));
-    });
-  });
-
   group('escapeInitialDirectory()', () {
     late FilePickerMacOS picker;
 

--- a/test/file_picker_macos_test.dart
+++ b/test/file_picker_macos_test.dart
@@ -119,7 +119,10 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
             log.add(methodCall);
-            return '/Users/test/Documents';
+            if (methodCall.method == 'getDirectoryPath') {
+              return '/Users/test/Documents';
+            }
+            return null;
           });
       log.clear();
     });


### PR DESCRIPTION
Fixes #2087 by including 'dialogTitle' in the method channel arguments map for getDirectoryPath on macOS.