### PR TITLE
feat(android): extract file_picker_android package

### DIFF
--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release of Android implementation package for `file_picker`.

--- a/packages/file_picker_android/README.md
+++ b/packages/file_picker_android/README.md
@@ -1,0 +1,7 @@
+# file_picker_android
+
+The Android implementation of `file_picker`.
+
+## Usage
+
+This package is endorsed, which means you can simply use `file_picker` as normal, and the Android implementation will be automatically included.

--- a/packages/file_picker_android/android/build.gradle.kts
+++ b/packages/file_picker_android/android/build.gradle.kts
@@ -1,0 +1,88 @@
+import com.android.build.gradle.LibraryExtension
+import groovy.lang.GroovyObject
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withGroovyBuilder
+
+group = "com.mr.flutter.plugin.filepicker"
+version = "1.0-SNAPSHOT"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.5.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+fun GroovyObject.intProperty(name: String): Int {
+    val value = getProperty(name)
+    return when (value) {
+        is Number -> value.toInt()
+        is String -> value.toInt()
+        else -> error("Property '$name' is not an Int-compatible value: $value")
+    }
+}
+
+val agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    .substringBefore('.')
+    .toInt()
+val builtInKotlinProperty = providers.gradleProperty("android.builtInKotlin").orNull
+val isBuiltInKotlinEnabled = agpVersion >= 9 &&
+    (builtInKotlinProperty == null || builtInKotlinProperty.toBoolean())
+val shouldApplyKotlinAndroidPlugin = agpVersion < 9 || !isBuiltInKotlinEnabled
+
+apply(plugin = "com.android.library")
+if (shouldApplyKotlinAndroidPlugin) {
+    apply(plugin = "org.jetbrains.kotlin.android")
+}
+
+val flutterExtension = extensions.getByName("flutter") as GroovyObject
+val flutterCompileSdkVersion = flutterExtension.intProperty("compileSdkVersion")
+
+configure<LibraryExtension> {
+    compileSdk = flutterCompileSdkVersion
+    namespace = "com.mr.flutter.plugin.filepicker"
+
+    defaultConfig {
+        minSdk = 21
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("proguard-rules.pro")
+    }
+
+    lint {
+        disable += "InvalidPackage"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    if (shouldApplyKotlinAndroidPlugin) {
+        withGroovyBuilder {
+            "kotlinOptions" {
+                setProperty("jvmTarget", JavaVersion.VERSION_17.toString())
+            }
+        }
+    }
+}
+
+dependencies {
+    add("implementation", "androidx.core:core:1.18.0")
+    add("implementation", "androidx.core:core-ktx:1.18.0")
+    add("implementation", "androidx.annotation:annotation:1.10.0")
+    add("implementation", "androidx.lifecycle:lifecycle-runtime:2.10.0")
+    add("implementation", "org.apache.tika:tika-core:3.3.0")
+}
+

--- a/packages/file_picker_android/android/proguard-rules.pro
+++ b/packages/file_picker_android/android/proguard-rules.pro
@@ -1,0 +1,8 @@
+#TIKA PROGUARD RULES
+-keep class org.apache.tika.** { *; }
+-keep class javax.xml.stream.XMLResolver.** { *; }
+-dontwarn javax.xml.stream.XMLInputFactory
+-dontwarn javax.xml.stream.XMLResolver
+-dontwarn javax.xml.stream.XMLStreamException
+-dontwarn org.osgi.**
+-dontwarn aQute.bnd.annotation.**

--- a/packages/file_picker_android/android/src/main/AndroidManifest.xml
+++ b/packages/file_picker_android/android/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.mr.flutter.plugin.filepicker">
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.GET_CONTENT" />
+      <data android:mimeType="*/*" />
+    </intent>
+  </queries>
+</manifest>

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileInfo.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileInfo.kt
@@ -1,0 +1,73 @@
+package com.mr.flutter.plugin.filepicker
+
+import android.net.Uri
+
+class FileInfo(
+    val path: String?,
+    val name: String?,
+    val uri: Uri?,
+    val size: Long,
+    val bytes: ByteArray?,
+    val safHandle: java.util.HashMap<String, Any>? = null
+) {
+    class Builder {
+        private var path: String? = null
+        private var name: String? = null
+        private var uri: Uri? = null
+        private var size: Long = 0
+        private var bytes: ByteArray? = null
+        private var safHandle: java.util.HashMap<String, Any>? = null
+
+        fun withPath(path: String?): Builder {
+            this.path = path
+            return this
+        }
+
+        fun withName(name: String?): Builder {
+            this.name = name
+            return this
+        }
+
+        fun withSize(size: Long): Builder {
+            this.size = size
+            return this
+        }
+
+        fun withData(bytes: ByteArray): Builder {
+            this.bytes = bytes
+            return this
+        }
+
+        fun withUri(uri: Uri?): Builder {
+            this.uri = uri
+            return this
+        }
+
+        fun withSafHandle(safHandle: java.util.HashMap<String, Any>?): Builder {
+            this.safHandle = safHandle
+            return this
+        }
+
+        fun build(): FileInfo {
+            return FileInfo(
+                this.path,
+                this.name,
+                this.uri,
+                this.size,
+                this.bytes,
+                this.safHandle
+            )
+        }
+    }
+
+    fun toMap(): HashMap<String, Any?> {
+        return hashMapOf<String, Any?>(
+            Pair("path", path),
+            Pair("name", name),
+            Pair("size", size),
+            Pair("bytes", bytes),
+            Pair("identifier", uri.toString()),
+            Pair("safHandle", safHandle)
+        )
+    }
+}

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerDelegate.kt
@@ -1,0 +1,149 @@
+package com.mr.flutter.plugin.filepicker
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.mr.flutter.plugin.filepicker.FileUtils.maybeRenameGenericMimeDuplicate
+import com.mr.flutter.plugin.filepicker.FileUtils.processFiles
+import io.flutter.plugin.common.EventChannel.EventSink
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class FilePickerDelegate(
+    val activity: Activity,
+    var pendingResult: MethodChannel.Result? = null
+) : ActivityResultListener {
+
+    companion object {
+        const val TAG = "FilePickerDelegate"
+        const val REQUEST_CODE = 0x4F50
+        const val SAVE_FILE_CODE = 0x4F51
+
+        fun finishWithAlreadyActiveError(result: MethodChannel.Result) {
+            result.error("already_active", "File picker is already active", null)
+        }
+    }
+
+    var isMultipleSelection = false
+    var loadDataToMemory = false
+    var type: String? = null
+    var compressionQuality = 0
+    var allowedExtensions: ArrayList<String>? = null
+    var eventSink: EventSink? = null
+    var bytes: ByteArray? = null
+    var saveFileName: String? = null
+    var saveMimeType: String? = null
+    var androidSafOptions: java.util.HashMap<*, *>? = null
+
+    fun setEventHandler(eventSink: EventSink?) {
+        this.eventSink = eventSink
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        return when (requestCode) {
+            SAVE_FILE_CODE -> handleSaveFileResult(resultCode, data)
+            REQUEST_CODE -> handleFilePickerResult(resultCode, data)
+            else -> false.also {
+                finishWithError(
+                    "unknown_activity",
+                    "Unknown activity error, please file an issue."
+                )
+            }
+        }
+    }
+
+    private fun handleSaveFileResult(resultCode: Int, data: Intent?): Boolean {
+        return when (resultCode) {
+            Activity.RESULT_OK -> saveFile(data?.data)
+            Activity.RESULT_CANCELED -> {
+                finishWithSuccess(null)
+                false
+            }
+
+            else -> false
+        }
+    }
+
+    private fun saveFile(uri: Uri?): Boolean {
+        uri ?: return false
+        dispatchEventStatus(true)
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val savedUri = FileUtils.writeBytesData(context = activity, uri, bytes) ?: uri
+                val renamedUri = maybeRenameGenericMimeDuplicate(
+                    context = activity,
+                    uri = savedUri,
+                    originalFileName = saveFileName,
+                    mimeType = saveMimeType
+                )
+                Handler(Looper.getMainLooper()).post {
+                    finishWithSuccess(renamedUri.path)
+                }
+            } catch (e: IOException) {
+                Log.e(TAG, "Error while saving file", e)
+                Handler(Looper.getMainLooper()).post {
+                    finishWithError("Error while saving file", e.message)
+                }
+            }
+        }
+        return true
+    }
+
+    private fun handleFilePickerResult(resultCode: Int, data: Intent?): Boolean {
+        return when (resultCode) {
+            Activity.RESULT_OK -> {
+                dispatchEventStatus(true)
+                processFiles(activity, data, compressionQuality, loadDataToMemory, type.orEmpty(), androidSafOptions)
+                true
+            }
+
+            Activity.RESULT_CANCELED -> {
+                finishWithSuccess(null)
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    fun setPendingMethodCallResult(result: MethodChannel.Result): Boolean {
+        return if (pendingResult == null) {
+            pendingResult = result
+            true
+        } else {
+            false
+        }
+    }
+
+    fun finishWithSuccess(data: Any?) {
+        dispatchEventStatus(false)
+        pendingResult?.let {
+            it.success(data?.takeIf { it is String }
+                ?: (data as? ArrayList<*>)?.mapNotNull { (it as? FileInfo)?.toMap() })
+            clearPendingResult()
+        }
+    }
+
+    fun finishWithError(errorCode: String, errorMessage: String?) {
+        dispatchEventStatus(false)
+        pendingResult?.error(errorCode, errorMessage, null)
+        clearPendingResult()
+    }
+
+    private fun dispatchEventStatus(status: Boolean) {
+        if (eventSink != null && type != "dir") {
+            Handler(Looper.getMainLooper()).post { eventSink?.success(status) }
+        }
+    }
+
+    private fun clearPendingResult() {
+        pendingResult = null
+    }
+}

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -1,0 +1,280 @@
+package com.mr.flutter.plugin.filepicker
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.mr.flutter.plugin.filepicker.FileUtils.clearCache
+import com.mr.flutter.plugin.filepicker.FileUtils.getFileExtension
+import com.mr.flutter.plugin.filepicker.FileUtils.getMimeTypes
+import com.mr.flutter.plugin.filepicker.FileUtils.saveFile
+import com.mr.flutter.plugin.filepicker.FileUtils.startFileExplorer
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.EventChannel.EventSink
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+
+/**
+ * FilePickerPlugin
+ */
+class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
+    ActivityAware {
+
+    companion object {
+        private const val TAG = "FilePicker"
+        private const val CHANNEL = "miguelruivo.flutter.plugins.filepicker"
+        private const val EVENT_CHANNEL = "miguelruivo.flutter.plugins.filepickerevent"
+
+        private fun resolveType(type: String): String? {
+            return when (type) {
+                "audio" -> "audio/*"
+                "image" -> "image/*"
+                "video" -> "video/*"
+                "media" -> "media"
+                "any", "custom" -> "*/*"
+                "dir" -> "dir"
+                else -> null
+            }
+        }
+    }
+
+    private inner class LifeCycleObserver
+        (private val thisActivity: Activity) : Application.ActivityLifecycleCallbacks,
+        DefaultLifecycleObserver {
+        override fun onCreate(owner: LifecycleOwner) {
+        }
+
+        override fun onStart(owner: LifecycleOwner) {
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+        }
+
+        override fun onPause(owner: LifecycleOwner) {
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            this.onActivityStopped(this.thisActivity)
+        }
+
+        override fun onDestroy(owner: LifecycleOwner) {
+            this.onActivityDestroyed(this.thisActivity)
+        }
+
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        }
+
+        override fun onActivityStarted(activity: Activity) {
+        }
+
+        override fun onActivityResumed(activity: Activity) {
+        }
+
+        override fun onActivityPaused(activity: Activity) {
+        }
+
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        }
+
+        override fun onActivityDestroyed(activity: Activity) {
+            // Use getApplicationContext() to avoid casting failures
+            if (this.thisActivity === activity && activity.applicationContext != null) {
+                (activity.applicationContext as Application).unregisterActivityLifecycleCallbacks(
+                    this
+                )
+            }
+        }
+
+        override fun onActivityStopped(activity: Activity) {
+        }
+    }
+
+    private var activityBinding: ActivityPluginBinding? = null
+    private var delegate: FilePickerDelegate? = null
+    private var application: Application? = null
+    private var pluginBinding: FlutterPluginBinding? = null
+
+    // TODO: Remove references to v1 embedding once the minimum Flutter version is >= 3.29
+    // See: https://docs.flutter.dev/release/breaking-changes/v1-android-embedding
+    // This will be null when not using the v2 embedding
+    private var lifecycle: Lifecycle? = null
+    private var observer: LifeCycleObserver? = null
+    private var activity: Activity? = null
+    private var channel: MethodChannel? = null
+
+    override fun onMethodCall(call: MethodCall, rawResult: MethodChannel.Result) {
+        if (this.activity == null) {
+            rawResult.error(
+                "no_activity",
+                "file picker plugin requires a foreground activity",
+                null
+            )
+            return
+        }
+
+        val result: MethodChannel.Result = MethodResultWrapper(rawResult)
+        val arguments = call.arguments as? HashMap<*, *>
+        val method = call.method
+
+        when (method) {
+            "clear" -> {
+                result.success(activity?.applicationContext?.let { clearCache(it) })
+            }
+
+            "releaseSafGrant" -> {
+                val uriStr = arguments?.get("uri") as? String
+                if (uriStr == null) {
+                  result.success(null)
+                  return
+                }
+                
+                try {
+                    val uri = android.net.Uri.parse(uriStr)
+                    val flags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    activity?.applicationContext?.contentResolver?.releasePersistableUriPermission(uri, flags)
+                } catch (e: SecurityException) {
+                    // Ignore if we didn't have the permission or it was already released
+                    android.util.Log.e(TAG, "Failed to release SAF permission for $uriStr", e)
+                }
+                result.success(null)
+            }
+
+            "save" -> {
+                val type = resolveType(arguments?.get("fileType") as String)
+                val initialDirectory = arguments?.get("initialDirectory") as String?
+                val bytes = arguments?.get("bytes") as ByteArray?
+                val fileNameWithoutExtension = "${arguments?.get("fileName")}"
+                val fileName =
+                    if (fileNameWithoutExtension.isNotEmpty() && !fileNameWithoutExtension.contains(
+                            "."
+                        )
+                    ) "$fileNameWithoutExtension.${getFileExtension(bytes)}" else fileNameWithoutExtension
+                delegate?.saveFile(fileName, type, initialDirectory, bytes, result)
+            }
+
+            "custom" -> {
+                val allowedExtensions =
+                    getMimeTypes(arguments?.get("allowedExtensions") as ArrayList<String>?)
+                val androidSafOptions = arguments?.get("androidSafOptions") as? java.util.HashMap<*, *>
+                delegate?.startFileExplorer(
+                    resolveType(method),
+                    arguments?.get("allowMultipleSelection") as Boolean?,
+                    arguments?.get("withData") as Boolean?,
+                    allowedExtensions,
+                    arguments?.get("compressionQuality") as Int?,
+                    androidSafOptions,
+                    result
+                )
+            }
+
+            else -> {
+                val fileType = resolveType(method)
+                if (fileType == null) {
+                    result.notImplemented()
+                    return
+                }
+
+                val androidSafOptions = arguments?.get("androidSafOptions") as? java.util.HashMap<*, *>
+                delegate?.startFileExplorer(
+                    fileType,
+                    arguments?.get("allowMultipleSelection") as Boolean?,
+                    arguments?.get("withData") as Boolean?,
+                    arrayListOf(),
+                    arguments?.get("compressionQuality") as Int?,
+                    androidSafOptions,
+                    result
+                )
+            }
+        }
+    }
+
+    private fun setup(
+        messenger: BinaryMessenger,
+        application: Application,
+        activity: Activity,
+        activityBinding: ActivityPluginBinding
+    ) {
+        this.activity = activity
+        this.application = application
+        this.delegate = FilePickerDelegate(activity)
+        this.channel = MethodChannel(messenger, CHANNEL)
+        channel?.setMethodCallHandler(this)
+        delegate?.let { it ->
+            EventChannel(messenger, EVENT_CHANNEL).setStreamHandler(object :
+                EventChannel.StreamHandler {
+                override fun onListen(arguments: Any?, events: EventSink?) {
+                    it.setEventHandler(events)
+                }
+
+                override fun onCancel(arguments: Any?) {
+                    it.setEventHandler(null)
+                }
+            })
+            this.observer = LifeCycleObserver(activity)
+
+            // V2 embedding setup for activity listeners.
+            activityBinding.addActivityResultListener(it)
+            this.lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding)
+            observer?.let { it -> lifecycle?.addObserver(it) }
+        }
+    }
+
+    private fun tearDown() {
+        delegate?.let { it ->
+            activityBinding?.removeActivityResultListener(it)
+        }
+        this.activityBinding = null
+        observer?.let { it ->
+            lifecycle?.removeObserver(it)
+            application?.unregisterActivityLifecycleCallbacks(it)
+        }
+        this.lifecycle = null
+        delegate?.setEventHandler(null)
+        this.delegate = null
+        channel?.setMethodCallHandler(null)
+        this.channel = null
+        this.application = null
+    }
+
+    override fun onAttachedToEngine(binding: FlutterPluginBinding) {
+        this.pluginBinding = binding
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
+        this.pluginBinding = null
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        this.activityBinding = binding
+        pluginBinding?.let { it ->
+            this.setup(
+                it.binaryMessenger,
+                it.applicationContext as Application,
+                activityBinding!!.activity,
+                activityBinding!!
+            )
+        }
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        this.onDetachedFromActivity()
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        this.onAttachedToActivity(binding)
+    }
+
+    override fun onDetachedFromActivity() {
+        this.tearDown()
+    }
+}

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -103,9 +103,6 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
     private var application: Application? = null
     private var pluginBinding: FlutterPluginBinding? = null
 
