### PR TITLE
File picker platform interface setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,18 +43,20 @@ jobs:
 
       - run: flutter --version
 
-      - name: Install dependencies
-        run: flutter pub get
+      - name: Install dependencies & Bootstrap
+        run: |
+          flutter pub get
+          dart run melos bootstrap
 
       - name: Verify formatting
         if: matrix.flutter == 'stable'
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
-        run: dart analyze .
+        run: dart run melos run analyze
 
       - name: Run tests
-        run: flutter test
+        run: dart run melos run test
 
   test_os_matrix:
     needs: test_flutter_versions
@@ -72,17 +74,19 @@ jobs:
 
       - run: flutter --version
 
-      - name: Install dependencies
-        run: flutter pub get
+      - name: Install dependencies & Bootstrap
+        run: |
+          flutter pub get
+          dart run melos bootstrap
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
-        run: dart analyze .
+        run: dart run melos run analyze
 
       - name: Run tests
-        run: flutter test
+        run: dart run melos run test
 
       # Linux build (example app)
       - name: Install Linux desktop dependencies
@@ -98,7 +102,9 @@ jobs:
       - name: Build Linux example
         if: matrix.os == 'ubuntu-latest'
         working-directory: example
-        run: flutter build linux
+        run: |
+          flutter pub get
+          flutter build linux
 
       # Windows build (example app)
       - name: Enable Windows desktop
@@ -108,7 +114,9 @@ jobs:
       - name: Build Windows example
         if: matrix.os == 'windows-latest'
         working-directory: example
-        run: flutter build windows
+        run: |
+          flutter pub get
+          flutter build windows
 
       # macOS build (example app)
       - name: Enable macOS desktop
@@ -118,7 +126,9 @@ jobs:
       - name: Build macOS example
         if: matrix.os == 'macos-latest'
         working-directory: example
-        run: flutter build macos
+        run: |
+          flutter pub get
+          flutter build macos
 
   build_web:
     needs: test_flutter_versions
@@ -137,4 +147,6 @@ jobs:
         run: flutter config --enable-web
       - name: Build Web example
         working-directory: example
-        run: flutter build web --wasm
+        run: |
+          flutter pub get
+          flutter build web --wasm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,13 @@ jobs:
         if: matrix.flutter == 'stable' || matrix.flutter == 'beta'
         with:
           channel: ${{ matrix.flutter }}
+          cache: true
 
       - uses: subosito/flutter-action@v2
         if: matrix.flutter != 'stable' && matrix.flutter != 'beta'
         with:
           flutter-version: ${{ matrix.flutter }}
+          cache: true
 
       - run: flutter --version
 
@@ -49,7 +51,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
-        run: flutter analyze
+        run: dart analyze .
 
       - name: Run tests
         run: flutter test
@@ -66,6 +68,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
 
       - run: flutter --version
 
@@ -76,7 +79,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
-        run: flutter analyze
+        run: dart analyze .
 
       - name: Run tests
         run: flutter test
@@ -95,9 +98,7 @@ jobs:
       - name: Build Linux example
         if: matrix.os == 'ubuntu-latest'
         working-directory: example
-        run: |
-          flutter pub get
-          flutter build linux
+        run: flutter build linux
 
       # Windows build (example app)
       - name: Enable Windows desktop
@@ -107,9 +108,7 @@ jobs:
       - name: Build Windows example
         if: matrix.os == 'windows-latest'
         working-directory: example
-        run: |
-          flutter pub get
-          flutter build windows
+        run: flutter build windows
 
       # macOS build (example app)
       - name: Enable macOS desktop
@@ -119,9 +118,7 @@ jobs:
       - name: Build macOS example
         if: matrix.os == 'macos-latest'
         working-directory: example
-        run: |
-          flutter pub get
-          flutter build macos
+        run: flutter build macos
 
   build_web:
     needs: test_flutter_versions
@@ -132,6 +129,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
       - run: flutter --version
       - name: Install dependencies
         run: flutter pub get
@@ -139,6 +137,4 @@ jobs:
         run: flutter config --enable-web
       - name: Build Web example
         working-directory: example
