### PR TITLE
fix: update Gradle wrapper to version 9.6.1 and add missing properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+
+android.newDsl=false
+android.builtInKotlin=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 01 08:56:40 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -1,5 +1,4 @@
 package com.mr.flutter.plugin.filepicker
-
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle


### PR DESCRIPTION
## Summary

This PR updates the Android build configuration to resolve compatibility issues when building Flutter applications with newer Android Gradle Plugin (AGP) and Gradle versions.

### Changes

* Updated the Gradle wrapper to **Gradle 9.6.1**.
* Added the following properties to `gradle.properties`:

  ```properties
  android.newDsl=false
  android.builtInKotlin=false
  ```

### Why

When using the plugin in a Flutter application with recent Android tooling, the Android build failed during plugin registration with errors similar to:

```text
cannot find symbol
com.mr.flutter.plugin.filepicker.FilePickerPlugin
```

Disabling the new Android DSL and Built-in Kotlin for the current plugin configuration restores compatibility until the plugin fully migrates to Flutter's Built-in Kotlin support.

### Validation

The changes were verified by:

* Building the plugin example application successfully.
* Integrating the updated plugin into a Flutter application that previously failed to compile.
* Confirming that the Android build completes successfully after applying these changes.

This PR provides a compatibility fix for projects using the current plugin implementation with newer Android build tooling.
Issue number #2050 