-    // TODO: Remove references to v1 embedding once the minimum Flutter version is >= 3.29
-    // See: https://docs.flutter.dev/release/breaking-changes/v1-android-embedding
-    // This will be null when not using the v2 embedding
     private var lifecycle: Lifecycle? = null
     private var observer: LifeCycleObserver? = null
     private var activity: Activity? = null

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -1,0 +1,902 @@
+package com.mr.flutter.plugin.filepicker
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.Environment
+import android.os.Parcelable
+import android.provider.DocumentsContract
+import android.provider.OpenableColumns
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.net.toUri
+import com.mr.flutter.plugin.filepicker.FilePickerDelegate.Companion.REQUEST_CODE
+import com.mr.flutter.plugin.filepicker.FilePickerDelegate.Companion.SAVE_FILE_CODE
+import com.mr.flutter.plugin.filepicker.FilePickerDelegate.Companion.finishWithAlreadyActiveError
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.apache.tika.Tika
+import org.apache.tika.io.TikaInputStream
+import org.apache.tika.metadata.Metadata
+import org.apache.tika.metadata.TikaCoreProperties
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object FileUtils {
+    private const val TAG = "FilePickerUtils"
+    private const val MAX_RENAME_ATTEMPTS = 20
+    // On Android, the CSV mime type from getMimeTypeFromExtension() returns
+    // "text/comma-separated-values" which is non-standard and doesn't filter
+    // CSV files in Google Drive.
+    // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+    // (see https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java#439)
+    private const val CSV_EXTENSION = "csv"
+    private const val CSV_MIME_TYPE = "text/csv"
+    // Maximum dimension (width or height) allowed when decoding an image for
+    // compression. Images larger than this are subsampled via
+    // BitmapFactory.Options.inSampleSize to avoid excessive memory usage
+    // (see https://developer.android.com/topic/performance/graphics/load-bitmap).
+    // 4096 matches the common GPU texture size limit, so regular photos are
+    // decoded at full resolution and only unusually large images are downscaled.
+    private const val MAX_COMPRESSED_IMAGE_DIMENSION = 4096
+
+    fun FilePickerDelegate.processFiles(
+        activity: Activity,
+        data: Intent?,
+        compressionQuality: Int,
+        loadDataToMemory: Boolean,
+        type: String,
+        androidSafOptions: java.util.HashMap<*, *>?
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            if (data == null) {
+                finishWithError("unknown_activity", "Unknown activity error, please fill an issue.")
+                return@launch
+            }
+
+            val grantStr = androidSafOptions?.get("grant") as? String
+            val accessStr = androidSafOptions?.get("access") as? String
+            val autoPersist = (androidSafOptions?.get("autoPersist") as? Boolean) ?: true
+            
+            val isPersist = grantStr == "lifetime"
+            val isReadWrite = accessStr == "readWrite"
+
+            val hasSafOptions = androidSafOptions != null
+
+            fun maybeTakePersistableUriPermission(uri: Uri) {
+                 if (isPersist && autoPersist) {
+                     try {
+                         val flags = if (isReadWrite) {
+                            android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                         } else {
+                            android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+                         }
+                         activity.contentResolver.takePersistableUriPermission(uri, flags)
+                     } catch (e: SecurityException) {
+                         Log.e(TAG, "Failed to take persistable URI permission for $uri", e)
+                     }
+                 }
+            }
+
+            val files = mutableListOf<FileInfo>()
+
+            try {
+                when {
+                    data.clipData != null -> {
+                        for (i in 0 until data.clipData!!.itemCount) {
+                            var uri = data.clipData!!.getItemAt(i).uri
+                            maybeTakePersistableUriPermission(uri)
+                            uri = processUri(activity, uri, compressionQuality)
+                            addFile(activity, uri, loadDataToMemory, files, hasSafOptions, isReadWrite)
+                        }
+                        finishWithSuccess(files)
+                    }
+
+                    data.data != null -> {
+                        var uri = processUri(activity, data.data!!, compressionQuality)
+
+                        if (type == "dir") {
+                            maybeTakePersistableUriPermission(data.data!!)
+                            if (androidSafOptions != null) {
+                                finishWithSuccess(data.data!!.toString())
+                            } else {
+                                uri = DocumentsContract.buildDocumentUriUsingTree(
+                                    uri,
+                                    DocumentsContract.getTreeDocumentId(uri)
+                                )
+                                val dirPath = getFullPathFromTreeUri(uri, activity)
+                                if (dirPath != null) {
+                                    finishWithSuccess(dirPath)
+                                } else {
+                                    finishWithError("unknown_path", "Failed to retrieve directory path.")
+                                }
+                            }
+                        } else {
+                            maybeTakePersistableUriPermission(data.data!!)
+                            addFile(activity, uri, loadDataToMemory, files, hasSafOptions, isReadWrite)
+                            handleFileResult(files)
+                        }
+                    }
+
+                    data.extras?.containsKey("selectedItems") == true -> {
+                        val fileUris = getSelectedItems(data.extras!!)
+                        fileUris?.filterIsInstance<Uri>()?.forEach { uri ->
+                            maybeTakePersistableUriPermission(uri)
+                            addFile(activity, uri, loadDataToMemory, files, hasSafOptions, isReadWrite)
+                        }
+                        finishWithSuccess(files)
+                    }
+
+                    else -> finishWithError(
+                        "unknown_activity",
+                        "Unknown activity error, please fill an issue."
+                    )
+                }
+            } catch (oom: OutOfMemoryError) {
+                Log.e(TAG, "Out of memory while processing selected files.", oom)
+                finishWithError(
+                    "out_of_memory",
+                    "Selected files are too large to load into memory. Disable withData or use withReadStream."
+                )
+            } catch (e: Exception) {
+                finishWithError("file_picker_error", e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    fun writeBytesData(
+        context: Context,
+        uri: Uri,
+        bytes: ByteArray?
+    ): Uri {
+        context.contentResolver.openOutputStream(uri)?.use { output ->
+            bytes?.let {
+                output.write(it)
+            }
+        }
+
+        return uri
+    }
+
+    private fun FilePickerDelegate.handleFileResult(files: List<FileInfo>) {
+        if (files.isNotEmpty()) {
+            finishWithSuccess(files)
+        } else {
+            finishWithError("unknown_path", "Failed to retrieve path.")
+        }
+    }
+
+    /**
+     * Creates and launches an intent for the given file type.
+     *
+     * This method is responsible for creating the appropriate intent based on the type of file
+     * that is requested to be picked.
+     *
+     * This may be either a directory, a regular file, or a gallery pick.
+     */
+    fun FilePickerDelegate.startFileExplorer() {
+        val intent: Intent
+
+        // Temporary fix, remove this null-check after Flutter Engine 1.14 has landed on stable
+        if (type == null) {
+            return
+        }
+
+        if (type == "dir") {
+            intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+        } else {
+            if (type == "image/*") {
+                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    type = this@startFileExplorer.type
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
+                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
+                    if (!allowedExtensions.isNullOrEmpty()) {
+                        putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
+                    }
+                }
+            }
+            else if (type == "audio/*" ){
+                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    this.type = this@startFileExplorer.type
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
+                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        val authority = "com.android.providers.media.documents"
+                        val audioRootUri = DocumentsContract.buildRootUri(authority, "audio_root")
+                        putExtra(DocumentsContract.EXTRA_INITIAL_URI, audioRootUri)
+                    }
+                }
+            } else if(type == "video/*"){
+                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    this.type = this@startFileExplorer.type
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
+                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
+                }
+            }
+            else if (type == "media") {
+                intent = Intent(Intent.ACTION_GET_CONTENT)
+                intent.type = "*/*"
+                val mimeTypes = arrayOf("image/*", "video/*", "audio/*")
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
+                intent.addCategory(Intent.CATEGORY_OPENABLE)
+                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection)
+            } else {
+                intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = this@startFileExplorer.type
+                    if (!allowedExtensions.isNullOrEmpty()) {
+                        putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
+                    } else {
+                        putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(type))
+                    }
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection)
+                    putExtra("multi-pick", isMultipleSelection)
+                }
+            }
+        }
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivityForResult(intent, REQUEST_CODE)
+        } else {
+            Log.e(
+                FilePickerDelegate.TAG,
+                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
+            )
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you have a file explorer installed.")
+        }
+    }
+
+    /**
+     * Called by the plugin to start a new file explorer activity.
+     *
+     * @param type The file types that will be selectable.
+     * @param isMultipleSelection Whether multiple files can be selected.
+     * @param withData Whether the file data should be loaded into memory.
+     * @param allowedExtensions The allowed file extensions for custom file types.
+     * @param compressionQuality The compression quality for images.
+     * @param result The MethodChannel result to send the file picking result to.
+     */
+    fun FilePickerDelegate?.startFileExplorer(
+        type: String?,
+        isMultipleSelection: Boolean?,
+        withData: Boolean?,
+        allowedExtensions: ArrayList<String>,
+        compressionQuality: Int? = 0,
+        androidSafOptions: java.util.HashMap<*, *>?,
+        result: MethodChannel.Result
+    ) {
+        if (this?.setPendingMethodCallResult(result) == false) {
+            finishWithAlreadyActiveError(result)
+            return
+        }
+        this?.type = type
+        if (isMultipleSelection != null) {
+            this?.isMultipleSelection = isMultipleSelection
+        }
+        if (withData != null) {
+            this?.loadDataToMemory = withData
+        }
+        this?.allowedExtensions = allowedExtensions
+        if (compressionQuality != null) {
+            this?.compressionQuality = compressionQuality
+        }
+        this?.androidSafOptions = androidSafOptions
+
+        this?.startFileExplorer()
+    }
+
+    fun getFileExtension(bytes: ByteArray?): String {
+        val tika = Tika()
+        val mimeType = tika.detect(bytes)
+        return mimeType.substringAfter("/")
+    }
+
+    private fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
+        val tika = Tika()
+
+        val detectedType = if (fileName.isNullOrEmpty()) {
+            tika.detect(bytes)
+        } else {
+            val detector = tika.detector
+
+            val stream = TikaInputStream.get(bytes)
+            val metadata = Metadata()
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
+            detector.detect(stream, metadata).toString()
+        }
+        return if (detectedType == "text/plain") {
+            "*/*"
+        } else {
+            detectedType
+        }
+    }
+
+    fun FilePickerDelegate.saveFile(
+        fileName: String?,
+        type: String?,
+        initialDirectory: String?,
+        bytes: ByteArray?,
+        result: MethodChannel.Result
+    ) {
+        if (!this.setPendingMethodCallResult(result)) {
+            finishWithAlreadyActiveError(result)
+            return
+        }
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+        intent.addCategory(Intent.CATEGORY_OPENABLE)
+        if (!fileName.isNullOrEmpty()) {
+            intent.putExtra(Intent.EXTRA_TITLE, fileName)
+        }
+        this.bytes = bytes
+        this.saveFileName = fileName
+        if ("dir" != type) {
+            try {
+                intent.type = getMimeTypeForBytes(fileName = fileName, bytes = bytes)
+                this.saveMimeType = intent.type
+            } catch (t: Throwable) {
+                intent.type = "*/*"
+                this.saveMimeType = intent.type
+                Log.e(
+                    FilePickerDelegate.TAG,
+                    "Failed to detect mime type. $t"
+                )
+            }
+        }
+        if (!initialDirectory.isNullOrEmpty()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialDirectory.toUri())
+            }
+        }
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivityForResult(intent, SAVE_FILE_CODE)
+        } else {
+            Log.e(
+                FilePickerDelegate.TAG,
+                "Can't find a valid activity to handle the request. Make sure you've a file explorer installed."
+            )
+            finishWithError("explorer_not_found", "Can't find a valid activity to handle the request. Make sure you have a file explorer installed.")
+        }
+    }
+
+    fun maybeRenameGenericMimeDuplicate(
+        context: Context,
+        uri: Uri,
+        originalFileName: String?,
+        mimeType: String?
+    ): Uri {
+        if (originalFileName.isNullOrBlank()) {
+            return uri
+        }
+
+        val extension = originalFileName.substringAfterLast('.', "")
+        if (extension.isBlank()) {
+            return uri
+        }
+
+        val currentName = getFileName(uri, context) ?: return uri
+        val escapedExtension = Regex.escape(extension)
+
+        var (baseName, suffix) = extractBaseNameAndSuffix(currentName, escapedExtension)
+
+        // Clean up baseName if it already has one or more " (M)" suffixes to prevent nesting.
+        val normalized = normalizeBaseNameAndSuffix(baseName, suffix)
+        baseName = normalized.first
+        suffix = normalized.second
+
+        var finalUri = uri
+        var success = false
+        var currentSuffix = suffix ?: 0
+        var attempts = 0
+
+        while (!success && attempts < MAX_RENAME_ATTEMPTS) {
+            val targetName = when {
+                currentSuffix > 0 -> "$baseName ($currentSuffix).$extension"
+                else -> "$baseName.$extension"
+            }
+
+            if (targetName == currentName && attempts == 0) {
+                return uri
+            }
+
+            try {
+                val newUri = DocumentsContract.renameDocument(context.contentResolver, finalUri, targetName)
+                if (newUri != null) {
+                    val actualName = getFileName(newUri, context)
+                    if (actualName == targetName) {
+                        finalUri = newUri
+                        success = true
+                    } else {
+                        // The provider likely auto-suffixed because targetName exists (e.g., "file (1).ext" -> "file (1) (1).ext").
+                        // Update finalUri and increment our suffix to try to find a "clean" one ourselves.
+                        finalUri = newUri
+                        currentSuffix++
+                        attempts++
+                    }
+                } else {
+                    currentSuffix++
+                    attempts++
+                }
+            } catch (ex: Exception) {
+                currentSuffix++
+                attempts++
+                if (attempts >= MAX_RENAME_ATTEMPTS) {
+                    Log.w(
+                        TAG,
+                        "Failed to normalize saved document name from '$currentName' to '$targetName' after $MAX_RENAME_ATTEMPTS attempts. MIME=$mimeType, error=$ex"
+                    )
+                }
+            }
+        }
+
+        return finalUri
+    }
+
+    private fun extractBaseNameAndSuffix(currentName: String, escapedExtension: String): Pair<String, Int?> {
+        // Android duplicate style "name.ext (N)" that we normalize. Example: "report.pdf (1)"
+        val androidCollisionRegex = Regex("^(.*)\\.$escapedExtension \\((\\d+)\\)$")
+        // Desired style "name (N).ext"
+        val normalizedCollisionRegex = Regex("^(.*) \\((\\d+)\\)\\.$escapedExtension$")
+        // Regular "name.ext"
+        val plainNameRegex = Regex("^(.*)\\.$escapedExtension$")
+
+        return when {
+            androidCollisionRegex.matches(currentName) -> {
+                val match = androidCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            normalizedCollisionRegex.matches(currentName) -> {
+                val match = normalizedCollisionRegex.matchEntire(currentName)!!
+                match.groupValues[1] to match.groupValues[2].toInt()
+            }
+            plainNameRegex.matches(currentName) -> {
+                val match = plainNameRegex.matchEntire(currentName)!!
+                match.groupValues[1] to null
+            }
+            else -> {
+                currentName to null
+            }
+        }
+    }
+
+    private fun normalizeBaseNameAndSuffix(baseName: String, suffix: Int?): Pair<String, Int?> {
+        var normalizedBaseName = baseName
+        var normalizedSuffix = suffix
+        // Trailing numeric suffix chunk "name (N)" we repeatedly strip and accumulate.
+        // Example: "report (1)" -> base "report", suffix +1
+        val baseNameSuffixRegex = Regex("^(.*) \\((\\d+)\\)$")
+
+        while (true) {
+            val baseMatch = baseNameSuffixRegex.matchEntire(normalizedBaseName) ?: break
+
+            val realBase = baseMatch.groupValues[1]
+            val baseSuffix = baseMatch.groupValues[2].toInt()
+            normalizedBaseName = realBase
+            normalizedSuffix = (normalizedSuffix ?: 0) + baseSuffix
+        }
+
+        return normalizedBaseName to normalizedSuffix
+    }
+
+    private fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
+        return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
+            compressImage(uri, compressionQuality, activity.applicationContext)
+        } else {
+            uri
+        }
+    }
+
+    private fun addFile(
+        activity: Activity,
+        uri: Uri,
+        loadDataToMemory: Boolean,
+        files: MutableList<FileInfo>,
+        hasSafOptions: Boolean = false,
+        isReadWrite: Boolean = false
+    ) {
+        openFileStream(activity, uri, loadDataToMemory, hasSafOptions, isReadWrite)?.let { file ->
+            files.add(file)
+        }
+    }
+
+    @Suppress("deprecation")
+    private fun getSelectedItems(bundle: Bundle): ArrayList<Parcelable>? {
+        if (Build.VERSION.SDK_INT >= 33) {
+            return bundle.getParcelableArrayList("selectedItems", Parcelable::class.java)
+        }
+
+        return bundle.getParcelableArrayList("selectedItems")
+    }
+
+    fun getMimeTypes(allowedExtensions: ArrayList<String>?): ArrayList<String> {
+        if (allowedExtensions.isNullOrEmpty()) {
+            return ArrayList(listOf("*/*"))
+        }
+
+        val mimes = ArrayList<String>()
+
+        for (i in allowedExtensions.indices) {
+            val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                allowedExtensions[i]
+            )
+            if (mime == null) {
+                Log.w(
+                    TAG,
+                    "Custom file type '" + allowedExtensions[i] + "' is unsupported and will not be filtered."
+                )
+                return ArrayList(listOf("*/*"))
+            }
+
+            mimes.add(mime)
+            if(allowedExtensions[i] == CSV_EXTENSION) {
+                // Add the standard CSV mime type.
+                mimes.add(CSV_MIME_TYPE)
+            }
+        }
+        Log.d(
+            TAG,
+            "Custom file types are $allowedExtensions. The mime types were detected as $mimes."
+        )
+        return mimes
+    }
+
+    @JvmStatic
+    fun getFileName(uri: Uri, context: Context): String? {
+        var result: String? = null
+
+        try {
+            if (uri.scheme == "content") {
+                context.contentResolver.query(
+                    uri,
+                    arrayOf(OpenableColumns.DISPLAY_NAME),
+                    null,
+                    null,
+                    null
+                ).use { cursor ->
+                    if (cursor != null && cursor.moveToFirst()) {
+                        result =
+                            cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                    }
+                }
+            }
+            if (result == null) {
+                result = uri.path?.substringAfterLast('/')
+            }
+        } catch (ex: Exception) {
+            Log.e(
+                TAG,
+                "Failed to handle file name: $ex"
+            )
+        }
+
+        return result
+    }
+
+    @JvmStatic
+    fun isImage(context: Context, uri: Uri): Boolean {
+        val extension = getFileExtension(context, uri) ?: return false
+
+        return extension.contentEquals("jpg") || extension.contentEquals("jpeg")
+                || extension.contentEquals("png") || extension.contentEquals("webp")
+                || extension.contentEquals("heic") || extension.contentEquals("heif")
+    }
+
+    private fun getFileExtension(context: Context, uri: Uri): String? {
+        val contentResolver = context.contentResolver
+        val mimeType = contentResolver.getType(uri)
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+    }
+
+    private fun getCompressFormat(context: Context, uri: Uri): Bitmap.CompressFormat {
+        val format = getFileExtension(context, uri)
+        return when (format!!.uppercase(Locale.getDefault())) {
+            "PNG" -> Bitmap.CompressFormat.PNG
+            "WEBP" -> Bitmap.CompressFormat.WEBP
+            else -> Bitmap.CompressFormat.JPEG
+        }
+    }
+
+    private fun getCompressFormatBasedFileExtension(format: Bitmap.CompressFormat): String {
+        return when (format) {
+            Bitmap.CompressFormat.PNG -> "png"
+            Bitmap.CompressFormat.WEBP -> "webp"
+            else -> "jpeg"
+        }
+    }
+
+    @JvmStatic
+    fun compressImage(originalImageUri: Uri, compressionQuality: Int, context: Context): Uri {
+        val compressedUri: Uri
+        try {
+            // First pass: decode only the image bounds so a subsampling factor
+            // can be computed without loading the full bitmap into memory.
+            val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
+                BitmapFactory.decodeStream(imageStream, null, boundsOptions)
+            }
+            val decodeOptions = BitmapFactory.Options().apply {
+                inSampleSize = calculateInSampleSize(
+                    boundsOptions,
+                    MAX_COMPRESSED_IMAGE_DIMENSION,
+                    MAX_COMPRESSED_IMAGE_DIMENSION
+                )
+            }
+            context.contentResolver.openInputStream(originalImageUri).use { imageStream ->
+                val compressFormat = getCompressFormat(context, originalImageUri)
+                val compressedFile = createImageFile(context, compressFormat)
+                val originalBitmap = BitmapFactory.decodeStream(imageStream, null, decodeOptions)
+                    ?: throw IOException("Failed to decode image: $originalImageUri")
+                // Compress and save the image
+                val fileOutputStream = FileOutputStream(compressedFile)
+                originalBitmap.compress(compressFormat, compressionQuality, fileOutputStream)
+                fileOutputStream.flush()
+                fileOutputStream.close()
+                compressedUri = Uri.fromFile(compressedFile)
+            }
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        }
+        return compressedUri
+    }
+
+    /**
+     * Calculates the largest power-of-two [BitmapFactory.Options.inSampleSize]
+     * that keeps both dimensions at least as large as the requested size, as
+     * recommended by https://developer.android.com/topic/performance/graphics/load-bitmap.
+     */
+    private fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+        reqHeight: Int
+    ): Int {
+        val height = options.outHeight
+        val width = options.outWidth
+        var inSampleSize = 1
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight = height / 2
+            val halfWidth = width / 2
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
+
+    @Throws(IOException::class)
+    private fun createImageFile(context: Context, compressFormat: Bitmap.CompressFormat): File {
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+        val imageFileName = "IMAGE_" + timeStamp + "_"
+        val storageDir = context.cacheDir
+        return File.createTempFile(imageFileName, "." + getCompressFormatBasedFileExtension(compressFormat), storageDir)
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    private fun isDownloadsDocument(uri: Uri): Boolean {
+        return uri.authority == "com.android.providers.downloads.documents"
+    }
+
+    @JvmStatic
+    fun clearCache(context: Context): Boolean {
+        try {
+            val cacheDir = File(context.cacheDir.toString() + "/file_picker/")
+            recursiveDeleteFile(cacheDir)
+        } catch (ex: Exception) {
+            Log.e(
+                TAG,
+                "There was an error while clearing cached files: $ex"
+            )
+            return false
+        }
+        return true
+    }
+
+    private fun loadData(file: File, fileInfo: FileInfo.Builder) {
+        try {
+            val size = file.length().toInt()
+            val bytes = ByteArray(size)
+
+            try {
+                val buf = BufferedInputStream(FileInputStream(file))
+                buf.read(bytes, 0, bytes.size)
+                buf.close()
+            } catch (e: FileNotFoundException) {
+                Log.e(TAG, "File not found: " + e.message, null)
+            } catch (e: IOException) {
+                Log.e(TAG, "Failed to close file streams: " + e.message, null)
+            }
+            fileInfo.withData(bytes)
+        } catch (e: Exception) {
+            Log.e(
+                TAG,
+                "Failed to load bytes into memory with error $e. Probably the file is too big to fit device memory. Bytes won't be added to the file this time."
+            )
+        }
+    }
+
+    @JvmStatic
+    fun openFileStream(
+        context: Context, 
+        uri: Uri, 
+        withData: Boolean,
+        hasSafOptions: Boolean = false,
+        isReadWrite: Boolean = false
+    ): FileInfo? {
+        var fileInputStream: InputStream? = null
+        var fileOutputStream: FileOutputStream? = null
+        val fileInfo = FileInfo.Builder()
+        val fileName = getFileName(uri, context)
+        val path =
+            context.cacheDir.absolutePath + "/file_picker/" + System.currentTimeMillis() + "/" + (fileName
+                ?: "unamed")
+
+        val file = File(path)
+        
+        val safeDir = File(context.cacheDir.absolutePath + "/file_picker/").canonicalPath
+        if (!file.canonicalPath.startsWith(safeDir)) {
+            throw SecurityException("Path traversal detected. Escaping the intended cache directory is not allowed.")
+        }
+
+        if (!file.exists()) {
+            try {
+                file.parentFile?.mkdirs()
+
+                fileInputStream = context.contentResolver.openInputStream(uri)
+                fileOutputStream = FileOutputStream(file)
+
+                val out = BufferedOutputStream(fileOutputStream)
+                val buffer = ByteArray(8192)
+                var len: Int
+
+                while ((fileInputStream!!.read(buffer).also { len = it }) >= 0) {
+                    out.write(buffer, 0, len)
+                }
+                out.flush()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to retrieve and cache file: " + e.message, e)
+                return null
+            } finally {
+                try {
+                    fileOutputStream?.fd?.sync()
+                    fileOutputStream?.close()
+                    fileInputStream?.close()
+                } catch (ex: IOException) {
+                    Log.e(TAG, "Failed to close file streams: " + ex.message, ex)
+                }
+            }
+        }
+
+        if (withData) {
+            loadData(file, fileInfo)
+        }
+
+        fileInfo
+            .withPath(path)
+            .withName(fileName)
+            .withUri(uri)
+            .withSize(file.length())
+
+        if (hasSafOptions) {
+            val safHandleMap = java.util.HashMap<String, Any>()
+            safHandleMap["uri"] = uri.toString()
+            safHandleMap["access"] = if (isReadWrite) "readWrite" else "readOnly"
+            fileInfo.withSafHandle(safHandleMap)
+        }
+
+        return fileInfo.build()
+    }
+
+    private fun getPathFromTreeUri(uri: Uri): String {
+        val docId = DocumentsContract.getTreeDocumentId(uri)
+        val parts = docId.split(":")
+
+        // Check if the URI corresponds to external storage
+        return if (parts.size > 1) {
+            val volumeId = parts[0]
+            val path = parts[1]
+
+            // Map volume ID to external storage path
+            if ("primary".equals(volumeId, ignoreCase = true)) {
+                "${Environment.getExternalStorageDirectory()}/$path"
+            } else {
+                "/storage/$volumeId/$path"
+            }
+        } else {
+            "${Environment.getExternalStorageDirectory()}/${parts.last()}"
+        }
+    }
+
+    @JvmStatic
+    fun getFullPathFromTreeUri(treeUri: Uri?, context: Context): String? {
+        if (treeUri == null) {
+            return null
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            if (isDownloadsDocument(treeUri)) {
+                val docId = DocumentsContract.getDocumentId(treeUri)
+                val extPath =
+                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
+                if (docId == "downloads") {
+                    return extPath
+                } else if (docId.matches("^ms[df]:.*".toRegex())) {
+                    // Handle "msf:" (Media Store File) and "msd:" (Media Store Directory) prefixes.
+                    // These are commonly seen on Android 10+ (API 29+) when selecting files from the
+                    // "Downloads" category in the system picker.
+                    // Note that this does not happen on all devices.
+                    // Example URI: content://com.android.providers.downloads.documents/document/msf:1000000033
+                    val fileName = getFileName(treeUri, context)
+                    return "$extPath/$fileName"
+                } else if (docId.startsWith("raw:")) {
+                    return docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }
+                        .toTypedArray()[1]
+                }
+                return null
+            }
+        }
+
+        var volumePath = getPathFromTreeUri(treeUri)
+
+        if (volumePath.endsWith(File.separator)) {
+            volumePath = volumePath.dropLast(1)
+        }
+
+        var documentPath = getDocumentPathFromTreeUri(treeUri)
+
+        if (documentPath.endsWith(File.separator)) {
+            documentPath = documentPath.dropLast(1)
+        }
+        return if (documentPath.isNotEmpty()) {
+            if (volumePath.endsWith(documentPath)) {
+                volumePath
+            } else {
+                if (documentPath.startsWith(File.separator)) {
+                    volumePath + documentPath
+                } else {
+                    volumePath + File.separator + documentPath
+                }
+            }
+        } else {
+            volumePath
+        }
+    }
+
+    private fun getDocumentPathFromTreeUri(treeUri: Uri): String {
+        val docId = DocumentsContract.getTreeDocumentId(treeUri)
+        val split = docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        return if ((split.size >= 2)) split[1]
+        else File.separator
+    }
+
+    private fun recursiveDeleteFile(file: File?) {
+        if (file == null || !file.exists()) {
+            return
+        }
+
+        if (file.listFiles() != null && file.isDirectory) {
+            for (child in file.listFiles().orEmpty()) {
+                recursiveDeleteFile(child)
+            }
+        }
+
+        file.delete()
+    }
+}

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/MethodResultWrapper.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/MethodResultWrapper.kt
@@ -1,0 +1,44 @@
+package com.mr.flutter.plugin.filepicker
+
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.MethodChannel
+
+// MethodChannel.Result wrapper that responds on the platform thread.
+class MethodResultWrapper(private val methodResult: MethodChannel.Result) :
+    MethodChannel.Result {
+    private val handler =
+        Handler(Looper.getMainLooper())
+
+    override fun success(result: Any?) {
+        handler.post {
+            try {
+                methodResult.success(
+                    result
+                )
+            } catch (oom: OutOfMemoryError) {
+                methodResult.error(
+                    "out_of_memory",
+                    "Selected files are too large to return in memory. Disable withData or use withReadStream.",
+                    null
+                )
+            }
+        }
+    }
+
+    override fun error(
+        errorCode: String, errorMessage: String?, errorDetails: Any?
+    ) {
+        handler.post {
+            methodResult.error(
+                errorCode,
+                errorMessage,
+                errorDetails
+            )
+        }
+    }
+
+    override fun notImplemented() {
+        handler.post { methodResult.notImplemented() }
+    }
+}

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/MethodResultWrapper.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/MethodResultWrapper.kt
@@ -19,7 +19,7 @@ class MethodResultWrapper(private val methodResult: MethodChannel.Result) :
             } catch (oom: OutOfMemoryError) {
                 methodResult.error(
                     "out_of_memory",
-                    "Selected files are too large to return in memory. Disable withData or use withReadStream.",
+                    "Selected files are too large to load into memory.",
                     null
                 )
             }