-        run: |
-          flutter pub get
-          flutter build web --wasm
+        run: flutter build web --wasm

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,11 @@ include: package:lints/recommended.yaml
 analyzer:
   errors:
     deprecated_member_use_from_same_package: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -11,9 +11,7 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   bool withData = false,
 }) {
   return Future.wait(
-    filePaths.where((String filePath) => filePath.isNotEmpty).map((
-      String filePath,
-    ) async {
+    filePaths.where((String filePath) => filePath.isNotEmpty).map((String filePath) async {
       final file = File(filePath);
 
       if (withReadStream) {
@@ -30,11 +28,7 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   );
 }
 
-Future<PlatformFile> createPlatformFile(
-  Object file,
-  Uint8List? bytes,
-  Stream<List<int>>? readStream,
-) async {
+Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) async {
   if (file case final File nativeFile) {
     return PlatformFile(
       bytes: bytes,
@@ -48,26 +42,6 @@ Future<PlatformFile> createPlatformFile(
   throw ArgumentError('Expected file to be a File.');
 }
 
-Future<String?> runExecutableWithArguments(
-  String executable,
-  List<String> arguments,
-) async {
-  final processResult = await Process.run(executable, arguments);
-  final path = processResult.stdout?.toString().trim();
-  if (processResult.exitCode != 0 || path == null || path.isEmpty) {
-    return null;
-  }
-  return path;
-}
-
-Future<String> isExecutableOnPath(String executable) async {
-  final path = await runExecutableWithArguments('which', [executable]);
-  if (path == null) {
-    throw Exception('Couldn\'t find the executable $executable in the path.');
-  }
-  return path;
-}
-
 Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
   if (path == null || bytes == null || bytes.isEmpty) {
     return;
@@ -76,11 +50,7 @@ Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
   final receivePort = ReceivePort();
   final transferable = TransferableTypedData.fromList([bytes]);
 
-  await Isolate.spawn(_saveBytesIsolateEntry, [
-    receivePort.sendPort,
-    path,
-    transferable,
-  ]);
+  await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
 
   final result = await receivePort.first;
   receivePort.close();
@@ -90,11 +60,7 @@ Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
 }
 
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-  if (args case [
-    SendPort send,
-    String path,
-    TransferableTypedData transferable,
-  ]) {
+  if (args case [SendPort send, String path, TransferableTypedData transferable]) {
     try {
       final Uint8List bytes = transferable.materialize().asUint8List();
       final file = File(path);

--- a/lib/src/utils/_file_utils_io.dart
+++ b/lib/src/utils/_file_utils_io.dart
@@ -11,7 +11,9 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   bool withData = false,
 }) {
   return Future.wait(
-    filePaths.where((String filePath) => filePath.isNotEmpty).map((String filePath) async {
+    filePaths.where((String filePath) => filePath.isNotEmpty).map((
+      String filePath,
+    ) async {
       final file = File(filePath);
 
       if (withReadStream) {
@@ -28,7 +30,11 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   );
 }
 
-Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) async {
+Future<PlatformFile> createPlatformFile(
+  Object file,
+  Uint8List? bytes,
+  Stream<List<int>>? readStream,
+) async {
   if (file case final File nativeFile) {
     return PlatformFile(
       bytes: bytes,
@@ -50,7 +56,11 @@ Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
   final receivePort = ReceivePort();
   final transferable = TransferableTypedData.fromList([bytes]);
 
-  await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
+  await Isolate.spawn(_saveBytesIsolateEntry, [
+    receivePort.sendPort,
+    path,
+    transferable,
+  ]);
 
   final result = await receivePort.first;
   receivePort.close();
@@ -60,7 +70,11 @@ Future<void> saveBytesToFile(Uint8List? bytes, String? path) async {
 }
 
 Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-  if (args case [SendPort send, String path, TransferableTypedData transferable]) {
+  if (args case [
+    SendPort send,
+    String path,
+    TransferableTypedData transferable,
+  ]) {
     try {
       final Uint8List bytes = transferable.materialize().asUint8List();
       final file = File(path);

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -5,10 +5,19 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   List<String> filePaths, {
   bool withReadStream = false,
   bool withData = false,
-}) => throw UnsupportedError('filePathsToPlatformFiles is only supported on native platforms');
+}) => throw UnsupportedError(
+  'filePathsToPlatformFiles is only supported on native platforms',
+);
 
-Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) =>
-    throw UnsupportedError('createPlatformFile is only supported on native platforms');
+Future<PlatformFile> createPlatformFile(
+  Object file,
+  Uint8List? bytes,
+  Stream<List<int>>? readStream,
+) => throw UnsupportedError(
+  'createPlatformFile is only supported on native platforms',
+);
 
 Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
-    throw UnsupportedError('saveBytesToFile is only supported on native platforms');
+    throw UnsupportedError(
+      'saveBytesToFile is only supported on native platforms',
+    );

--- a/lib/src/utils/_file_utils_web.dart
+++ b/lib/src/utils/_file_utils_web.dart
@@ -5,30 +5,10 @@ Future<List<PlatformFile>> filePathsToPlatformFiles(
   List<String> filePaths, {
   bool withReadStream = false,
   bool withData = false,
-}) => throw UnsupportedError(
-  'filePathsToPlatformFiles is only supported on native platforms',
-);
+}) => throw UnsupportedError('filePathsToPlatformFiles is only supported on native platforms');
 
-Future<PlatformFile> createPlatformFile(
-  Object file,
-  Uint8List? bytes,
-  Stream<List<int>>? readStream,
-) => throw UnsupportedError(
-  'createPlatformFile is only supported on native platforms',
-);
-
-Future<String?> runExecutableWithArguments(
-  String executable,
-  List<String> arguments,
-) => throw UnsupportedError(
-  'runExecutableWithArguments is only supported on native platforms',
-);
-
-Future<String> isExecutableOnPath(String executable) => throw UnsupportedError(
-  'isExecutableOnPath is only supported on native platforms',
-);
+Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) =>
+    throw UnsupportedError('createPlatformFile is only supported on native platforms');
 
 Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
-    throw UnsupportedError(
-      'saveBytesToFile is only supported on native platforms',
-    );
+    throw UnsupportedError('saveBytesToFile is only supported on native platforms');

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -1,7 +1,9 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 
-import '_file_utils_web.dart' if (dart.library.io) '_file_utils_io.dart' as impl;
+import '_file_utils_web.dart'
+    if (dart.library.io) '_file_utils_io.dart'
+    as impl;
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -19,7 +21,11 @@ class FilePickerUtils {
     List<String> filePaths, {
     bool withReadStream = false,
     bool withData = false,
-  }) => impl.filePathsToPlatformFiles(filePaths, withReadStream: withReadStream, withData: withData);
+  }) => impl.filePathsToPlatformFiles(
+    filePaths,
+    withReadStream: withReadStream,
+    withData: withData,
+  );
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
@@ -28,13 +34,17 @@ class FilePickerUtils {
   /// The [bytes] are the file bytes.
   /// The [readStream] is a [Stream] of the file content.
   @visibleForTesting
-  static Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) =>
-      impl.createPlatformFile(file, bytes, readStream);
+  static Future<PlatformFile> createPlatformFile(
+    Object file,
+    Uint8List? bytes,
+    Stream<List<int>>? readStream,
+  ) => impl.createPlatformFile(file, bytes, readStream);
 
   /// Saves the given [bytes] to a file at [path].
   ///
   /// Does nothing if [path] or [bytes] is null or empty.
-  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) => impl.saveBytesToFile(bytes, path);
+  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
+      impl.saveBytesToFile(bytes, path);
 
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///
@@ -50,7 +60,10 @@ class FilePickerUtils {
   ///
   /// Throws an [ArgumentError] if extension filters are provided while the
   /// [type] is not [FileType.custom].
-  static void validateAllowedExtensions(FileType type, List<String>? allowedExtensions) {
+  static void validateAllowedExtensions(
+    FileType type,
+    List<String>? allowedExtensions,
+  ) {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
       throw ArgumentError.value(
         allowedExtensions,
@@ -60,7 +73,8 @@ class FilePickerUtils {
       );
     }
 
-    if (type == FileType.custom && (allowedExtensions == null || allowedExtensions.isEmpty)) {
+    if (type == FileType.custom &&
+        (allowedExtensions == null || allowedExtensions.isEmpty)) {
       throw ArgumentError.value(
         allowedExtensions,
         'allowedExtensions',

--- a/lib/src/utils/file_picker_utils.dart
+++ b/lib/src/utils/file_picker_utils.dart
@@ -1,9 +1,7 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 
-import '_file_utils_web.dart'
-    if (dart.library.io) '_file_utils_io.dart'
-    as impl;
+import '_file_utils_web.dart' if (dart.library.io) '_file_utils_io.dart' as impl;
 
 /// Utility class for [FilePicker] that provides common helper methods
 /// used across different platform implementations.
@@ -21,11 +19,7 @@ class FilePickerUtils {
     List<String> filePaths, {
     bool withReadStream = false,
     bool withData = false,
-  }) => impl.filePathsToPlatformFiles(
-    filePaths,
-    withReadStream: withReadStream,
-    withData: withData,
-  );
+  }) => impl.filePathsToPlatformFiles(filePaths, withReadStream: withReadStream, withData: withData);
 
   /// Creates a [PlatformFile] instance from a [File] object.
   ///
@@ -34,33 +28,13 @@ class FilePickerUtils {
   /// The [bytes] are the file bytes.
   /// The [readStream] is a [Stream] of the file content.
   @visibleForTesting
-  static Future<PlatformFile> createPlatformFile(
-    Object file,
-    Uint8List? bytes,
-    Stream<List<int>>? readStream,
-  ) => impl.createPlatformFile(file, bytes, readStream);
-
-  /// Runs an executable with the given arguments and returns the output.
-  ///
-  /// Returns the trimmed stdout as a [String], or null if the process fails
-  /// or produces no output.
-  static Future<String?> runExecutableWithArguments(
-    String executable,
-    List<String> arguments,
-  ) => impl.runExecutableWithArguments(executable, arguments);
-
-  /// Checks if an executable exists on the system path using `which`.
-  ///
-  /// Returns the absolute path to the executable if found.
-  /// Throws an [Exception] if the executable is not found.
-  static Future<String> isExecutableOnPath(String executable) =>
-      impl.isExecutableOnPath(executable);
+  static Future<PlatformFile> createPlatformFile(Object file, Uint8List? bytes, Stream<List<int>>? readStream) =>
+      impl.createPlatformFile(file, bytes, readStream);
 
   /// Saves the given [bytes] to a file at [path].
   ///
   /// Does nothing if [path] or [bytes] is null or empty.
-  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) =>
-      impl.saveBytesToFile(bytes, path);
+  static Future<void> saveBytesToFile(Uint8List? bytes, String? path) => impl.saveBytesToFile(bytes, path);
 
   /// Checks if the start of the string [x] is an alphabetical character (a-z or A-Z).
   ///
@@ -76,10 +50,7 @@ class FilePickerUtils {
   ///
   /// Throws an [ArgumentError] if extension filters are provided while the
   /// [type] is not [FileType.custom].
-  static void validateAllowedExtensions(
-    FileType type,
-    List<String>? allowedExtensions,
-  ) {
+  static void validateAllowedExtensions(FileType type, List<String>? allowedExtensions) {
     if (type != FileType.custom && (allowedExtensions?.isNotEmpty ?? false)) {
       throw ArgumentError.value(
         allowedExtensions,
@@ -89,8 +60,7 @@ class FilePickerUtils {
       );
     }
 
-    if (type == FileType.custom &&
-        (allowedExtensions == null || allowedExtensions.isEmpty)) {
+    if (type == FileType.custom && (allowedExtensions == null || allowedExtensions.isEmpty)) {
       throw ArgumentError.value(
         allowedExtensions,
         'allowedExtensions',

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+* Initial release of `file_picker_platform_interface`.

--- a/packages/file_picker_platform_interface/README.md
+++ b/packages/file_picker_platform_interface/README.md
@@ -1,0 +1,19 @@
+# file_picker_platform_interface
+
+A common platform interface for the `file_picker` plugin.
+
+This package defines the interface that all platform implementation packages for `file_picker` (such as `file_picker_android`, `file_picker_darwin`, `file_picker_windows`, `file_picker_linux`, `file_picker_web`) must implement.
+
+## Usage
+
+To implement a new platform plugin for `file_picker`, extend `FilePickerPlatform` and register your implementation:
+
+```dart
+class FilePickerCustomPlatform extends FilePickerPlatform {
+  static void registerWith() {
+    FilePickerPlatform.instance = FilePickerCustomPlatform();
+  }
+
+  // Implement methods...
+}
+```

--- a/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
@@ -8,3 +8,5 @@ export 'src/file_picker_options/windows_options.dart';
 export 'src/file_picker_platform_interface.dart';
 export 'src/method_channel_file_picker.dart';
 export 'src/platform_file.dart';
+export 'src/utils/file_picker_save_utils_io.dart'
+    if (dart.library.js_interop) 'src/utils/file_picker_save_utils_web.dart';

--- a/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
@@ -1,0 +1,9 @@
+export 'src/enums/file_picker_status.dart';
+export 'src/enums/file_type.dart';
+export 'src/file_picker_options/android_options.dart';
+export 'src/file_picker_options/linux_options.dart';
+export 'src/file_picker_options/web_options.dart';
+export 'src/file_picker_options/windows_options.dart';
+export 'src/file_picker_platform_interface.dart';
+export 'src/exceptions.dart';
+export 'src/platform_file.dart';

--- a/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/file_picker_platform_interface.dart
@@ -1,9 +1,10 @@
 export 'src/enums/file_picker_status.dart';
 export 'src/enums/file_type.dart';
+export 'src/exceptions.dart';
 export 'src/file_picker_options/android_options.dart';
 export 'src/file_picker_options/linux_options.dart';
 export 'src/file_picker_options/web_options.dart';
 export 'src/file_picker_options/windows_options.dart';
 export 'src/file_picker_platform_interface.dart';
-export 'src/exceptions.dart';
+export 'src/method_channel_file_picker.dart';
 export 'src/platform_file.dart';

--- a/packages/file_picker_platform_interface/lib/src/enums/file_picker_status.dart
+++ b/packages/file_picker_platform_interface/lib/src/enums/file_picker_status.dart
@@ -1,0 +1,8 @@
+/// The status of the file picker.
+enum FilePickerStatus {
+  /// The file picker is currently active/open.
+  picking,
+
+  /// The file picking process is complete.
+  done,
+}

--- a/packages/file_picker_platform_interface/lib/src/enums/file_type.dart
+++ b/packages/file_picker_platform_interface/lib/src/enums/file_type.dart
@@ -1,0 +1,20 @@
+/// The type of file that a file picker can select.
+enum FileType {
+  /// Select any file.
+  any,
+
+  /// Select video and image files.
+  media,
+
+  /// Select image files.
+  image,
+
+  /// Select video files.
+  video,
+
+  /// Select audio files.
+  audio,
+
+  /// Select files with specific extensions.
+  custom,
+}

--- a/packages/file_picker_platform_interface/lib/src/exceptions.dart
+++ b/packages/file_picker_platform_interface/lib/src/exceptions.dart
@@ -1,0 +1,12 @@
+/// An exception that is thrown when a file name contains characters that are not allowed
+/// for the underlying platform.
+class IllegalCharacterInFileNameException implements Exception {
+  /// Creates an instance of [IllegalCharacterInFileNameException].
+  const IllegalCharacterInFileNameException(this.message);
+
+  /// The error message.
+  final String message;
+
+  @override
+  String toString() => 'IllegalCharacterInFileNameException: $message';
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_options/android_options.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_options/android_options.dart
@@ -1,0 +1,5 @@
+/// The options for the Android file picker.
+class AndroidOptions {
+  /// Creates an instance of [AndroidOptions].
+  const AndroidOptions();
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_options/linux_options.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_options/linux_options.dart
@@ -1,0 +1,5 @@
+/// The options for the Linux file picker.
+class LinuxOptions {
+  /// Creates an instance of [LinuxOptions].
+  const LinuxOptions();
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_options/web_options.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_options/web_options.dart
@@ -1,0 +1,5 @@
+/// The options for the web file picker.
+class WebOptions {
+  /// Creates an instance of [WebOptions].
+  const WebOptions();
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_options/windows_options.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_options/windows_options.dart
@@ -1,0 +1,5 @@
+/// The options for the Windows file picker.
+class WindowsOptions {
+  /// Creates an instance of [WindowsOptions].
+  const WindowsOptions();
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -48,4 +48,36 @@ abstract class FilePickerPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('pickFile() has not been implemented.');
   }
+
+  /// Pick multiple files using the native file picker.
+  ///
+  /// The [dialogTitle], if provided, will be used as title for the picker dialog.
+  /// The [initialDirectory], if provided, will be used as the path for the initial directory of the file picker.
+  /// The [type] parameter specifies the type of files to be picked and defaults to [FileType.any].
+  /// The [allowedExtensions] parameter, if provided,
+  /// will restrict the file picker to allow only files with the specified extensions,
+  /// and defaults to allowing all files.
+  /// The [onFileLoading] callback, if provided, will be called when the file picker is loading the selected files.
+  /// The [compressionQuality] parameter specifies the compression quality, in percent, to compress the picked files.
+  ///
+  /// The [androidOptions], [windowsOptions], [linuxOptions],
+  /// and [webOptions] parameters allow for platform-specific configurations when configuring the file picker.
+  /// See their respective classes for more details on the available options.
+  ///
+  /// Returns the [FilePickerResult] containing the selected files, if any.
+  /// The result may contain no files if the user cancels the operation.
+  Future<FilePickerResult> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) {
+    throw UnimplementedError('pickFiles() has not been implemented.');
+  }
 }

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -80,4 +80,29 @@ abstract class FilePickerPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('pickFiles() has not been implemented.');
   }
+
+  /// Pick files and directories using the native file picker.
+  ///
+  /// The [dialogTitle], if provided, will be used as title for the picker dialog.
+  /// The [initialDirectory], if provided, will be used as the path for the initial directory of the file picker.
+  /// The [type] parameter specifies the type of files to be picked and defaults to [FileType.any].
+  /// The [allowedExtensions] parameter, if provided,
+  /// will restrict the file picker to allow only files with the specified extensions,
+  /// and defaults to allowing all files.
+  ///
+  /// Returns a list of absolute paths for the selected files and directories, if any.
+  /// The resulting list will be empty if the user cancels the operation.
+  Future<List<String>> pickFileAndDirectoryPaths({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+  }) async {
+    throw UnimplementedError('pickFileAndDirectoryPaths() has not been implemented.');
+  }
+
+  /// Clear the temporary files created by the underlying file picker.
+  Future<void> clearTemporaryFiles() async {
+    throw UnimplementedError('clearTemporaryFiles() has not been implemented.');
+  }
 }

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -139,10 +139,9 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// allow for platform-specific configurations when configuring the save file dialog.
   /// See their respective classes for more details on the available options.
   ///
-  /// Returns the result of the save file operation, or null if the user cancels the operation.
-  /// Depending on the platform, the result may contain an absolute path to the file,
-  /// a URL to the saved file, a content URI, or no information about where the file was eventually saved.
-  Future<SaveFileResult?> saveFile({
+  /// Returns the [Uri] of the saved file, or null if the user cancels the operation.
+  /// Depending on the platform, the [Uri.scheme] may be `file`, `content`, `http(s)`, `data` or `blob`.
+  Future<Uri?> saveFile({
     required String fileName,
     required Uint8List bytes,
     required String mimeType,

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// The interface that implementations of file_picker must implement.
+abstract class FilePickerPlatform extends PlatformInterface {
+  FilePickerPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static FilePickerPlatform _instance = MethodChannelFilePicker();
+
+  static FilePickerPlatform get instance => _instance;
+
+  static set instance(FilePickerPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Pick a single file using the native file picker.
+  ///
+  /// The [dialogTitle], if provided, will be used as title for the picker dialog.
+  /// The [initialDirectory], if provided, will be used as the path for the initial directory of the file picker.
+  /// The [type] parameter specifies the type of file to be picked and defaults to [FileType.any].
+  /// The [allowedExtensions] parameter, if provided,
+  /// will restrict the file picker to allow only files with the specified extensions,
+  /// and defaults to allowing all files.
+  /// The [onFileLoading] callback, if provided, will be called when the file picker is loading the selected file.
+  /// The [compressionQuality] parameter specifies the compression quality, in percent, to compress the picked file.
+  ///
+  /// The [androidOptions], [windowsOptions], [linuxOptions],
+  /// and [webOptions] parameters allow for platform-specific configurations when configuring the file picker.
+  /// See their respective classes for more details on the available options.
+  ///
+  /// Returns the [PlatformFile] containing the selected file, or `null` if the user cancels the operation.
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) {
+    throw UnimplementedError('pickFile() has not been implemented.');
+  }
+}

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -101,6 +101,27 @@ abstract class FilePickerPlatform extends PlatformInterface {
     throw UnimplementedError('pickFileAndDirectoryPaths() has not been implemented.');
   }
 
+  /// Pick a single directory using the native file picker.
+  ///
+  /// The [dialogTitle], if provided, will be used as title for the picker dialog.
+  /// The [initialDirectory], if provided, will be used as the path for the initial directory of the directory picker.
+  ///
+  /// The [androidOptions], [windowsOptions], [linuxOptions],
+  /// and [webOptions] parameters allow for platform-specific configurations when configuring the directory picker.
+  /// See their respective classes for more details on the available options.
+  ///
+  /// Returns the absolute path of the selected directory, or `null` if the user cancels the operation.
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    throw UnimplementedError('getDirectoryPath() has not been implemented.');
+  }
+
   /// Clear the temporary files created by the underlying file picker.
   Future<void> clearTemporaryFiles() async {
     throw UnimplementedError('clearTemporaryFiles() has not been implemented.');

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -9,6 +9,7 @@ import 'file_picker_options/android_options.dart';
 import 'file_picker_options/linux_options.dart';
 import 'file_picker_options/web_options.dart';
 import 'file_picker_options/windows_options.dart';
+import 'platform_file.dart';
 
 /// The interface that implementations of file_picker must implement.
 abstract class FilePickerPlatform extends PlatformInterface {

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -3,6 +3,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'file_picker_options/android_options.dart';
+import 'file_picker_options/linux_options.dart';
+import 'file_picker_options/web_options.dart';
+import 'file_picker_options/windows_options.dart';
+
 /// The interface that implementations of file_picker must implement.
 abstract class FilePickerPlatform extends PlatformInterface {
   FilePickerPlatform() : super(token: _token);

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -64,9 +64,9 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// and [webOptions] parameters allow for platform-specific configurations when configuring the file picker.
   /// See their respective classes for more details on the available options.
   ///
-  /// Returns the [FilePickerResult] containing the selected files, if any.
-  /// The result may contain no files if the user cancels the operation.
-  Future<FilePickerResult> pickFiles({
+  /// Returns a list of [PlatformFile] containing the selected files, if any.
+  /// The list may be empty if the user cancels the operation.
+  Future<List<PlatformFile>> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
@@ -125,5 +125,34 @@ abstract class FilePickerPlatform extends PlatformInterface {
   /// Clear the temporary files created by the underlying file picker.
   Future<void> clearTemporaryFiles() async {
     throw UnimplementedError('clearTemporaryFiles() has not been implemented.');
+  }
+
+  /// Save the given [bytes] to a file with the given [fileName], using the native save file dialog.
+  ///
+  /// The [fileName] should include the file extension, e.g. `myFile.txt`.
+  /// The [mimeType] should be a valid MIME type for the file, e.g. `text/plain`.
+  /// The [dialogTitle], if provided, will be used as title for the save file dialog.
+  /// The [initialDirectory], if provided, will be used as the path for the initial directory of the save file dialog.
+  /// The [onFileSaving] callback, if provided, will be called when the save file dialog is saving the file.
+  ///
+  /// The [windowsOptions], [linuxOptions], and [webOptions] parameters
+  /// allow for platform-specific configurations when configuring the save file dialog.
+  /// See their respective classes for more details on the available options.
+  ///
+  /// Returns the result of the save file operation, or null if the user cancels the operation.
+  /// Depending on the platform, the result may contain an absolute path to the file,
+  /// a URL to the saved file, a content URI, or no information about where the file was eventually saved.
+  Future<SaveFileResult?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
+    String? dialogTitle,
+    String? initialDirectory,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    throw UnimplementedError('saveFile() has not been implemented.');
   }
 }

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -9,6 +9,7 @@ import 'file_picker_options/android_options.dart';
 import 'file_picker_options/linux_options.dart';
 import 'file_picker_options/web_options.dart';
 import 'file_picker_options/windows_options.dart';
+import 'method_channel_file_picker.dart';
 import 'platform_file.dart';
 
 /// The interface that implementations of file_picker must implement.

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -107,7 +107,9 @@ abstract class FilePickerPlatform extends PlatformInterface {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
   }) async {
-    throw UnimplementedError('pickFileAndDirectoryPaths() has not been implemented.');
+    throw UnimplementedError(
+      'pickFileAndDirectoryPaths() has not been implemented.',
+    );
   }
 
   /// Pick a single directory using the native file picker.

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'enums/file_picker_status.dart';
+import 'enums/file_type.dart';
 import 'file_picker_options/android_options.dart';
 import 'file_picker_options/linux_options.dart';
 import 'file_picker_options/web_options.dart';

--- a/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
+++ b/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
@@ -7,11 +7,16 @@ import 'file_picker_platform_interface.dart';
 class MethodChannelFilePicker extends FilePickerPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final methodChannel = const MethodChannel('miguelruivo.flutter.plugins.filepicker', StandardMethodCodec());
+  final methodChannel = const MethodChannel(
+    'miguelruivo.flutter.plugins.filepicker',
+    StandardMethodCodec(),
+  );
 
   /// The event channel used to receive real-time updates from the native platform.
   @visibleForTesting
-  final eventChannel = const EventChannel('miguelruivo.flutter.plugins.filepickerevent');
+  final eventChannel = const EventChannel(
+    'miguelruivo.flutter.plugins.filepickerevent',
+  );
 
   /// Registers this class as the default instance of [FilePickerPlatform].
   static void registerWith() {

--- a/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
+++ b/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'file_picker_platform_interface.dart';
+
+/// An implementation of [FilePickerPlatform] that uses method channels.
+class MethodChannelFilePicker extends FilePickerPlatform {
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  final methodChannel = const MethodChannel('miguelruivo.flutter.plugins.filepicker', StandardMethodCodec());
+
+  /// The event channel used to receive real-time updates from the native platform.
+  @visibleForTesting
+  final eventChannel = const EventChannel('miguelruivo.flutter.plugins.filepickerevent');
+
+  /// Registers this class as the default instance of [FilePickerPlatform].
+  static void registerWith() {
+    FilePickerPlatform.instance = MethodChannelFilePicker();
+  }
+
+  // TODO: implement the method channel using the new interface
+}

--- a/packages/file_picker_platform_interface/lib/src/platform_file.dart
+++ b/packages/file_picker_platform_interface/lib/src/platform_file.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:cross_file/cross_file.dart';
+
+/// The abstract representation of a picked file on the current platform.
+///
+/// Depending on the current platform,
+/// an implementation may provide additional properties or methods specific to that platform.
+abstract base class PlatformFile {
+  /// The name of the underlying file, including the extension.
+  String get name;
+
+  /// An [Uri] to the underlying file.
+  ///
+  /// Depending on the platform, this may point to a local file, a blob, a data URI, or a network resource.
+  Uri get uri;
+
+  /// Get this file as an [XFile].
+  XFile get xFile;
+
+  /// Get the length of the file in bytes.
+  Future<int> length();
+
+  /// Read the bytes of the file as a single chunk.
+  ///
+  /// Prefer [readAsByteStream] for large files.
+  Future<Uint8List> readAsBytes();
+
+  /// Read the file content as a stream of bytes.
+  Stream<Uint8List> readAsByteStream();
+}

--- a/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_io.dart
+++ b/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_io.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+final class FilePickerSaveUtils {
+  /// Save the given [bytes] to a file at [path].
+  static Future<void> saveBytesToFile(Uint8List bytes, String path) async {
+    if (bytes.isEmpty) {
+      return;
+    }
+
+    final receivePort = ReceivePort();
+    final transferable = TransferableTypedData.fromList([bytes]);
+
+    await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
+
+    final result = await receivePort.first;
+
+    receivePort.close();
+
+    if (result is Exception) {
+      throw result;
+    }
+  }
+
+  static Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
+    if (args case [SendPort send, String path, TransferableTypedData transferable]) {
+      try {
+        final Uint8List bytes = transferable.materialize().asUint8List();
+        final file = File(path);
+        await file.writeAsBytes(bytes);
+        send.send(null);
+      } catch (e) {
+        send.send(e);
+      }
+      return;
+    }
+
+    if (args case [final SendPort port, ...]) {
+      port.send(Exception('Invalid isolate arguments'));
+    }
+  }
+}

--- a/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_io.dart
+++ b/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_io.dart
@@ -12,7 +12,11 @@ final class FilePickerSaveUtils {
     final receivePort = ReceivePort();
     final transferable = TransferableTypedData.fromList([bytes]);
 
-    await Isolate.spawn(_saveBytesIsolateEntry, [receivePort.sendPort, path, transferable]);
+    await Isolate.spawn(_saveBytesIsolateEntry, [
+      receivePort.sendPort,
+      path,
+      transferable,
+    ]);
 
     final result = await receivePort.first;
 
@@ -24,7 +28,11 @@ final class FilePickerSaveUtils {
   }
 
   static Future<void> _saveBytesIsolateEntry(List<Object?> args) async {
-    if (args case [SendPort send, String path, TransferableTypedData transferable]) {
+    if (args case [
+      SendPort send,
+      String path,
+      TransferableTypedData transferable,
+    ]) {
       try {
         final Uint8List bytes = transferable.materialize().asUint8List();
         final file = File(path);

--- a/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_web.dart
+++ b/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_web.dart
@@ -1,0 +1,8 @@
+import 'dart:typed_data';
+
+final class FilePickerSaveUtils {
+  /// Save the given [bytes] to a file at [path].
+  static Future<void> saveBytesToFile(Uint8List bytes, String path) async {
+    throw UnsupportedError('saveBytesToFile() is not supported on this platform.');
+  }
+}

--- a/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_web.dart
+++ b/packages/file_picker_platform_interface/lib/src/utils/file_picker_save_utils_web.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 final class FilePickerSaveUtils {
   /// Save the given [bytes] to a file at [path].
   static Future<void> saveBytesToFile(Uint8List bytes, String path) async {
-    throw UnsupportedError('saveBytesToFile() is not supported on this platform.');
+    throw UnsupportedError(
+      'saveBytesToFile() is not supported on this platform.',
+    );
   }
 }

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -1,0 +1,23 @@
+name: file_picker_platform_interface
+description: A common platform interface for the file_picker plugin.
+version: 1.0.0
+homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
+repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
+
+resolution: workspace
+
+environment:
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: ^2.1.8
+  cross_file: ^0.3.5+2
+  path: ^1.9.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0

--- a/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
+++ b/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
@@ -28,11 +28,18 @@ void main() {
       final ExtendsFilePickerPlatform instance = ExtendsFilePickerPlatform();
       expect(() => instance.pickFile(), throwsUnimplementedError);
       expect(() => instance.pickFiles(), throwsUnimplementedError);
-      expect(() => instance.pickFileAndDirectoryPaths(), throwsUnimplementedError);
+      expect(
+        () => instance.pickFileAndDirectoryPaths(),
+        throwsUnimplementedError,
+      );
       expect(() => instance.clearTemporaryFiles(), throwsUnimplementedError);
       expect(() => instance.getDirectoryPath(), throwsUnimplementedError);
       expect(
-        () => instance.saveFile(fileName: 'test.txt', bytes: Uint8List(0), mimeType: 'text/plain'),
+        () => instance.saveFile(
+          fileName: 'test.txt',
+          bytes: Uint8List(0),
+          mimeType: 'text/plain',
+        ),
         throwsUnimplementedError,
       );
     });

--- a/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
+++ b/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class ExtendsFilePickerPlatform extends FilePickerPlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FilePickerPlatformInterface', () {
+    test('Can be extended', () {
+      final ExtendsFilePickerPlatform instance = ExtendsFilePickerPlatform();
+      expect(instance, isA<FilePickerPlatform>());
+    });
+
+    test('Default instance is MethodChannelFilePicker', () {
+      expect(FilePickerPlatform.instance, isA<MethodChannelFilePicker>());
+    });
+
+    test('Can set instance', () {
+      final ExtendsFilePickerPlatform instance = ExtendsFilePickerPlatform();
+      FilePickerPlatform.instance = instance;
+      expect(FilePickerPlatform.instance, instance);
+    });
+
+    test('Default implementations throw UnimplementedError', () async {
+      final ExtendsFilePickerPlatform instance = ExtendsFilePickerPlatform();
+      expect(() => instance.pickFile(), throwsUnimplementedError);
+      expect(() => instance.pickFiles(), throwsUnimplementedError);
+      expect(() => instance.pickFileAndDirectoryPaths(), throwsUnimplementedError);
+      expect(() => instance.clearTemporaryFiles(), throwsUnimplementedError);
+      expect(() => instance.getDirectoryPath(), throwsUnimplementedError);
+      expect(
+        () => instance.saveFile(fileName: 'test.txt', bytes: Uint8List(0), mimeType: 'text/plain'),
+        throwsUnimplementedError,
+      );
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,9 @@ repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
 version: 12.0.0-beta.8
 
+workspace:
+  - packages/file_picker_platform_interface
+
 dependencies:
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,19 @@ version: 12.0.0-beta.8
 workspace:
   - packages/file_picker_platform_interface
 
+melos:
+  packages:
+    - .
+    - packages/*
+  scripts:
+    analyze:
+      exec: flutter analyze .
+      description: Run flutter analyze in all packages.
+
+    test:
+      exec: flutter test
+      description: Run flutter test in all packages.
+
 dependencies:
   flutter:
     sdk: flutter
@@ -27,6 +40,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  melos: ^8.2.2
 
 environment:
   sdk: ">=3.10.0 <4.0.0"

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -13,23 +13,9 @@ void main() {
   final pdfTestFile = '/tmp/test_utils.pdf';
   final yamlTestFile = '/tmp/test_utils.yml';
 
-  setUpAll(
-    () => setUpTestFiles(
-      appTestFilePath,
-      imageTestFile,
-      pdfTestFile,
-      yamlTestFile,
-    ),
-  );
+  setUpAll(() => setUpTestFiles(appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile));
 
-  tearDownAll(
-    () => tearDownTestFiles(
-      appTestFilePath,
-      imageTestFile,
-      pdfTestFile,
-      yamlTestFile,
-    ),
-  );
+  tearDownAll(() => tearDownTestFiles(appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile));
 
   group('createPlatformFile()', () {
     test('should return an instance of PlatformFile', () async {
@@ -37,11 +23,7 @@ void main() {
       final bytes = imageFile.readAsBytesSync();
       final readStream = imageFile.openRead();
 
-      final platformFile = await FilePickerUtils.createPlatformFile(
-        imageFile,
-        bytes,
-        readStream,
-      );
+      final platformFile = await FilePickerUtils.createPlatformFile(imageFile, bytes, readStream);
 
       expect(platformFile.bytes, equals(bytes));
       expect(platformFile.name, equals('test_utils.jpg'));
@@ -51,135 +33,81 @@ void main() {
       expect(platformFile.toString(), isNot(contains('Uint8List')));
     });
 
-    test(
-      'should read bytes from the file path when bytes are not available',
-      () async {
-        final imageFile = File(imageTestFile);
-        final expectedBytes = imageFile.readAsBytesSync();
+    test('should read bytes from the file path when bytes are not available', () async {
+      final imageFile = File(imageTestFile);
+      final expectedBytes = imageFile.readAsBytesSync();
 
-        final platformFile = await FilePickerUtils.createPlatformFile(
-          imageFile,
-          null,
-          null,
-        );
+      final platformFile = await FilePickerUtils.createPlatformFile(imageFile, null, null);
 
-        final bytes = await platformFile.readAsBytes();
+      final bytes = await platformFile.readAsBytes();
 
-        expect(bytes, equals(expectedBytes));
-      },
-    );
+      expect(bytes, equals(expectedBytes));
+    });
 
     test(
       'should not throw an exception when picking .app files on macOS (.app files on macOS are actually directories but they are treated as files, similar to .exe files on Windows)',
       () async {
         final appFile = File(appTestFilePath);
 
-        final platformFile = await FilePickerUtils.createPlatformFile(
-          appFile,
-          null,
-          null,
-        );
+        final platformFile = await FilePickerUtils.createPlatformFile(appFile, null, null);
 
         expect(platformFile.bytes, equals(null));
         expect(platformFile.name, equals('test_utils.app'));
         expect(platformFile.readStream, equals(null));
-        expect(
-          platformFile.size,
-          equals(0),
-          reason: 'Expect size to be 0 because .app files are directories.',
-        );
+        expect(platformFile.size, equals(0), reason: 'Expect size to be 0 because .app files are directories.');
       },
     );
   });
 
   group('filePathsToPlatformFiles()', () {
-    test(
-      'should transform a list of file paths into a list of PlatformFiles',
-      () async {
-        final filePaths = [imageTestFile, pdfTestFile, yamlTestFile];
+    test('should transform a list of file paths into a list of PlatformFiles', () async {
+      final filePaths = [imageTestFile, pdfTestFile, yamlTestFile];
 
-        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
-          filePaths,
-        );
+      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths);
 
-        expect(platformFiles.length, equals(filePaths.length));
+      expect(platformFiles.length, equals(filePaths.length));
 
-        final imageFile = platformFiles.firstWhere(
-          (element) => element.name == 'test_utils.jpg',
-        );
-        expect(imageFile.extension, equals('jpg'));
-        expect(imageFile.name, equals('test_utils.jpg'));
-        expect(imageFile.path, equals(imageTestFile));
-        expect(imageFile.size, equals(4073378));
+      final imageFile = platformFiles.firstWhere((element) => element.name == 'test_utils.jpg');
+      expect(imageFile.extension, equals('jpg'));
+      expect(imageFile.name, equals('test_utils.jpg'));
+      expect(imageFile.path, equals(imageTestFile));
+      expect(imageFile.size, equals(4073378));
 
-        final pdfFile = platformFiles.firstWhere(
-          (element) => element.name == 'test_utils.pdf',
-        );
-        expect(pdfFile.extension, equals('pdf'));
-        expect(pdfFile.name, equals('test_utils.pdf'));
-        expect(pdfFile.path, equals(pdfTestFile));
-        expect(pdfFile.size, equals(7478));
+      final pdfFile = platformFiles.firstWhere((element) => element.name == 'test_utils.pdf');
+      expect(pdfFile.extension, equals('pdf'));
+      expect(pdfFile.name, equals('test_utils.pdf'));
+      expect(pdfFile.path, equals(pdfTestFile));
+      expect(pdfFile.size, equals(7478));
 
-        final yamlFile = platformFiles.firstWhere(
-          (element) => element.name == 'test_utils.yml',
-        );
-        expect(yamlFile.extension, equals('yml'));
-        expect(yamlFile.name, equals('test_utils.yml'));
-        expect(yamlFile.path, equals(yamlTestFile));
-        expect(yamlFile.size, equals(213));
-      },
-    );
+      final yamlFile = platformFiles.firstWhere((element) => element.name == 'test_utils.yml');
+      expect(yamlFile.extension, equals('yml'));
+      expect(yamlFile.name, equals('test_utils.yml'));
+      expect(yamlFile.path, equals(yamlTestFile));
+      expect(yamlFile.size, equals(213));
+    });
 
-    test(
-      'should transform an empty list of file paths into an empty list of PlatformFiles',
-      () async {
-        final filePaths = <String>[];
+    test('should transform an empty list of file paths into an empty list of PlatformFiles', () async {
+      final filePaths = <String>[];
 
-        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
-          filePaths,
-        );
+      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths);
 
-        expect(platformFiles.length, equals(filePaths.length));
-      },
-    );
+      expect(platformFiles.length, equals(filePaths.length));
+    });
 
-    test(
-      'should transform a list of file paths containing a path into a list of PlatformFiles',
-      () async {
-        final filePaths = <String>['test'];
+    test('should transform a list of file paths containing a path into a list of PlatformFiles', () async {
+      final filePaths = <String>['test'];
 
-        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
-          filePaths,
-          withReadStream: true,
-        );
+      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths, withReadStream: true);
 
-        expect(platformFiles.length, equals(filePaths.length));
-      },
-    );
+      expect(platformFiles.length, equals(filePaths.length));
+    });
 
-    test(
-      'should transform a list of file paths containing a valid path into a list of PlatformFiles',
-      () async {
-        final filePaths = <String>['test/test_files/test.pdf'];
+    test('should transform a list of file paths containing a valid path into a list of PlatformFiles', () async {
+      final filePaths = <String>['test/test_files/test.pdf'];
 
-        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
-          filePaths,
-          withData: true,
-        );
+      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths, withData: true);
 
-        expect(platformFiles.length, equals(filePaths.length));
-      },
-    );
-  });
-
-  group('runExecutableWithArguments()', () {
-    test('should catch an exception when sending an empty filepath', () async {
-      final filepath = '';
-
-      expect(
-        () async => await FilePickerUtils.isExecutableOnPath(filepath),
-        throwsA(isA<Exception>()),
-      );
+      expect(platformFiles.length, equals(filePaths.length));
     });
   });
 

--- a/test/file_picker_utils_test.dart
+++ b/test/file_picker_utils_test.dart
@@ -13,9 +13,23 @@ void main() {
   final pdfTestFile = '/tmp/test_utils.pdf';
   final yamlTestFile = '/tmp/test_utils.yml';
 
-  setUpAll(() => setUpTestFiles(appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile));
+  setUpAll(
+    () => setUpTestFiles(
+      appTestFilePath,
+      imageTestFile,
+      pdfTestFile,
+      yamlTestFile,
+    ),
+  );
 
-  tearDownAll(() => tearDownTestFiles(appTestFilePath, imageTestFile, pdfTestFile, yamlTestFile));
+  tearDownAll(
+    () => tearDownTestFiles(
+      appTestFilePath,
+      imageTestFile,
+      pdfTestFile,
+      yamlTestFile,
+    ),
+  );
 
   group('createPlatformFile()', () {
     test('should return an instance of PlatformFile', () async {
@@ -23,7 +37,11 @@ void main() {
       final bytes = imageFile.readAsBytesSync();
       final readStream = imageFile.openRead();
 
-      final platformFile = await FilePickerUtils.createPlatformFile(imageFile, bytes, readStream);
+      final platformFile = await FilePickerUtils.createPlatformFile(
+        imageFile,
+        bytes,
+        readStream,
+      );
 
       expect(platformFile.bytes, equals(bytes));
       expect(platformFile.name, equals('test_utils.jpg'));
@@ -33,82 +51,125 @@ void main() {
       expect(platformFile.toString(), isNot(contains('Uint8List')));
     });
 
-    test('should read bytes from the file path when bytes are not available', () async {
-      final imageFile = File(imageTestFile);
-      final expectedBytes = imageFile.readAsBytesSync();
+    test(
+      'should read bytes from the file path when bytes are not available',
+      () async {
+        final imageFile = File(imageTestFile);
+        final expectedBytes = imageFile.readAsBytesSync();
 
-      final platformFile = await FilePickerUtils.createPlatformFile(imageFile, null, null);
+        final platformFile = await FilePickerUtils.createPlatformFile(
+          imageFile,
+          null,
+          null,
+        );
 
-      final bytes = await platformFile.readAsBytes();
+        final bytes = await platformFile.readAsBytes();
 
-      expect(bytes, equals(expectedBytes));
-    });
+        expect(bytes, equals(expectedBytes));
+      },
+    );
 
     test(
       'should not throw an exception when picking .app files on macOS (.app files on macOS are actually directories but they are treated as files, similar to .exe files on Windows)',
       () async {
         final appFile = File(appTestFilePath);
 
-        final platformFile = await FilePickerUtils.createPlatformFile(appFile, null, null);
+        final platformFile = await FilePickerUtils.createPlatformFile(
+          appFile,
+          null,
+          null,
+        );
 
         expect(platformFile.bytes, equals(null));
         expect(platformFile.name, equals('test_utils.app'));
         expect(platformFile.readStream, equals(null));
-        expect(platformFile.size, equals(0), reason: 'Expect size to be 0 because .app files are directories.');
+        expect(
+          platformFile.size,
+          equals(0),
+          reason: 'Expect size to be 0 because .app files are directories.',
+        );
       },
     );
   });
 
   group('filePathsToPlatformFiles()', () {
-    test('should transform a list of file paths into a list of PlatformFiles', () async {
-      final filePaths = [imageTestFile, pdfTestFile, yamlTestFile];
+    test(
+      'should transform a list of file paths into a list of PlatformFiles',
+      () async {
+        final filePaths = [imageTestFile, pdfTestFile, yamlTestFile];
 
-      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths);
+        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
+          filePaths,
+        );
 
-      expect(platformFiles.length, equals(filePaths.length));
+        expect(platformFiles.length, equals(filePaths.length));
 
-      final imageFile = platformFiles.firstWhere((element) => element.name == 'test_utils.jpg');
-      expect(imageFile.extension, equals('jpg'));
-      expect(imageFile.name, equals('test_utils.jpg'));
-      expect(imageFile.path, equals(imageTestFile));
-      expect(imageFile.size, equals(4073378));
+        final imageFile = platformFiles.firstWhere(
+          (element) => element.name == 'test_utils.jpg',
+        );
+        expect(imageFile.extension, equals('jpg'));
+        expect(imageFile.name, equals('test_utils.jpg'));
+        expect(imageFile.path, equals(imageTestFile));
+        expect(imageFile.size, equals(4073378));
 
-      final pdfFile = platformFiles.firstWhere((element) => element.name == 'test_utils.pdf');
-      expect(pdfFile.extension, equals('pdf'));
-      expect(pdfFile.name, equals('test_utils.pdf'));
-      expect(pdfFile.path, equals(pdfTestFile));
-      expect(pdfFile.size, equals(7478));
+        final pdfFile = platformFiles.firstWhere(
+          (element) => element.name == 'test_utils.pdf',
+        );
+        expect(pdfFile.extension, equals('pdf'));
+        expect(pdfFile.name, equals('test_utils.pdf'));
+        expect(pdfFile.path, equals(pdfTestFile));
+        expect(pdfFile.size, equals(7478));
 
-      final yamlFile = platformFiles.firstWhere((element) => element.name == 'test_utils.yml');
-      expect(yamlFile.extension, equals('yml'));
-      expect(yamlFile.name, equals('test_utils.yml'));
-      expect(yamlFile.path, equals(yamlTestFile));
-      expect(yamlFile.size, equals(213));
-    });
+        final yamlFile = platformFiles.firstWhere(
+          (element) => element.name == 'test_utils.yml',
+        );
+        expect(yamlFile.extension, equals('yml'));
+        expect(yamlFile.name, equals('test_utils.yml'));
+        expect(yamlFile.path, equals(yamlTestFile));
+        expect(yamlFile.size, equals(213));
+      },
+    );
 
-    test('should transform an empty list of file paths into an empty list of PlatformFiles', () async {
-      final filePaths = <String>[];
+    test(
+      'should transform an empty list of file paths into an empty list of PlatformFiles',
+      () async {
+        final filePaths = <String>[];
 
-      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths);
+        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
+          filePaths,
+        );
 
-      expect(platformFiles.length, equals(filePaths.length));
-    });
+        expect(platformFiles.length, equals(filePaths.length));
+      },
+    );
 
-    test('should transform a list of file paths containing a path into a list of PlatformFiles', () async {
-      final filePaths = <String>['test'];
+    test(
+      'should transform a list of file paths containing a path into a list of PlatformFiles',
+      () async {
+        final filePaths = <String>['test'];
 
-      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths, withReadStream: true);
+        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
+          filePaths,
+          withReadStream: true,
+        );
 
-      expect(platformFiles.length, equals(filePaths.length));
-    });
+        expect(platformFiles.length, equals(filePaths.length));
+      },
+    );
 
-    test('should transform a list of file paths containing a valid path into a list of PlatformFiles', () async {
-      final filePaths = <String>['test/test_files/test.pdf'];
+    test(
+      'should transform a list of file paths containing a valid path into a list of PlatformFiles',
+      () async {
+        final filePaths = <String>['test/test_files/test.pdf'];
 
-      final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(filePaths, withData: true);
+        final platformFiles = await FilePickerUtils.filePathsToPlatformFiles(
+          filePaths,
+          withData: true,
+        );
 
-      expect(platformFiles.length, equals(filePaths.length));
-    });
+        expect(platformFiles.length, equals(filePaths.length));
+      },
+    );
   });
 
   group('isAlpha()', () {


### PR DESCRIPTION
This PR adds a package for `file_picker_platform_interface`, which will be the base for the federated plugin.

Note: This is only the platform interface itself.

@vicajilau Provide as much feedback on the API itself. There are some notable changes to the interface:

1) There is a `pickFile()` method that returns a PlatformFile, or null if canceled
2) `pickFiles()` returns a list of PlatformFile, instead of a wrapper class around the list
3) I removed the deprecated options for now (we could add those back later for the transition? I'd rather not, since there was a beta where it was deprecated, so people had time) We can write a migration guid on the Wiki and link it in the changelog.
I would rather bite the bullet and clean it up for good.
4) `pickFileAndDirectoryPaths` no longer returns null. I think that an empty list here is good enough for the same result. Saves a null check.
5) `clearTemporaryFiles()` now returns `Future<void>`. I don't know if the nullable boolean was ever useful.
6) `saveFile()` now no longer accepts allowed extensions / type. Instead I added a `mimeType` for the type hint and I would think that we make the `fileName` include the extension.
7) Since `saveFile()`'s return type was actually somewhat ambiguous / undocumented in places, I changed the return type to `Uri?`. Then we can do file paths, blob/data urls, and Android content Uris. Null is for when the operation is cancelled.