--- a/packages/file_picker_android/lib/file_picker_android.dart
+++ b/packages/file_picker_android/lib/file_picker_android.dart
@@ -1,0 +1,4 @@
+export 'src/android_platform_file.dart';
+export 'src/android_saf_handle.dart';
+export 'src/file_picker_android.dart';
+export 'src/file_picker_android_options.dart';

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:cross_file/cross_file.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+
+import 'android_saf_handle.dart';
+
+/// A [PlatformFile] implementation for Android.
+base class AndroidPlatformFile extends PlatformFile {
+  AndroidPlatformFile({
+    required this.name,
+    required this.uri,
+    this.safHandle,
+    XFile? xFile,
+    int? bytesLength,
+  })  : _xFile = xFile,
+        _bytesLength = bytesLength;
+
+  factory AndroidPlatformFile.fromMap(Map<Object?, Object?> data) {
+    final String name = data['name'] as String? ?? '';
+    final String path = data['path'] as String? ?? '';
+    final Uri uri = Uri.tryParse(path) ?? Uri.file(path);
+
+    AndroidSAFHandle? safHandle;
+    if (data case {'safHandle': final Map<Object?, Object?> safMap}) {
+      safHandle = AndroidSAFHandle.fromMap(safMap);
+    }
+
+    final Uint8List? bytes = data['bytes'] as Uint8List?;
+
+    return AndroidPlatformFile(
+      name: name,
+      uri: uri,
+      safHandle: safHandle,
+      xFile: path.isNotEmpty ? XFile(path, name: name, bytes: bytes) : null,
+      bytesLength: bytes?.lengthInBytes ?? (data['size'] as int?),
+    );
+  }
+
+  @override
+  final String name;
+
+  @override
+  final Uri uri;
+
+  /// The handle to the Storage Access Framework URI, if applicable.
+  final AndroidSAFHandle? safHandle;
+
+  final XFile? _xFile;
+  final int? _bytesLength;
+
+  @override
+  XFile get xFile {
+    final file = _xFile;
+    if (file != null) return file;
+    if (uri.scheme == 'file') {
+      return XFile(uri.toFilePath(), name: name);
+    }
+    return XFile(uri.toString(), name: name);
+  }
+
+  @override
+  Future<int> length() async {
+    final len = _bytesLength;
+    if (len != null && len > 0) return len;
+    try {
+      return await xFile.length();
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  @override
+  Future<Uint8List> readAsBytes() async {
+    return xFile.readAsBytes();
+  }
+
+  @override
+  Stream<Uint8List> readAsByteStream() {
+    return xFile.openRead();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! AndroidPlatformFile) return false;
+    return super == other &&
+        other.name == name &&
+        other.uri == uri &&
+        other.safHandle == safHandle;
+  }
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, name, uri, safHandle);
+
+  @override
+  String toString() {
+    return 'AndroidPlatformFile(name: $name, uri: $uri, safHandle: $safHandle)';
+  }
+}

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -14,8 +14,8 @@ base class AndroidPlatformFile extends PlatformFile {
     this.safHandle,
     XFile? xFile,
     int? bytesLength,
-  })  : _xFile = xFile,
-        _bytesLength = bytesLength;
+  }) : _xFile = xFile,
+       _bytesLength = bytesLength;
 
   factory AndroidPlatformFile.fromMap(Map<Object?, Object?> data) {
     final String name = data['name'] as String? ?? '';

--- a/packages/file_picker_android/lib/src/android_saf_handle.dart
+++ b/packages/file_picker_android/lib/src/android_saf_handle.dart
@@ -26,8 +26,7 @@ final class AndroidSAFHandle {
 
   /// Release the grant on the given [uri].
   Future<void> releaseGrant() async {
-    final instance = FilePickerPlatform.instance;
-    if (instance is FilePickerAndroid) {
+    if (FilePickerPlatform.instance case final FilePickerAndroid instance) {
       await instance.releaseSAFGrant(uri.toString());
     }
   }

--- a/packages/file_picker_android/lib/src/android_saf_handle.dart
+++ b/packages/file_picker_android/lib/src/android_saf_handle.dart
@@ -1,0 +1,48 @@
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+
+import 'file_picker_android.dart';
+import 'file_picker_android_options.dart';
+
+/// An opaque handle to an Android Storage Access Framework [uri].
+final class AndroidSAFHandle {
+  const AndroidSAFHandle({required this.accessMode, required this.uri});
+
+  factory AndroidSAFHandle.fromMap(Map<Object?, Object?> map) {
+    return AndroidSAFHandle(
+      uri: Uri.parse(map['uri'] as String),
+      accessMode: map['access'] == 'readWrite'
+          ? AndroidSAFAccessMode.readWrite
+          : AndroidSAFAccessMode.readOnly,
+    );
+  }
+
+  /// The access mode that is granted to the [uri].
+  final AndroidSAFAccessMode accessMode;
+
+  /// The URI that this handle represents.
+  ///
+  /// Typically a `content://` URI.
+  final Uri uri;
+
+  /// Release the grant on the given [uri].
+  Future<void> releaseGrant() async {
+    final instance = FilePickerPlatform.instance;
+    if (instance is FilePickerAndroid) {
+      await instance.releaseSAFGrant(uri.toString());
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AndroidSAFHandle &&
+        other.accessMode == accessMode &&
+        other.uri == uri;
+  }
+
+  @override
+  int get hashCode => Object.hash(accessMode, uri);
+
+  @override
+  String toString() => 'AndroidSAFHandle(uri: $uri, accessMode: $accessMode)';
+}

--- a/packages/file_picker_android/lib/src/file_picker_android.dart
+++ b/packages/file_picker_android/lib/src/file_picker_android.dart
@@ -160,7 +160,7 @@ class FilePickerAndroid extends FilePickerPlatform {
 
   @override
   Future<void> clearTemporaryFiles() async {
-    await methodChannel.invokeMethod<bool>('clear');
+    await methodChannel.invokeMethod<void>('clear');
   }
 
   @override

--- a/packages/file_picker_android/lib/src/file_picker_android.dart
+++ b/packages/file_picker_android/lib/src/file_picker_android.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'android_platform_file.dart';
+import 'file_picker_android_options.dart';
+
+/// An implementation of [FilePickerPlatform] for Android.
+class FilePickerAndroid extends FilePickerPlatform {
+  /// Registers this class as the default instance of [FilePickerPlatform].
+  static void registerWith() {
+    FilePickerPlatform.instance = FilePickerAndroid();
+  }
+
+  static const String _tag = 'FilePickerAndroid';
+
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  final methodChannel = const MethodChannel(
+    'miguelruivo.flutter.plugins.filepicker',
+    StandardMethodCodec(),
+  );
+
+  /// The event channel used to receive real-time updates from the native platform.
+  @visibleForTesting
+  final eventChannel = const EventChannel(
+    'miguelruivo.flutter.plugins.filepickerevent',
+  );
+
+  static StreamSubscription? _eventSubscription;
+
+  @override
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const FilePickerAndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final files = await pickFiles(
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      androidOptions: androidOptions,
+    );
+    return files.firstOrNull;
+  }
+
+  @override
+  Future<List<PlatformFile>> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const FilePickerAndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final String typeName = type.name;
+
+    try {
+      if (onFileLoading != null) {
+        _eventSubscription = eventChannel.receiveBroadcastStream().listen((
+          data,
+        ) {
+          if (data is! bool) return;
+          onFileLoading(
+            data ? FilePickerStatus.picking : FilePickerStatus.done,
+          );
+        }, onError: (error) => throw Exception(error));
+      }
+
+      final Map<String, Object?>? safOptionsMap = switch (androidOptions) {
+        FilePickerAndroidOptions opts => opts.toMap(),
+        _ => null,
+      };
+
+      final List<Map>? result = await methodChannel.invokeListMethod(typeName, {
+        'allowMultipleSelection': true,
+        'allowedExtensions': allowedExtensions,
+        'withData': false,
+        'compressionQuality': compressionQuality,
+        'androidSafOptions': ?safOptionsMap,
+      });
+
+      if (result == null) {
+        return [];
+      }
+
+      final platformFiles = <PlatformFile>[];
+      for (final Map platformFileMap in result) {
+        platformFiles.add(AndroidPlatformFile.fromMap(platformFileMap));
+      }
+
+      return platformFiles;
+    } catch (e) {
+      rethrow;
+    } finally {
+      await _eventSubscription?.cancel();
+      _eventSubscription = null;
+    }
+  }
+
+  @override
+  Future<List<String>> pickFileAndDirectoryPaths({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+  }) async {
+    final files = await pickFiles(
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+    );
+    return files.map((e) => e.uri.path).toList();
+  }
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    String? initialDirectory,
+    AndroidOptions androidOptions = const FilePickerAndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    try {
+      final Map<String, Object?>? safOptionsMap = switch (androidOptions) {
+        FilePickerAndroidOptions opts => opts.toMap(),
+        _ => null,
+      };
+
+      return await methodChannel.invokeMethod<String>('dir', {
+        'androidSafOptions': ?safOptionsMap,
+      });
+    } on PlatformException catch (ex) {
+      if (ex.code == "unknown_path") {
+        print(
+          '[$_tag] Could not resolve directory path. Maybe it\'s a protected one or unsupported (such as Downloads folder). Make sure that you are on SDK 21 or above.',
+        );
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> clearTemporaryFiles() async {
+    await methodChannel.invokeMethod<bool>('clear');
+  }
+
+  @override
+  Future<Uri?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
+    String? dialogTitle,
+    String? initialDirectory,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    try {
+      if (onFileSaving != null) {
+        onFileSaving(FilePickerStatus.picking);
+        _eventSubscription = eventChannel.receiveBroadcastStream().listen((
+          data,
+        ) {
+          if (data is! bool) return;
+          onFileSaving(data ? FilePickerStatus.picking : FilePickerStatus.done);
+        }, onError: (error) => throw Exception(error));
+      }
+
+      final String? savedPath = await methodChannel
+          .invokeMethod<String>("save", {
+            "fileName": fileName,
+            "fileType": mimeType,
+            "initialDirectory": initialDirectory,
+            "bytes": bytes,
+          });
+
+      if (onFileSaving != null) {
+        onFileSaving(FilePickerStatus.done);
+      }
+
+      if (savedPath == null) return null;
+      return Uri.tryParse(savedPath) ?? Uri.file(savedPath);
+    } catch (e) {
+      rethrow;
+    } finally {
+      await _eventSubscription?.cancel();
+      _eventSubscription = null;
+    }
+  }
+
+  /// Releases the given Storage Access Framework [uri] grant on Android.
+  Future<void> releaseSAFGrant(String uri) async {
+    await methodChannel.invokeMethod('releaseSafGrant', {'uri': uri});
+  }
+}

--- a/packages/file_picker_android/lib/src/file_picker_android_options.dart
+++ b/packages/file_picker_android/lib/src/file_picker_android_options.dart
@@ -18,9 +18,9 @@ enum AndroidSAFGrant {
   lifetime,
 }
 
-/// Configuration options specific to the Android platform.
-final class FilePickerAndroidOptions extends AndroidOptions {
-  const FilePickerAndroidOptions({
+/// Configuration options for working with Android Storage Access Framework (SAF).
+final class AndroidSAFOptions {
+  const AndroidSAFOptions({
     this.grant = AndroidSAFGrant.transient,
     this.accessMode = AndroidSAFAccessMode.readOnly,
     this.persistGrant = true,
@@ -47,5 +47,17 @@ final class FilePickerAndroidOptions extends AndroidOptions {
       'access': accessMode.name,
       'autoPersist': persistGrant,
     };
+  }
+}
+
+/// Configuration options specific to the Android platform.
+final class FilePickerAndroidOptions extends AndroidOptions {
+  const FilePickerAndroidOptions({this.safOptions = const AndroidSAFOptions()});
+
+  /// Options for working with the Android Storage Access Framework.
+  final AndroidSAFOptions safOptions;
+
+  Map<String, Object?> toMap() {
+    return {'safOptions': safOptions.toMap()};
   }
 }

--- a/packages/file_picker_android/lib/src/file_picker_android_options.dart
+++ b/packages/file_picker_android/lib/src/file_picker_android_options.dart
@@ -1,0 +1,51 @@
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+
+/// The access mode that is coupled to an [AndroidSAFGrant].
+enum AndroidSAFAccessMode {
+  /// Only allow read permission for a URI.
+  readOnly,
+
+  /// Allow both read and write permissions for a URI.
+  readWrite,
+}
+
+/// The grant type for an Android Storage Access Framework grant.
+enum AndroidSAFGrant {
+  /// Grant permission to the requested URI for the current request only.
+  transient,
+
+  /// Grant permission to the requested URI, until permission is explicitly revoked.
+  lifetime,
+}
+
+/// Configuration options specific to the Android platform.
+final class FilePickerAndroidOptions extends AndroidOptions {
+  const FilePickerAndroidOptions({
+    this.grant = AndroidSAFGrant.transient,
+    this.accessMode = AndroidSAFAccessMode.readOnly,
+    this.persistGrant = true,
+  });
+
+  /// The grant to use with the Android Storage Access Framework.
+  ///
+  /// Defaults to [AndroidSAFGrant.transient].
+  final AndroidSAFGrant grant;
+
+  /// The access mode to use with the Android Storage Access Framework.
+  ///
+  /// Defaults to [AndroidSAFAccessMode.readOnly].
+  final AndroidSAFAccessMode accessMode;
+
+  /// Whether to persist the [grant], so that it is preserved across device reboots.
+  ///
+  /// Defaults to `true`.
+  final bool persistGrant;
+
+  Map<String, Object?> toMap() {
+    return {
+      'grant': grant.name,
+      'access': accessMode.name,
+      'autoPersist': persistGrant,
+    };
+  }
+}

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,0 +1,29 @@
+name: file_picker_android
+description: Android implementation of the file_picker plugin.
+version: 1.0.0
+homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
+repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
+
+resolution: workspace
+
+environment:
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
+
+flutter:
+  plugin:
+    implements: file_picker
+    pluginClass: FilePickerPlugin
+    package: com.mr.flutter.plugin.filepicker
+    dartPluginClass: FilePickerAndroid
+
+dependencies:
+  flutter:
+    sdk: flutter
+  file_picker_platform_interface: ^1.0.0
+  cross_file: ^0.3.5+2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0

--- a/packages/file_picker_android/test/file_picker_android_test.dart
+++ b/packages/file_picker_android/test/file_picker_android_test.dart
@@ -1,0 +1,38 @@
+import 'package:file_picker_android/file_picker_android.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FilePickerAndroid', () {
+    test('registers instance', () {
+      FilePickerAndroid.registerWith();
+      expect(FilePickerPlatform.instance, isA<FilePickerAndroid>());
+    });
+
+    test('FilePickerAndroidOptions toMap contains expected keys', () {
+      const options = FilePickerAndroidOptions(
+        grant: AndroidSAFGrant.lifetime,
+        accessMode: AndroidSAFAccessMode.readWrite,
+        persistGrant: true,
+      );
+      final map = options.toMap();
+      expect(map['grant'], equals('lifetime'));
+      expect(map['access'], equals('readWrite'));
+      expect(map['autoPersist'], isTrue);
+    });
+
+    test('AndroidSAFHandle parses map correctly', () {
+      final handle = AndroidSAFHandle.fromMap({
+        'uri': 'content://media/external/images/media/1',
+        'access': 'readWrite',
+      });
+      expect(
+        handle.uri,
+        equals(Uri.parse('content://media/external/images/media/1')),
+      );
+      expect(handle.accessMode, equals(AndroidSAFAccessMode.readWrite));
+    });
+  });
+}

--- a/packages/file_picker_android/test/file_picker_android_test.dart
+++ b/packages/file_picker_android/test/file_picker_android_test.dart
@@ -11,13 +11,14 @@ void main() {
       expect(FilePickerPlatform.instance, isA<FilePickerAndroid>());
     });
 
-    test('FilePickerAndroidOptions toMap contains expected keys', () {
-      const options = FilePickerAndroidOptions(
+    test('AndroidSAFOptions toMap contains expected keys', () {
+      const safOptions = AndroidSAFOptions(
         grant: AndroidSAFGrant.lifetime,
         accessMode: AndroidSAFAccessMode.readWrite,
         persistGrant: true,
       );
-      final map = options.toMap();
+      const options = FilePickerAndroidOptions(safOptions: safOptions);
+      final map = options.safOptions.toMap();
       expect(map['grant'], equals('lifetime'));
       expect(map['access'], equals('readWrite'));
       expect(map['autoPersist'], isTrue);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ version: 12.0.0-beta.8
 
 workspace:
   - packages/file_picker_platform_interface
+  - packages/file_picker_android
 
 melos:
   packages:


### PR DESCRIPTION
## Description
This PR extracts the Android platform implementation of `file_picker` into an independent federated package under `packages/file_picker_android`.

## Changes Included
- Created `packages/file_picker_android/` package with `pubspec.yaml` configured for `FilePickerAndroid` (`dartPluginClass: FilePickerAndroid`).
- Moved native Kotlin code (`FilePickerPlugin.kt`, `FilePickerDelegate.kt`, `FileUtils.kt`, `FileInfo.kt`, `MethodResultWrapper.kt`, `AndroidManifest.xml`, `build.gradle.kts`, `proguard-rules.pro`).
- Implemented `FilePickerAndroid` extending `FilePickerPlatform`.
- Implemented `FilePickerAndroidOptions extends AndroidOptions` for Android Storage Access Framework (SAF) configuration (`grant`, `accessMode`, `persistGrant`).
- Implemented `AndroidSAFHandle` with `releaseGrant()` method for releasing SAF URI permissions.
- Implemented `AndroidPlatformFile extends PlatformFile`.
- Added unit tests in `packages/file_picker_android/test/file_picker_android_test.dart`.
- Added `packages/file_picker_android` to workspace in root `pubspec.yaml`.

## Verification
- `dart run melos bootstrap`: 2 packages bootstrapped successfully.
- `dart run melos run analyze`: 0 issues found across all packages.
- `dart run melos run test`: All unit tests passed.