### PR TITLE
feat(windows): extract Windows implementation into file_picker_windows package

### DIFF
--- a/packages/file_picker_windows/CHANGELOG.md
+++ b/packages/file_picker_windows/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release of Windows implementation package for `file_picker`.

--- a/packages/file_picker_windows/README.md
+++ b/packages/file_picker_windows/README.md
@@ -1,0 +1,7 @@
+# file_picker_windows
+
+The Windows implementation of `file_picker`.
+
+## Usage
+
+This package is endorsed, which means you can simply use `file_picker` as normal, and the Windows implementation will be automatically included.

--- a/packages/file_picker_windows/lib/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/file_picker_windows.dart
@@ -1,0 +1,3 @@
+export 'src/file_picker_windows.dart';
+export 'src/file_picker_windows_options.dart';
+export 'src/windows_platform_file.dart';

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:isolate';
 import 'dart:math';
 import 'dart:typed_data';
+
 import 'package:ffi/ffi.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:flutter/foundation.dart';
@@ -124,6 +125,7 @@ class FilePickerWindows extends FilePickerPlatform {
     });
   }
 
+  /// Runs [IFileOpenDialog] inside a separate isolate to prompt for a directory path.
   static String? _getDirectoryPathIsolate(Map<String, Object?> args) {
     String? dialogTitle = args['dialogTitle'] as String?;
     String? initialDirectory = args['initialDirectory'] as String?;
@@ -241,6 +243,7 @@ class FilePickerWindows extends FilePickerPlatform {
   /// Private getter for opening the `user32.dll` dynamic library.
   DynamicLibrary get _user32 => DynamicLibrary.open('user32.dll');
 
+  /// Opens the Win32 file picker dialog using [GetOpenFileNameW].
   List<String>? _pickFiles(_OpenSaveFileArgs args) {
     final getOpenFileNameW = _comdlg32
         .lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
@@ -260,6 +263,7 @@ class FilePickerWindows extends FilePickerPlatform {
     return files;
   }
 
+  /// Opens the Win32 save file dialog using [GetSaveFileNameW].
   String? _saveFile(_OpenSaveFileArgs args) {
     final getSaveFileNameW = _comdlg32
         .lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
@@ -301,6 +305,8 @@ class FilePickerWindows extends FilePickerPlatform {
   static const _videoFilter =
       'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
 
+  /// Converts a [FileType] enum and allowed extension list into a null-terminated
+  /// Win32 file filter string for `OPENFILENAMEW`.
   String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
     if (type == FileType.custom &&
         (allowedExtensions == null || allowedExtensions.isEmpty)) {
@@ -324,6 +330,7 @@ class FilePickerWindows extends FilePickerPlatform {
     }
   }
 
+  /// Validates that a file name does not contain reserved Win32 characters.
   void validateFileName(String fileName) {
     if (fileName.contains(RegExp(r'[<>:/\\|?*"]'))) {
       throw ArgumentError(
@@ -332,6 +339,24 @@ class FilePickerWindows extends FilePickerPlatform {
     }
   }
 
+  /// Extracts the list of selected files from the Win32 API struct [OPENFILENAMEW].
+  ///
+  /// After the user has closed the file picker dialog, Win32 API sets the property
+  /// `lpstrFile` of [OPENFILENAMEW] to the user's selection. This property contains
+  /// a string terminated by two `null` characters. If the user has selected only one
+  /// file, then the returned string contains the absolute file path, e. g.
+  /// `C:\Users\John\file1.jpg\x00\x00`. If the user has selected more than one file,
+  /// then the returned string contains the directory of the selected files, followed
+  /// by a `null` character, followed by the file names each separated by a `null`
+  /// character, e.g. `C:\Users\John\x00file1.jpg\x00file2.jpg\x00file3.jpg\x00\x00`.
+  ///
+  /// `isResultFromSaveFileDialog` allows to handle the result of the save-file
+  /// dialog differently because somehow, if the save-file dialog is invoked with a
+  /// long default file name (e.g. `abcdefghijklmnopqrstuvxyz0123456789.png`) and the
+  /// user changed the file name to a short one (e.g. `test.txt`), then the field
+  /// `lpstrFile` not only contains the selected file `test.txt` but also, separated
+  /// by only one `null` character, some remaining part of the originally given default
+  /// file name.
   List<String> extractSelectedFilesFromOpenFileNameW(
     OPENFILENAMEW openFileNameW, {
     bool isResultFromSaveFileDialog = false,
@@ -370,6 +395,7 @@ class FilePickerWindows extends FilePickerPlatform {
     return filePaths;
   }
 
+  /// Allocates and populates an [OPENFILENAMEW] struct with native memory for Win32 API calls.
   Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(_OpenSaveFileArgs args) {
     final lpstrFileBufferSize = 8192 * maximumPathLength;
     final Pointer<OPENFILENAMEW> openFileNameW = calloc<OPENFILENAMEW>();
@@ -420,6 +446,7 @@ class FilePickerWindows extends FilePickerPlatform {
     return openFileNameW;
   }
 
+  /// Retrieves the HWND handle of the Flutter runner window using `user32.dll`.
   Pointer _getWindowHandle() {
     final findWindowA = _user32
         .lookupFunction<
@@ -435,6 +462,7 @@ class FilePickerWindows extends FilePickerPlatform {
     return Pointer.fromAddress(hWnd);
   }
 
+  /// Frees allocated native memory for an [OPENFILENAMEW] pointer.
   void _freeMemory(Pointer<OPENFILENAMEW> openFileNameW) {
     calloc.free(openFileNameW.ref.lpstrTitle);
     calloc.free(openFileNameW.ref.lpstrFile);
@@ -443,28 +471,49 @@ class FilePickerWindows extends FilePickerPlatform {
     calloc.free(openFileNameW);
   }
 
+  /// Top-level isolate callback to invoke [_pickFiles].
   static void _callPickFiles(_OpenSaveFileArgs args) {
     final impl = FilePickerWindows();
     args.port.send(impl._pickFiles(args));
   }
 
+  /// Top-level isolate callback to invoke [_saveFile].
   static void _callSaveFile(_OpenSaveFileArgs args) {
     final impl = FilePickerWindows();
     args.port.send(impl._saveFile(args));
   }
 }
 
+/// Arguments passed to background isolates for open and save file dialogs.
 class _OpenSaveFileArgs {
+  /// SendPort used to reply to the main isolate.
   final SendPort port;
+
+  /// Default file name suggested in the save dialog.
   final String? defaultFileName;
+
+  /// Optional title for the dialog box.
   final String? dialogTitle;
+
+  /// Optional initial directory to open.
   final String? initialDirectory;
+
+  /// File type filter rule.
   final FileType type;
+
+  /// List of custom allowed extensions when [type] is [FileType.custom].
   final List<String>? allowedExtensions;
 
+  /// Whether multi-selection is enabled.
   final bool allowMultiple;
+
+  /// Whether to lock the parent window modally.
   final bool lockParentWindow;
+
+  /// Whether to prompt before overwriting an existing file in save dialogs.
   final bool confirmOverwrite;
+
+  /// The HWND handle of the parent window.
   final int? parentWindowHandle;
 
   _OpenSaveFileArgs({

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -431,15 +431,15 @@ class FilePickerWindows extends FilePickerPlatform {
       openFileNameW.ref.flags |= ofnOverwritePrompt;
     }
 
-    if (args.defaultFileName != null) {
-      validateFileName(args.defaultFileName!);
+    if (args.defaultFileName case final defaultFileName?) {
+      validateFileName(defaultFileName);
 
       final Uint16List nativeString = openFileNameW.ref.lpstrFile
           .cast<Uint16>()
           .asTypedList(maximumPathLength);
-      final safeName = args.defaultFileName!.substring(
+      final safeName = defaultFileName.substring(
         0,
-        min(maximumPathLength - 1, args.defaultFileName!.length),
+        min(maximumPathLength - 1, defaultFileName.length),
       );
       final units = safeName.codeUnits;
       nativeString.setRange(0, units.length, units);

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -12,6 +12,7 @@ import 'package:win32/win32.dart';
 
 import 'file_picker_windows_ffi_types.dart';
 import 'file_picker_windows_options.dart';
+import 'open_save_file_args.dart';
 import 'windows_platform_file.dart';
 
 /// An implementation of [FilePickerPlatform] for Windows.
@@ -67,7 +68,7 @@ class FilePickerWindows extends FilePickerPlatform {
     final port = ReceivePort();
     await Isolate.spawn(
       _callPickFiles,
-      _OpenSaveFileArgs(
+      OpenSaveFileArgs(
         port: port.sendPort,
         dialogTitle: dialogTitle,
         initialDirectory: initialDirectory,
@@ -216,7 +217,7 @@ class FilePickerWindows extends FilePickerPlatform {
     final port = ReceivePort();
     await Isolate.spawn(
       _callSaveFile,
-      _OpenSaveFileArgs(
+      OpenSaveFileArgs(
         port: port.sendPort,
         defaultFileName: fileName,
         dialogTitle: dialogTitle,
@@ -244,7 +245,7 @@ class FilePickerWindows extends FilePickerPlatform {
   DynamicLibrary get _user32 => DynamicLibrary.open('user32.dll');
 
   /// Opens the Win32 file picker dialog using [GetOpenFileNameW].
-  List<String>? _pickFiles(_OpenSaveFileArgs args) {
+  List<String>? _pickFiles(OpenSaveFileArgs args) {
     final getOpenFileNameW = _comdlg32
         .lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
           'GetOpenFileNameW',
@@ -264,7 +265,7 @@ class FilePickerWindows extends FilePickerPlatform {
   }
 
   /// Opens the Win32 save file dialog using [GetSaveFileNameW].
-  String? _saveFile(_OpenSaveFileArgs args) {
+  String? _saveFile(OpenSaveFileArgs args) {
     final getSaveFileNameW = _comdlg32
         .lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
           'GetSaveFileNameW',
@@ -400,7 +401,7 @@ class FilePickerWindows extends FilePickerPlatform {
   static const _lpstrFileBufferSize = 8192 * maximumPathLength;
 
   /// Allocates and populates an [OPENFILENAMEW] struct with native memory for Win32 API calls.
-  Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(_OpenSaveFileArgs args) {
+  Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(OpenSaveFileArgs args) {
     final Pointer<OPENFILENAMEW> openFileNameW = calloc<OPENFILENAMEW>();
 
     openFileNameW.ref.lStructSize = sizeOf<OPENFILENAMEW>();
@@ -475,60 +476,14 @@ class FilePickerWindows extends FilePickerPlatform {
   }
 
   /// Top-level isolate callback to invoke [_pickFiles].
-  static void _callPickFiles(_OpenSaveFileArgs args) {
+  static void _callPickFiles(OpenSaveFileArgs args) {
     final impl = FilePickerWindows();
     args.port.send(impl._pickFiles(args));
   }
 
   /// Top-level isolate callback to invoke [_saveFile].
-  static void _callSaveFile(_OpenSaveFileArgs args) {
+  static void _callSaveFile(OpenSaveFileArgs args) {
     final impl = FilePickerWindows();
     args.port.send(impl._saveFile(args));
   }
-}
-
-/// Arguments passed to background isolates for open and save file dialogs.
-class _OpenSaveFileArgs {
-  /// SendPort used to reply to the main isolate.
-  final SendPort port;
-
-  /// Default file name suggested in the save dialog.
-  final String? defaultFileName;
-
-  /// Optional title for the dialog box.
-  final String? dialogTitle;
-
-  /// Optional initial directory to open.
-  final String? initialDirectory;
-
-  /// File type filter rule.
-  final FileType type;
-
-  /// List of custom allowed extensions when [type] is [FileType.custom].
-  final List<String>? allowedExtensions;
-
-  /// Whether multi-selection is enabled.
-  final bool allowMultiple;
-
-  /// Whether to lock the parent window modally.
-  final bool lockParentWindow;
-
-  /// Whether to prompt before overwriting an existing file in save dialogs.
-  final bool confirmOverwrite;
-
-  /// The HWND handle of the parent window.
-  final int? parentWindowHandle;
-
-  _OpenSaveFileArgs({
-    required this.port,
-    this.defaultFileName,
-    this.dialogTitle,
-    this.initialDirectory,
-    this.type = FileType.any,
-    this.allowedExtensions,
-    this.allowMultiple = false,
-    this.lockParentWindow = false,
-    this.confirmOverwrite = false,
-    this.parentWindowHandle,
-  });
 }

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -363,10 +363,11 @@ class FilePickerWindows extends FilePickerPlatform {
   }) {
     final List<String> filePaths = [];
     final buffer = StringBuffer();
+    final fileUnits = openFileNameW.lpstrFile.cast<Uint16>();
     int i = 0;
     bool lastCharWasNull = false;
     while (true) {
-      final char = openFileNameW.lpstrFile.cast<Uint16>()[i];
+      final char = fileUnits[i];
       final currentCharIsNull = char == 0;
       if (currentCharIsNull && lastCharWasNull) {
         break;

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -22,6 +22,28 @@ class FilePickerWindows extends FilePickerPlatform {
     FilePickerPlatform.instance = FilePickerWindows();
   }
 
+  /// The buffer size in characters allocated for `lpstrFile` in [OPENFILENAMEW].
+  static const _lpstrFileBufferSize = 8192 * maximumPathLength;
+
+  /// Filter string for any file type.
+  static const _anyFilter = 'All Files (*.*)\x00*.*\x00\x00';
+
+  /// Filter string for audio file types.
+  static const _audioFilter =
+      'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
+
+  /// Filter string for image file types.
+  static const _imageFilter =
+      'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
+
+  /// Filter string for media (video and image) file types.
+  static const _mediaFilter =
+      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
+
+  /// Filter string for video file types.
+  static const _videoFilter =
+      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
+
   @override
   Future<PlatformFile?> pickFile({
     String? dialogTitle,
@@ -287,25 +309,6 @@ class FilePickerWindows extends FilePickerPlatform {
     return returnValue;
   }
 
-  /// Filter string for any file type.
-  static const _anyFilter = 'All Files (*.*)\x00*.*\x00\x00';
-
-  /// Filter string for audio file types.
-  static const _audioFilter =
-      'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
-
-  /// Filter string for image file types.
-  static const _imageFilter =
-      'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
-
-  /// Filter string for media (video and image) file types.
-  static const _mediaFilter =
-      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
-
-  /// Filter string for video file types.
-  static const _videoFilter =
-      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
-
   /// Converts a [FileType] enum and allowed extension list into a null-terminated
   /// Win32 file filter string for `OPENFILENAMEW`.
   String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
@@ -396,9 +399,6 @@ class FilePickerWindows extends FilePickerPlatform {
 
     return filePaths;
   }
-
-  /// The buffer size in characters allocated for `lpstrFile` in [OPENFILENAMEW].
-  static const _lpstrFileBufferSize = 8192 * maximumPathLength;
 
   /// Allocates and populates an [OPENFILENAMEW] struct with native memory for Win32 API calls.
   Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(OpenSaveFileArgs args) {

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -79,7 +79,7 @@ class FilePickerWindows extends FilePickerPlatform {
     );
 
     final fileNames = (await port.first) as List<String>?;
-    if (fileNames == null) {
+    if (fileNames == null || fileNames.isEmpty) {
       return [];
     }
 

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -396,20 +396,22 @@ class FilePickerWindows extends FilePickerPlatform {
     return filePaths;
   }
 
+  /// The buffer size in characters allocated for `lpstrFile` in [OPENFILENAMEW].
+  static const _lpstrFileBufferSize = 8192 * maximumPathLength;
+
   /// Allocates and populates an [OPENFILENAMEW] struct with native memory for Win32 API calls.
   Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(_OpenSaveFileArgs args) {
-    final lpstrFileBufferSize = 8192 * maximumPathLength;
     final Pointer<OPENFILENAMEW> openFileNameW = calloc<OPENFILENAMEW>();
 
     openFileNameW.ref.lStructSize = sizeOf<OPENFILENAMEW>();
     openFileNameW.ref.lpstrTitle = (args.dialogTitle ?? 'Select File')
         .toNativeUtf16();
-    openFileNameW.ref.lpstrFile = calloc.allocate<Utf16>(lpstrFileBufferSize);
+    openFileNameW.ref.lpstrFile = calloc.allocate<Utf16>(_lpstrFileBufferSize);
     openFileNameW.ref.lpstrFilter = fileTypeToFileFilter(
       args.type,
       args.allowedExtensions,
     ).toNativeUtf16();
-    openFileNameW.ref.nMaxFile = lpstrFileBufferSize;
+    openFileNameW.ref.nMaxFile = _lpstrFileBufferSize;
     openFileNameW.ref.lpstrInitialDir = (args.initialDirectory ?? '')
         .toNativeUtf16();
     openFileNameW.ref.flags =

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -282,6 +282,25 @@ class FilePickerWindows extends FilePickerPlatform {
     return returnValue;
   }
 
+  /// Filter string for any file type.
+  static const _anyFilter = 'All Files (*.*)\x00*.*\x00\x00';
+
+  /// Filter string for audio file types.
+  static const _audioFilter =
+      'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
+
+  /// Filter string for image file types.
+  static const _imageFilter =
+      'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
+
+  /// Filter string for media (video and image) file types.
+  static const _mediaFilter =
+      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
+
+  /// Filter string for video file types.
+  static const _videoFilter =
+      'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
+
   String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
     if (type == FileType.custom &&
         (allowedExtensions == null || allowedExtensions.isEmpty)) {
@@ -291,17 +310,17 @@ class FilePickerWindows extends FilePickerPlatform {
     }
     switch (type) {
       case FileType.any:
-        return 'All Files (*.*)\x00*.*\x00\x00';
+        return _anyFilter;
       case FileType.audio:
-        return 'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
+        return _audioFilter;
       case FileType.custom:
         return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
       case FileType.image:
-        return 'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
+        return _imageFilter;
       case FileType.media:
-        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
+        return _mediaFilter;
       case FileType.video:
-        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
+        return _videoFilter;
     }
   }
 

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -78,8 +78,8 @@ class FilePickerWindows extends FilePickerPlatform {
       ),
     );
 
-    final fileNames = (await port.first) as List<String>?;
-    if (fileNames == null || fileNames.isEmpty) {
+    final fileNames = (await port.first) as List<String>? ?? [];
+    if (fileNames.isEmpty) {
       return [];
     }
 

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -235,10 +235,14 @@ class FilePickerWindows extends FilePickerPlatform {
     return null;
   }
 
-  List<String>? _pickFiles(_OpenSaveFileArgs args) {
-    final comdlg32 = DynamicLibrary.open('comdlg32.dll');
+  /// Private getter for opening the `comdlg32.dll` dynamic library.
+  DynamicLibrary get _comdlg32 => DynamicLibrary.open('comdlg32.dll');
 
-    final getOpenFileNameW = comdlg32
+  /// Private getter for opening the `user32.dll` dynamic library.
+  DynamicLibrary get _user32 => DynamicLibrary.open('user32.dll');
+
+  List<String>? _pickFiles(_OpenSaveFileArgs args) {
+    final getOpenFileNameW = _comdlg32
         .lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
           'GetOpenFileNameW',
         );
@@ -257,9 +261,7 @@ class FilePickerWindows extends FilePickerPlatform {
   }
 
   String? _saveFile(_OpenSaveFileArgs args) {
-    final comdlg32 = DynamicLibrary.open('comdlg32.dll');
-
-    final getSaveFileNameW = comdlg32
+    final getSaveFileNameW = _comdlg32
         .lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
           'GetSaveFileNameW',
         );
@@ -400,9 +402,7 @@ class FilePickerWindows extends FilePickerPlatform {
   }
 
   Pointer _getWindowHandle() {
-    final user32 = DynamicLibrary.open('user32.dll');
-
-    final findWindowA = user32
+    final findWindowA = _user32
         .lookupFunction<
           Int32 Function(Pointer<Utf8> lpClassName, Pointer<Utf8> lpWindowName),
           int Function(Pointer<Utf8> lpClassName, Pointer<Utf8> lpWindowName)

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -318,20 +318,15 @@ class FilePickerWindows extends FilePickerPlatform {
         'If type is set to FileType.custom, allowedExtensions cannot be null or empty.',
       );
     }
-    switch (type) {
-      case FileType.any:
-        return _anyFilter;
-      case FileType.audio:
-        return _audioFilter;
-      case FileType.custom:
-        return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
-      case FileType.image:
-        return _imageFilter;
-      case FileType.media:
-        return _mediaFilter;
-      case FileType.video:
-        return _videoFilter;
-    }
+    return switch (type) {
+      FileType.any => _anyFilter,
+      FileType.audio => _audioFilter,
+      FileType.custom =>
+        'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00',
+      FileType.image => _imageFilter,
+      FileType.media => _mediaFilter,
+      FileType.video => _videoFilter,
+    };
   }
 
   /// Validates that a file name does not contain reserved Win32 characters.

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -248,15 +248,10 @@ class FilePickerWindows extends FilePickerPlatform {
     );
 
     final result = getOpenFileNameW(openFileNameW);
-    late final List<String>? files;
-    if (result == 1) {
-      final filePaths = extractSelectedFilesFromOpenFileNameW(
-        openFileNameW.ref,
-      );
-      files = filePaths;
-    } else {
-      files = null;
-    }
+    final files = switch (result) {
+      1 => extractSelectedFilesFromOpenFileNameW(openFileNameW.ref),
+      _ => null,
+    };
     _freeMemory(openFileNameW);
     return files;
   }
@@ -274,15 +269,13 @@ class FilePickerWindows extends FilePickerPlatform {
     );
 
     final result = getSaveFileNameW(openFileNameW);
-    String? returnValue;
-    if (result == 1) {
-      final filePaths = extractSelectedFilesFromOpenFileNameW(
+    final returnValue = switch (result) {
+      1 => extractSelectedFilesFromOpenFileNameW(
         openFileNameW.ref,
         isResultFromSaveFileDialog: true,
-      );
-      returnValue = filePaths.firstOrNull;
-    }
-
+      ).firstOrNull,
+      _ => null,
+    };
     _freeMemory(openFileNameW);
     return returnValue;
   }

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -371,7 +371,9 @@ class FilePickerWindows extends FilePickerPlatform {
       final currentCharIsNull = char == 0;
       if (currentCharIsNull && lastCharWasNull) {
         break;
-      } else if (currentCharIsNull) {
+      }
+
+      if (currentCharIsNull) {
         filePaths.add(buffer.toString());
         buffer.clear();
         lastCharWasNull = true;

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -1,0 +1,472 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart';
+import 'package:win32/win32.dart';
+
+import 'file_picker_windows_ffi_types.dart';
+import 'file_picker_windows_options.dart';
+import 'windows_platform_file.dart';
+
+/// An implementation of [FilePickerPlatform] for Windows.
+class FilePickerWindows extends FilePickerPlatform {
+  /// Registers this class as the default instance of [FilePickerPlatform].
+  static void registerWith() {
+    FilePickerPlatform.instance = FilePickerWindows();
+  }
+
+  @override
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const FilePickerWindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final files = await pickFiles(
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      windowsOptions: windowsOptions,
+    );
+    return files.firstOrNull;
+  }
+
+  @override
+  Future<List<PlatformFile>> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const FilePickerWindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final FilePickerWindowsOptions options = switch (windowsOptions) {
+      FilePickerWindowsOptions opts => opts,
+      _ => const FilePickerWindowsOptions(),
+    };
+
+    final port = ReceivePort();
+    await Isolate.spawn(
+      _callPickFiles,
+      _OpenSaveFileArgs(
+        port: port.sendPort,
+        dialogTitle: dialogTitle,
+        initialDirectory: initialDirectory,
+        type: type,
+        allowedExtensions: allowedExtensions,
+        allowMultiple: true,
+        lockParentWindow: options.lockParentWindow,
+        parentWindowHandle: options.parentWindowHandle,
+      ),
+    );
+
+    final fileNames = (await port.first) as List<String>?;
+    if (fileNames == null) {
+      return [];
+    }
+
+    return [for (final path in fileNames) WindowsPlatformFile.fromPath(path)];
+  }
+
+  @override
+  Future<List<String>> pickFileAndDirectoryPaths({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+  }) async {
+    final files = await pickFiles(
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+    );
+    return files.map((e) => e.uri.path).toList();
+  }
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const FilePickerWindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final FilePickerWindowsOptions options = switch (windowsOptions) {
+      FilePickerWindowsOptions opts => opts,
+      _ => const FilePickerWindowsOptions(),
+    };
+
+    return compute(_getDirectoryPathIsolate, {
+      'dialogTitle': dialogTitle,
+      'initialDirectory': initialDirectory,
+      'lockParentWindow': options.lockParentWindow,
+      'parentWindowHandle': options.parentWindowHandle,
+    });
+  }
+
+  static String? _getDirectoryPathIsolate(Map<String, Object?> args) {
+    String? dialogTitle = args['dialogTitle'] as String?;
+    String? initialDirectory = args['initialDirectory'] as String?;
+    bool lockParentWindow = args['lockParentWindow'] as bool? ?? false;
+    int? parentWindowHandle = args['parentWindowHandle'] as int?;
+
+    final hr = CoInitializeEx(
+      COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE,
+    );
+
+    if (hr.isError) {
+      throw WindowsException(hr);
+    }
+
+    try {
+      return using((arena) {
+        final fileDialog = arena.com<IFileOpenDialog>(FileOpenDialog);
+
+        final options =
+            fileDialog.getOptions() |
+            FOS_PICKFOLDERS |
+            FOS_FORCEFILESYSTEM |
+            FOS_NOCHANGEDIR;
+        fileDialog.setOptions(FILEOPENDIALOGOPTIONS(options));
+
+        fileDialog.setTitle(arena.pcwstr(dialogTitle ?? 'Select Folder'));
+
+        if (initialDirectory != null) {
+          final item = arena.adopt(
+            SHCreateItemFromParsingName<IShellItem>(
+              arena.pcwstr(initialDirectory),
+              null,
+            ),
+          );
+          fileDialog.setFolder(item);
+        }
+
+        try {
+          HWND? parentHwnd;
+          if (lockParentWindow) {
+            parentHwnd = parentWindowHandle != null
+                ? Pointer.fromAddress(parentWindowHandle) as HWND
+                : GetForegroundWindow();
+          }
+          fileDialog.show(parentHwnd);
+        } on WindowsException catch (e) {
+          if (e.hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+            return null;
+          }
+          rethrow;
+        }
+
+        final selectedItem = fileDialog.getResult();
+        if (selectedItem == null) {
+          return null;
+        }
+
+        final item = arena.adopt(selectedItem);
+        final pathPtr = item.getDisplayName(SIGDN_FILESYSPATH);
+        try {
+          return pathPtr.toDartString();
+        } finally {
+          CoTaskMemFree(pathPtr);
+        }
+      });
+    } finally {
+      CoUninitialize();
+    }
+  }
+
+  @override
+  Future<Uri?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
+    String? dialogTitle,
+    String? initialDirectory,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const FilePickerWindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final FilePickerWindowsOptions options = switch (windowsOptions) {
+      FilePickerWindowsOptions opts => opts,
+      _ => const FilePickerWindowsOptions(),
+    };
+
+    final port = ReceivePort();
+    await Isolate.spawn(
+      _callSaveFile,
+      _OpenSaveFileArgs(
+        port: port.sendPort,
+        defaultFileName: fileName,
+        dialogTitle: dialogTitle,
+        initialDirectory: initialDirectory,
+        lockParentWindow: options.lockParentWindow,
+        confirmOverwrite: true,
+        parentWindowHandle: options.parentWindowHandle,
+      ),
+    );
+
+    final savedFilePath = (await port.first) as String?;
+    if (savedFilePath != null) {
+      final file = File(savedFilePath);
+      await file.writeAsBytes(bytes);
+      return Uri.file(savedFilePath);
+    }
+
+    return null;
+  }
+
+  List<String>? _pickFiles(_OpenSaveFileArgs args) {
+    final comdlg32 = DynamicLibrary.open('comdlg32.dll');
+
+    final getOpenFileNameW = comdlg32
+        .lookupFunction<GetOpenFileNameW, GetOpenFileNameWDart>(
+          'GetOpenFileNameW',
+        );
+
+    final Pointer<OPENFILENAMEW> openFileNameW = _instantiateOpenFileNameW(
+      args,
+    );
+
+    final result = getOpenFileNameW(openFileNameW);
+    late final List<String>? files;
+    if (result == 1) {
+      final filePaths = extractSelectedFilesFromOpenFileNameW(
+        openFileNameW.ref,
+      );
+      files = filePaths;
+    } else {
+      files = null;
+    }
+    _freeMemory(openFileNameW);
+    return files;
+  }
+
+  String? _saveFile(_OpenSaveFileArgs args) {
+    final comdlg32 = DynamicLibrary.open('comdlg32.dll');
+
+    final getSaveFileNameW = comdlg32
+        .lookupFunction<GetSaveFileNameW, GetSaveFileNameWDart>(
+          'GetSaveFileNameW',
+        );
+
+    final Pointer<OPENFILENAMEW> openFileNameW = _instantiateOpenFileNameW(
+      args,
+    );
+
+    final result = getSaveFileNameW(openFileNameW);
+    String? returnValue;
+    if (result == 1) {
+      final filePaths = extractSelectedFilesFromOpenFileNameW(
+        openFileNameW.ref,
+        isResultFromSaveFileDialog: true,
+      );
+      returnValue = filePaths.firstOrNull;
+    }
+
+    _freeMemory(openFileNameW);
+    return returnValue;
+  }
+
+  String fileTypeToFileFilter(FileType type, List<String>? allowedExtensions) {
+    if (type == FileType.custom &&
+        (allowedExtensions == null || allowedExtensions.isEmpty)) {
+      throw ArgumentError(
+        'If type is set to FileType.custom, allowedExtensions cannot be null or empty.',
+      );
+    }
+    switch (type) {
+      case FileType.any:
+        return 'All Files (*.*)\x00*.*\x00\x00';
+      case FileType.audio:
+        return 'Audios (*.aac,*.midi,*.mp3,*.ogg,*.wav,*.m4a)\x00*.aac;*.midi;*.mp3;*.ogg;*.wav;*.m4a\x00\x00';
+      case FileType.custom:
+        return 'Files (*.${allowedExtensions!.join(',*.')})\x00*.${allowedExtensions.join(';*.')}\x00\x00';
+      case FileType.image:
+        return 'Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png,*.webp)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png;*.webp\x00\x00';
+      case FileType.media:
+        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00Images (*.bmp,*.gif,*.jpeg,*.jpg,*.png)\x00*.bmp;*.gif;*.jpeg;*.jpg;*.png\x00\x00';
+      case FileType.video:
+        return 'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
+    }
+  }
+
+  void validateFileName(String fileName) {
+    if (fileName.contains(RegExp(r'[<>:/\\|?*"]'))) {
+      throw ArgumentError(
+        'Reserved characters may not be used in file names. See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions',
+      );
+    }
+  }
+
+  List<String> extractSelectedFilesFromOpenFileNameW(
+    OPENFILENAMEW openFileNameW, {
+    bool isResultFromSaveFileDialog = false,
+  }) {
+    final List<String> filePaths = [];
+    final buffer = StringBuffer();
+    int i = 0;
+    bool lastCharWasNull = false;
+    while (true) {
+      final char = openFileNameW.lpstrFile.cast<Uint16>()[i];
+      final currentCharIsNull = char == 0;
+      if (currentCharIsNull && lastCharWasNull) {
+        break;
+      } else if (currentCharIsNull) {
+        filePaths.add(buffer.toString());
+        buffer.clear();
+        lastCharWasNull = true;
+
+        if (isResultFromSaveFileDialog) {
+          break;
+        }
+      } else {
+        lastCharWasNull = false;
+        buffer.writeCharCode(char);
+      }
+      i++;
+    }
+
+    if (filePaths.length > 1) {
+      final String directoryPath = filePaths.removeAt(0);
+      return filePaths
+          .map<String>((filePath) => join(directoryPath, filePath))
+          .toList();
+    }
+
+    return filePaths;
+  }
+
+  Pointer<OPENFILENAMEW> _instantiateOpenFileNameW(_OpenSaveFileArgs args) {
+    final lpstrFileBufferSize = 8192 * maximumPathLength;
+    final Pointer<OPENFILENAMEW> openFileNameW = calloc<OPENFILENAMEW>();
+
+    openFileNameW.ref.lStructSize = sizeOf<OPENFILENAMEW>();
+    openFileNameW.ref.lpstrTitle = (args.dialogTitle ?? 'Select File')
+        .toNativeUtf16();
+    openFileNameW.ref.lpstrFile = calloc.allocate<Utf16>(lpstrFileBufferSize);
+    openFileNameW.ref.lpstrFilter = fileTypeToFileFilter(
+      args.type,
+      args.allowedExtensions,
+    ).toNativeUtf16();
+    openFileNameW.ref.nMaxFile = lpstrFileBufferSize;
+    openFileNameW.ref.lpstrInitialDir = (args.initialDirectory ?? '')
+        .toNativeUtf16();
+    openFileNameW.ref.flags =
+        ofnExplorer | ofnFileMustExist | ofnHideReadOnly | ofnNoChangeDir;
+
+    if (args.lockParentWindow) {
+      openFileNameW.ref.hwndOwner = args.parentWindowHandle != null
+          ? Pointer.fromAddress(args.parentWindowHandle!)
+          : _getWindowHandle();
+    }
+
+    if (args.allowMultiple) {
+      openFileNameW.ref.flags |= ofnAllowMultiSelect;
+    }
+
+    if (args.confirmOverwrite) {
+      openFileNameW.ref.flags |= ofnOverwritePrompt;
+    }
+
+    if (args.defaultFileName != null) {
+      validateFileName(args.defaultFileName!);
+
+      final Uint16List nativeString = openFileNameW.ref.lpstrFile
+          .cast<Uint16>()
+          .asTypedList(maximumPathLength);
+      final safeName = args.defaultFileName!.substring(
+        0,
+        min(maximumPathLength - 1, args.defaultFileName!.length),
+      );
+      final units = safeName.codeUnits;
+      nativeString.setRange(0, units.length, units);
+      nativeString[units.length] = 0;
+    }
+
+    return openFileNameW;
+  }
+
+  Pointer _getWindowHandle() {
+    final user32 = DynamicLibrary.open('user32.dll');
+
+    final findWindowA = user32
+        .lookupFunction<
+          Int32 Function(Pointer<Utf8> lpClassName, Pointer<Utf8> lpWindowName),
+          int Function(Pointer<Utf8> lpClassName, Pointer<Utf8> lpWindowName)
+        >('FindWindowA');
+
+    int hWnd = findWindowA(
+      'FLUTTER_RUNNER_WIN32_WINDOW'.toNativeUtf8(),
+      nullptr,
+    );
+
+    return Pointer.fromAddress(hWnd);
+  }
+
+  void _freeMemory(Pointer<OPENFILENAMEW> openFileNameW) {
+    calloc.free(openFileNameW.ref.lpstrTitle);
+    calloc.free(openFileNameW.ref.lpstrFile);
+    calloc.free(openFileNameW.ref.lpstrFilter);
+    calloc.free(openFileNameW.ref.lpstrInitialDir);
+    calloc.free(openFileNameW);
+  }
+
+  static void _callPickFiles(_OpenSaveFileArgs args) {
+    final impl = FilePickerWindows();
+    args.port.send(impl._pickFiles(args));
+  }
+
+  static void _callSaveFile(_OpenSaveFileArgs args) {
+    final impl = FilePickerWindows();
+    args.port.send(impl._saveFile(args));
+  }
+}
+
+class _OpenSaveFileArgs {
+  final SendPort port;
+  final String? defaultFileName;
+  final String? dialogTitle;
+  final String? initialDirectory;
+  final FileType type;
+  final List<String>? allowedExtensions;
+
+  final bool allowMultiple;
+  final bool lockParentWindow;
+  final bool confirmOverwrite;
+  final int? parentWindowHandle;
+
+  _OpenSaveFileArgs({
+    required this.port,
+    this.defaultFileName,
+    this.dialogTitle,
+    this.initialDirectory,
+    this.type = FileType.any,
+    this.allowedExtensions,
+    this.allowMultiple = false,
+    this.lockParentWindow = false,
+    this.confirmOverwrite = false,
+    this.parentWindowHandle,
+  });
+}

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -390,9 +390,7 @@ class FilePickerWindows extends FilePickerPlatform {
 
     if (filePaths.length > 1) {
       final String directoryPath = filePaths.removeAt(0);
-      return filePaths
-          .map<String>((filePath) => join(directoryPath, filePath))
-          .toList();
+      return [for (final filePath in filePaths) join(directoryPath, filePath)];
     }
 
     return filePaths;

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: deprecated_member_use
-
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -44,6 +44,12 @@ class FilePickerWindows extends FilePickerPlatform {
   static const _videoFilter =
       'Videos (*.avi,*.flv,*.mkv,*.mov,*.mp4,*.mpeg,*.webm,*.wmv)\x00*.avi;*.flv;*.mkv;*.mov;*.mp4;*.mpeg;*.webm;*.wmv\x00\x00';
 
+  /// Private getter for opening the `comdlg32.dll` dynamic library.
+  DynamicLibrary get _comdlg32 => DynamicLibrary.open('comdlg32.dll');
+
+  /// Private getter for opening the `user32.dll` dynamic library.
+  DynamicLibrary get _user32 => DynamicLibrary.open('user32.dll');
+
   @override
   Future<PlatformFile?> pickFile({
     String? dialogTitle,
@@ -259,12 +265,6 @@ class FilePickerWindows extends FilePickerPlatform {
 
     return null;
   }
-
-  /// Private getter for opening the `comdlg32.dll` dynamic library.
-  DynamicLibrary get _comdlg32 => DynamicLibrary.open('comdlg32.dll');
-
-  /// Private getter for opening the `user32.dll` dynamic library.
-  DynamicLibrary get _user32 => DynamicLibrary.open('user32.dll');
 
   /// Opens the Win32 file picker dialog using [GetOpenFileNameW].
   List<String>? _pickFiles(OpenSaveFileArgs args) {

--- a/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
@@ -1,0 +1,225 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+
+/// Function from Win32 API to display a dialog box that enables the user to select a Shell folder.
+///
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shbrowseforfolderw
+typedef SHBrowseForFolderW =
+    Pointer Function(
+      /// A pointer to a [BROWSEINFOA] structure that contains information used to display the dialog box.
+      Pointer lpbi,
+    );
+
+/// Function from Win32 API to create an Open dialog box that lets the user specify the drive,
+/// directory, and the name of a file or set of files to be opened.
+///
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-getopenfilenamew
+typedef GetOpenFileNameW =
+    Int8 Function(
+      /// A pointer to an [OPENFILENAMEW] structure that contains information used to initialize the
+      /// dialog box. When GetOpenFileName returns, this structure contains information about the user's
+      /// file selection.
+      Pointer unnamedParam1,
+    );
+
+/// Dart equivalent of [GetOpenFileNameW].
+typedef GetOpenFileNameWDart = int Function(Pointer unnamedParam1);
+
+/// Function from Win32 API to convert an item identifier list to a file system path.
+///
+/// Returns `true` if successful; otherwise, `false`.
+///
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetpathfromidlistw
+typedef SHGetPathFromIDListW =
+    Int8 Function(
+      /// The address of an item identifier list that specifies a file or directory location relative to
+      /// the root of the namespace (the desktop).
+      Pointer pidl,
+
+      /// The address of a buffer to receive the file system path. This buffer must be at least
+      /// [maximumPathLength] characters in size.
+      Pointer<Utf16> pszPath,
+    );
+
+/// Dart equivalent of [SHGetPathFromIDListW].
+typedef SHGetPathFromIDListWDart =
+    int Function(Pointer pidl, Pointer<Utf16> pszPath);
+
+/// Function from Win32 API to create a save dialog box that lets the user
+/// specify the drive, directory, and name of a file to save.
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-getsavefilenamew
+typedef GetSaveFileNameW =
+    Int8 Function(
+      /// A pointer to an [OPENFILENAMEW] structure that contains information used
+      /// to initialize the dialog box. When the function [GetSaveFileNameW]
+      /// returns, this structure contains information about the user's file
+      /// selection.
+      Pointer unnamedParam1,
+    );
+
+/// Dart equivalent of [GetSaveFileNameW]
+typedef GetSaveFileNameWDart = int Function(Pointer unnamedParam1);
+
+/// Struct from Win32 API that contains parameters for the [SHBrowseForFolderW] function and receives
+/// information about the folder selected by the user.
+///
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfoa
+final class BROWSEINFOA extends Struct {
+  /// A handle to the owner window for the dialog box.
+  external Pointer hwndOwner;
+
+  /// A PIDL that specifies the location of the root folder from which to start browsing. Only the
+  /// specified folder and its subfolders in the namespace hierarchy appear in the dialog box. This
+  /// member can be `null`; in that case, a default location is used.
+  external Pointer pidlRoot;
+
+  /// Pointer to a buffer to receive the display name of the folder selected by the user. The size
+  /// of this buffer is assumed to be [maximumPathLength] characters.
+  external Pointer<Utf16> pszDisplayName;
+
+  /// Pointer to a null-terminated string that is displayed above the tree view control in the dialog
+  /// box. This string can be used to specify instructions to the user.
+  external Pointer lpszTitle;
+
+  /// Flags that specify the options for the dialog box. This member can be 0 or a combination of the
+  /// following values.
+  @Uint32()
+  external int ulFlags;
+
+  /// Pointer to an application-defined function that the dialog box calls when an event occurs. For
+  /// more information, see the BrowseCallbackProc function. This member can be `null`.
+  external Pointer lpfn;
+
+  /// An application-defined value that the dialog box passes to the callback function, if one is
+  /// specified in [lpfn].
+  external Pointer lParam;
+
+  /// An [int] value that receives the index of the image associated with the selected folder, stored
+  /// in the system image list.
+  @Uint32()
+  external int iImage;
+}
+
+/// Struct from Win32 API that contains parameters for the [GetOpenFileNameW] function and receives
+/// information about the file(s) selected by the user.
+///
+/// Reference:
+/// https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamew
+final class OPENFILENAMEW extends Struct {
+  /// The length, in bytes, of the structure. Use sizeof [OPENFILENAMEW] for this parameter.
+  @Uint32()
+  external int lStructSize;
+
+  /// A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be `null` if the dialog box has no owner.
+  external Pointer hwndOwner;
+
+  /// If the OFN_ENABLETEMPLATEHANDLE flag is set in the Flags member, hInstance is a handle to a memory object containing a dialog box template. If the OFN_ENABLETEMPLATE flag is set, hInstance is a handle to a module that contains a dialog box template named by the lpTemplateName member. If neither flag is set, this member is ignored. If the OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the system uses the template to create an old-style dialog box that replaces the default dialog box.
+  external Pointer hInstance;
+
+  /// A buffer containing pairs of null-terminated filter strings. The last string in the buffer must be terminated by two `null` characters.
+  external Pointer<Utf16> lpstrFilter;
+
+  /// A static buffer that contains a pair of null-terminated filter strings for preserving the filter pattern chosen by the user.
+  external Pointer<Utf16> lpstrCustomFilter;
+
+  /// The size, in characters, of the buffer identified by [lpstrCustomFilter]. This buffer should be at least 40 characters long. This member is ignored if [lpstrCustomFilter] is `null` or points to a `null` string.
+  @Uint32()
+  external int nMaxCustFilter;
+
+  /// The index of the currently selected filter in the File Types control.
+  @Uint32()
+  external int nFilterIndex;
+
+  /// The file name used to initialize the File Name edit control. The first character of this buffer must be `null` if initialization is not necessary.
+  external Pointer<Utf16> lpstrFile;
+
+  /// The size, in characters, of the buffer pointed to by lpstrFile. The buffer must be large enough to store the path and file name string or strings, including the terminating `null` character. The GetOpenFileName and GetSaveFileName functions return `false` if the buffer is too small to contain the file information. The buffer should be at least 256 characters long.
+  @Uint32()
+  external int nMaxFile;
+
+  /// The file name and extension (without path information) of the selected file. This member can be `null`.
+  external Pointer<Utf16> lpstrFileTitle;
+
+  /// The size, in characters, of the buffer pointed to by [lpstrFileTitle]. This member is ignored if [lpstrFileTitle] is `null`.
+  @Uint32()
+  external int nMaxFileTitle;
+
+  /// The initial directory. The algorithm for selecting the initial directory varies on different platforms.
+  external Pointer<Utf16> lpstrInitialDir;
+
+  /// A string to be placed in the title bar of the dialog box. If this member is `null`, the system uses the default title (that is, Save As or Open).
+  external Pointer<Utf16> lpstrTitle;
+
+  /// A set of bit flags you can use to initialize the dialog box. When the dialog box returns, it sets these flags to indicate the user's input.
+  @Uint32()
+  external int flags;
+
+  /// The zero-based offset, in characters, from the beginning of the path to the file name in the string pointed to by [lpstrFile].
+  @Uint16()
+  external int nFileOffset;
+
+  /// The zero-based offset, in characters, from the beginning of the path to the file name extension in the string pointed to by [lpstrFile].
+  @Uint16()
+  external int nFileExtension;
+
+  /// The default extension. GetOpenFileName and GetSaveFileName append this extension to the file name if the user fails to type an extension.
+  external Pointer<Utf16> lpstrDefExt;
+
+  /// Application-defined data that the system passes to the hook procedure identified by the lpfnHook member. When the system sends the WM_INITDIALOG message to the hook procedure, the message's lParam parameter is a pointer to the OPENFILENAME structure specified when the dialog box was created. The hook procedure can use this pointer to get the lCustData value.
+  external Pointer lCustData;
+
+  /// A pointer to a hook procedure. This member is ignored unless the Flags member includes the OFN_ENABLEHOOK flag.
+  external Pointer lpfnHook;
+
+  /// The name of the dialog template resource in the module identified by the hInstance member. For numbered dialog box resources, this can be a value returned by the MAKEINTRESOURCE macro. This member is ignored unless the OFN_ENABLETEMPLATE flag is set in the Flags member. If the OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the system uses the template to create an old-style dialog box that replaces the default dialog box.
+  external Pointer<Utf16> lpTemplateName;
+
+  /// This member is reserved.
+  external Pointer pvReserved;
+
+  /// This member is reserved.
+  @Uint32()
+  external int dwReserved;
+
+  /// A set of bit flags you can use to initialize the dialog box.
+  @Uint32()
+  external int flagsEx;
+}
+
+/// Only return file system directories. If the user selects folders that are not part of the file
+/// system, the OK button is grayed.
+const bifReturnOnlyFsDirs = 0x00000001;
+
+/// Include an edit control in the browse dialog box that allows the user to type the name of an item.
+const bifEditBox = 0x00000010;
+
+/// Use the new user interface. Setting this flag provides the user with a larger dialog box that can
+/// be resized. The dialog box has several new capabilities, including: drag-and-drop capability within
+/// the dialog box, reordering, shortcut menus, new folders, delete, and other shortcut menu commands.
+const bifNewDialogStyle = 0x00000040;
+
+/// In the Windows API, the maximum length for a path is MAX_PATH, which is defined as 260 characters.
+const maximumPathLength = 260;
+
+/// The File Name list box allows multiple selections.
+const ofnAllowMultiSelect = 0x00000200;
+
+/// Indicates that any customizations made to the Open or Save As dialog box use the Explorer-style customization methods.
+const ofnExplorer = 0x00080000;
+
+/// The user can type only names of existing files in the File Name entry field.
+const ofnFileMustExist = 0x00001000;
+
+/// Hides the Read Only check box.
+const ofnHideReadOnly = 0x00000004;
+
+/// Causes the Save As dialog box to generate a message box if the selected file already exists. The user must confirm whether to overwrite the file.
+const ofnOverwritePrompt = 0x00000002;
+
+/// Restores the current directory to its original value if the user changed the directory while searching for files.
+const ofnNoChangeDir = 0x00000008;

--- a/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
@@ -163,8 +163,8 @@ final class OPENFILENAMEW extends Struct {
   @Uint32()
   external int nMaxFileTitle;
 
-  /// The initial directory. The algorithm for selecting the initial directory varies on different
-  /// platforms.
+  /// The initial directory. The algorithm for selecting the initial directory varies across different
+  /// Windows OS versions.
   external Pointer<Utf16> lpstrInitialDir;
 
   /// A string to be placed in the title bar of the dialog box. If this member is `null`, the system

--- a/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
@@ -86,8 +86,9 @@ final class BROWSEINFOA extends Struct {
   /// box. This string can be used to specify instructions to the user.
   external Pointer lpszTitle;
 
-  /// Flags that specify the options for the dialog box. This member can be 0 or a combination of the
-  /// following values.
+  /// Flags that specify the options for the dialog box. Refer to the
+  /// [BROWSEINFOA documentation](https://learn.microsoft.com/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfoa)
+  /// for valid `BIF_*` flag values.
   @Uint32()
   external int ulFlags;
 

--- a/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows_ffi_types.dart
@@ -29,43 +29,37 @@ typedef GetOpenFileNameWDart = int Function(Pointer unnamedParam1);
 
 /// Function from Win32 API to convert an item identifier list to a file system path.
 ///
-/// Returns `true` if successful; otherwise, `false`.
-///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetpathfromidlistw
 typedef SHGetPathFromIDListW =
     Int8 Function(
-      /// The address of an item identifier list that specifies a file or directory location relative to
-      /// the root of the namespace (the desktop).
+      /// A pointer to an item identifier list that specifies a file or directory location relative
+      /// to the root of the namespace (the desktop).
       Pointer pidl,
 
-      /// The address of a buffer to receive the file system path. This buffer must be at least
+      /// A pointer to a buffer to receive the file system path. This buffer must be at least
       /// [maximumPathLength] characters in size.
-      Pointer<Utf16> pszPath,
+      Pointer pszPath,
     );
 
-/// Dart equivalent of [SHGetPathFromIDListW].
-typedef SHGetPathFromIDListWDart =
-    int Function(Pointer pidl, Pointer<Utf16> pszPath);
-
-/// Function from Win32 API to create a save dialog box that lets the user
-/// specify the drive, directory, and name of a file to save.
+/// Function from Win32 API to create a Save dialog box that lets the user specify the drive,
+/// directory, and name of a file to save.
+///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/commdlg/nf-commdlg-getsavefilenamew
 typedef GetSaveFileNameW =
     Int8 Function(
-      /// A pointer to an [OPENFILENAMEW] structure that contains information used
-      /// to initialize the dialog box. When the function [GetSaveFileNameW]
-      /// returns, this structure contains information about the user's file
-      /// selection.
+      /// A pointer to an [OPENFILENAMEW] structure that contains information used to initialize the
+      /// dialog box. When GetSaveFileName returns, this structure contains information about the user's
+      /// file selection.
       Pointer unnamedParam1,
     );
 
-/// Dart equivalent of [GetSaveFileNameW]
+/// Dart equivalent of [GetSaveFileNameW].
 typedef GetSaveFileNameWDart = int Function(Pointer unnamedParam1);
 
-/// Struct from Win32 API that contains parameters for the [SHBrowseForFolderW] function and receives
-/// information about the folder selected by the user.
+/// Contains parameters for the [SHBrowseForFolderW] function and receives information about the folder
+/// selected by the user.
 ///
 /// Reference:
 /// https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfoa
@@ -116,19 +110,32 @@ final class OPENFILENAMEW extends Struct {
   @Uint32()
   external int lStructSize;
 
-  /// A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be `null` if the dialog box has no owner.
+  /// A handle to the window that owns the dialog box. This member can be any valid window handle,
+  /// or it can be `null` if the dialog box has no owner.
   external Pointer hwndOwner;
 
-  /// If the OFN_ENABLETEMPLATEHANDLE flag is set in the Flags member, hInstance is a handle to a memory object containing a dialog box template. If the OFN_ENABLETEMPLATE flag is set, hInstance is a handle to a module that contains a dialog box template named by the lpTemplateName member. If neither flag is set, this member is ignored. If the OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the system uses the template to create an old-style dialog box that replaces the default dialog box.
+  /// If the `OFN_ENABLETEMPLATEHANDLE` flag is set in the `Flags` member, `hInstance` is a handle to a
+  /// memory object containing a dialog box template.
+  /// If the `OFN_ENABLETEMPLATE` flag is set, `hInstance` is a handle to a module that contains a dialog
+  /// box template named by the `lpTemplateName` member.
+  /// If neither flag is set, this member is ignored.
+  /// If the `OFN_EXPLORER` flag is set, the system uses the specified template to create a dialog box
+  /// that is a child of the default Explorer-style dialog box.
+  /// If the `OFN_EXPLORER` flag is not set, the system uses the template to create an old-style dialog
+  /// box that replaces the default dialog box.
   external Pointer hInstance;
 
-  /// A buffer containing pairs of null-terminated filter strings. The last string in the buffer must be terminated by two `null` characters.
+  /// A buffer containing pairs of null-terminated filter strings. The last string in the buffer
+  /// must be terminated by two `null` characters.
   external Pointer<Utf16> lpstrFilter;
 
-  /// A static buffer that contains a pair of null-terminated filter strings for preserving the filter pattern chosen by the user.
+  /// A static buffer that contains a pair of null-terminated filter strings for preserving the filter
+  /// pattern chosen by the user.
   external Pointer<Utf16> lpstrCustomFilter;
 
-  /// The size, in characters, of the buffer identified by [lpstrCustomFilter]. This buffer should be at least 40 characters long. This member is ignored if [lpstrCustomFilter] is `null` or points to a `null` string.
+  /// The size, in characters, of the buffer identified by [lpstrCustomFilter]. This buffer should be
+  /// at least 40 characters long. This member is ignored if [lpstrCustomFilter] is `null` or points to
+  /// a `null` string.
   @Uint32()
   external int nMaxCustFilter;
 
@@ -136,48 +143,69 @@ final class OPENFILENAMEW extends Struct {
   @Uint32()
   external int nFilterIndex;
 
-  /// The file name used to initialize the File Name edit control. The first character of this buffer must be `null` if initialization is not necessary.
+  /// The file name used to initialize the File Name edit control. The first character of this buffer
+  /// must be `null` if initialization is not necessary.
   external Pointer<Utf16> lpstrFile;
 
-  /// The size, in characters, of the buffer pointed to by lpstrFile. The buffer must be large enough to store the path and file name string or strings, including the terminating `null` character. The GetOpenFileName and GetSaveFileName functions return `false` if the buffer is too small to contain the file information. The buffer should be at least 256 characters long.
+  /// The size, in characters, of the buffer pointed to by lpstrFile. The buffer must be large enough
+  /// to store the path and file name string or strings, including the terminating `null` character.
+  /// The GetOpenFileName and GetSaveFileName functions return `false` if the buffer is too small to
+  /// contain the file information. The buffer should be at least 256 characters long.
   @Uint32()
   external int nMaxFile;
 
-  /// The file name and extension (without path information) of the selected file. This member can be `null`.
+  /// The file name and extension (without path information) of the selected file. This member can be
+  /// `null`.
   external Pointer<Utf16> lpstrFileTitle;
 
-  /// The size, in characters, of the buffer pointed to by [lpstrFileTitle]. This member is ignored if [lpstrFileTitle] is `null`.
+  /// The size, in characters, of the buffer pointed to by [lpstrFileTitle]. This member is ignored
+  /// if [lpstrFileTitle] is `null`.
   @Uint32()
   external int nMaxFileTitle;
 
-  /// The initial directory. The algorithm for selecting the initial directory varies on different platforms.
+  /// The initial directory. The algorithm for selecting the initial directory varies on different
+  /// platforms.
   external Pointer<Utf16> lpstrInitialDir;
 
-  /// A string to be placed in the title bar of the dialog box. If this member is `null`, the system uses the default title (that is, Save As or Open).
+  /// A string to be placed in the title bar of the dialog box. If this member is `null`, the system
+  /// uses the default title (that is, Save As or Open).
   external Pointer<Utf16> lpstrTitle;
 
-  /// A set of bit flags you can use to initialize the dialog box. When the dialog box returns, it sets these flags to indicate the user's input.
+  /// A set of bit flags you can use to initialize the dialog box. When the dialog box returns, it
+  /// sets these flags to indicate the user's input.
   @Uint32()
   external int flags;
 
-  /// The zero-based offset, in characters, from the beginning of the path to the file name in the string pointed to by [lpstrFile].
+  /// The zero-based offset, in characters, from the beginning of the path to the file name in the
+  /// string pointed to by [lpstrFile].
   @Uint16()
   external int nFileOffset;
 
-  /// The zero-based offset, in characters, from the beginning of the path to the file name extension in the string pointed to by [lpstrFile].
+  /// The zero-based offset, in characters, from the beginning of the path to the file name extension
+  /// in the string pointed to by [lpstrFile].
   @Uint16()
   external int nFileExtension;
 
-  /// The default extension. GetOpenFileName and GetSaveFileName append this extension to the file name if the user fails to type an extension.
+  /// The default extension. GetOpenFileName and GetSaveFileName append this extension to the file
+  /// name if the user fails to type an extension.
   external Pointer<Utf16> lpstrDefExt;
 
-  /// Application-defined data that the system passes to the hook procedure identified by the lpfnHook member. When the system sends the WM_INITDIALOG message to the hook procedure, the message's lParam parameter is a pointer to the OPENFILENAME structure specified when the dialog box was created. The hook procedure can use this pointer to get the lCustData value.
+  /// Application-defined data that the system passes to the hook procedure identified by the lpfnHook
+  /// member. When the system sends the WM_INITDIALOG message to the hook procedure, the message's
+  /// lParam parameter is a pointer to the OPENFILENAME structure specified when the dialog box was
+  /// created. The hook procedure can use this pointer to get the lCustData value.
   external Pointer lCustData;
 
-  /// A pointer to a hook procedure. This member is ignored unless the Flags member includes the OFN_ENABLEHOOK flag.
+  /// A pointer to a hook procedure. This member is ignored unless the Flags member includes the
+  /// OFN_ENABLEHOOK flag.
   external Pointer lpfnHook;
 
-  /// The name of the dialog template resource in the module identified by the hInstance member. For numbered dialog box resources, this can be a value returned by the MAKEINTRESOURCE macro. This member is ignored unless the OFN_ENABLETEMPLATE flag is set in the Flags member. If the OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the system uses the template to create an old-style dialog box that replaces the default dialog box.
+  /// The name of the dialog template resource in the module identified by the hInstance member. For
+  /// numbered dialog box resources, this can be a value returned by the MAKEINTRESOURCE macro. This
+  /// member is ignored unless the OFN_ENABLETEMPLATE flag is set in the Flags member. If the
+  /// OFN_EXPLORER flag is set, the system uses the specified template to create a dialog box that is
+  /// a child of the default Explorer-style dialog box. If the OFN_EXPLORER flag is not set, the
+  /// system uses the template to create an old-style dialog box that replaces the default dialog box.
   external Pointer<Utf16> lpTemplateName;
 
   /// This member is reserved.
@@ -210,7 +238,8 @@ const maximumPathLength = 260;
 /// The File Name list box allows multiple selections.
 const ofnAllowMultiSelect = 0x00000200;
 
-/// Indicates that any customizations made to the Open or Save As dialog box use the Explorer-style customization methods.
+/// Indicates that any customizations made to the Open or Save As dialog box use the Explorer-style
+/// customization methods.
 const ofnExplorer = 0x00080000;
 
 /// The user can type only names of existing files in the File Name entry field.
@@ -219,8 +248,10 @@ const ofnFileMustExist = 0x00001000;
 /// Hides the Read Only check box.
 const ofnHideReadOnly = 0x00000004;
 
-/// Causes the Save As dialog box to generate a message box if the selected file already exists. The user must confirm whether to overwrite the file.
+/// Causes the Save As dialog box to generate a message box if the selected file already exists. The
+/// user must confirm whether to overwrite the file.
 const ofnOverwritePrompt = 0x00000002;
 
-/// Restores the current directory to its original value if the user changed the directory while searching for files.
+/// Restores the current directory to its original value if the user changed the directory while
+/// searching for files.
 const ofnNoChangeDir = 0x00000008;

--- a/packages/file_picker_windows/lib/src/file_picker_windows_options.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows_options.dart
@@ -1,0 +1,15 @@
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+
+/// Configuration options specific to the Windows platform.
+final class FilePickerWindowsOptions extends WindowsOptions {
+  const FilePickerWindowsOptions({
+    this.parentWindowHandle,
+    this.lockParentWindow = false,
+  });
+
+  /// The HWND handle of the parent window.
+  final int? parentWindowHandle;
+
+  /// Whether to lock the parent window modally.
+  final bool lockParentWindow;
+}

--- a/packages/file_picker_windows/lib/src/open_save_file_args.dart
+++ b/packages/file_picker_windows/lib/src/open_save_file_args.dart
@@ -1,0 +1,51 @@
+import 'dart:isolate';
+
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:meta/meta.dart';
+
+/// Arguments passed to background isolates for open and save file dialogs.
+@internal
+class OpenSaveFileArgs {
+  /// SendPort used to reply to the main isolate.
+  final SendPort port;
+
+  /// Default file name suggested in the save dialog.
+  final String? defaultFileName;
+
+  /// Optional title for the dialog box.
+  final String? dialogTitle;
+
+  /// Optional initial directory to open.
+  final String? initialDirectory;
+
+  /// File type filter rule.
+  final FileType type;
+
+  /// List of custom allowed extensions when [type] is [FileType.custom].
+  final List<String>? allowedExtensions;
+
+  /// Whether multi-selection is enabled.
+  final bool allowMultiple;
+
+  /// Whether to lock the parent window modally.
+  final bool lockParentWindow;
+
+  /// Whether to prompt before overwriting an existing file in save dialogs.
+  final bool confirmOverwrite;
+
+  /// The HWND handle of the parent window.
+  final int? parentWindowHandle;
+
+  OpenSaveFileArgs({
+    required this.port,
+    this.defaultFileName,
+    this.dialogTitle,
+    this.initialDirectory,
+    this.type = FileType.any,
+    this.allowedExtensions,
+    this.allowMultiple = false,
+    this.lockParentWindow = false,
+    this.confirmOverwrite = false,
+    this.parentWindowHandle,
+  });
+}

--- a/packages/file_picker_windows/lib/src/open_save_file_args.dart
+++ b/packages/file_picker_windows/lib/src/open_save_file_args.dart
@@ -6,6 +6,19 @@ import 'package:meta/meta.dart';
 /// Arguments passed to background isolates for open and save file dialogs.
 @internal
 class OpenSaveFileArgs {
+  OpenSaveFileArgs({
+    required this.port,
+    this.defaultFileName,
+    this.dialogTitle,
+    this.initialDirectory,
+    this.type = FileType.any,
+    this.allowedExtensions,
+    this.allowMultiple = false,
+    this.lockParentWindow = false,
+    this.confirmOverwrite = false,
+    this.parentWindowHandle,
+  });
+
   /// SendPort used to reply to the main isolate.
   final SendPort port;
 
@@ -35,17 +48,4 @@ class OpenSaveFileArgs {
 
   /// The HWND handle of the parent window.
   final int? parentWindowHandle;
-
-  OpenSaveFileArgs({
-    required this.port,
-    this.defaultFileName,
-    this.dialogTitle,
-    this.initialDirectory,
-    this.type = FileType.any,
-    this.allowedExtensions,
-    this.allowMultiple = false,
-    this.lockParentWindow = false,
-    this.confirmOverwrite = false,
-    this.parentWindowHandle,
-  });
 }

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:cross_file/cross_file.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:path/path.dart' as p;
+
+/// A [PlatformFile] implementation for Windows.
+base class WindowsPlatformFile extends PlatformFile {
+  WindowsPlatformFile({
+    required this.name,
+    required this.uri,
+    XFile? xFile,
+    int? bytesLength,
+  }) : _xFile = xFile,
+       _bytesLength = bytesLength;
+
+  factory WindowsPlatformFile.fromPath(String path, {Uint8List? bytes}) {
+    final uri = Uri.file(path, windows: true);
+    final name = p.windows.basename(path);
+    return WindowsPlatformFile(
+      name: name,
+      uri: uri,
+      xFile: XFile(path, name: name, bytes: bytes),
+      bytesLength: bytes?.lengthInBytes,
+    );
+  }
+
+  @override
+  final String name;
+
+  @override
+  final Uri uri;
+
+  final XFile? _xFile;
+  final int? _bytesLength;
+
+  @override
+  XFile get xFile {
+    final file = _xFile;
+    if (file != null) return file;
+    if (uri.scheme == 'file') {
+      return XFile(uri.toFilePath(), name: name);
+    }
+    return XFile(uri.toString(), name: name);
+  }
+
+  @override
+  Future<int> length() async {
+    final len = _bytesLength;
+    if (len != null && len > 0) return len;
+    try {
+      return await xFile.length();
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  @override
+  Future<Uint8List> readAsBytes() async {
+    return xFile.readAsBytes();
+  }
+
+  @override
+  Stream<Uint8List> readAsByteStream() {
+    return xFile.openRead();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WindowsPlatformFile &&
+        other.name == name &&
+        other.uri == uri;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, uri);
+
+  @override
+  String toString() {
+    return 'WindowsPlatformFile(name: $name, uri: $uri)';
+  }
+}

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   file_picker_platform_interface: ^1.0.0
   cross_file: ^0.3.5+2
   ffi: ^2.1.2
+  meta: ^1.11.0
   path: ^1.9.0
   win32: ">=5.5.4 <7.0.0"
 

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -1,0 +1,33 @@
+name: file_picker_windows
+description: Windows implementation of the file_picker plugin.
+version: 1.0.0
+homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
+repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
+
+resolution: workspace
+
+environment:
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
+
+flutter:
+  plugin:
+    implements: file_picker
+    dartPluginClass: FilePickerWindows
+    platforms:
+      windows:
+        dartPluginClass: FilePickerWindows
+
+dependencies:
+  flutter:
+    sdk: flutter
+  file_picker_platform_interface: ^1.0.0
+  cross_file: ^0.3.5+2
+  ffi: ^2.1.2
+  path: ^1.9.0
+  win32: ">=5.5.4 <7.0.0"
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0

--- a/packages/file_picker_windows/test/file_picker_windows_test.dart
+++ b/packages/file_picker_windows/test/file_picker_windows_test.dart
@@ -1,0 +1,29 @@
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:file_picker_windows/file_picker_windows.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FilePickerWindows', () {
+    test('registers instance', () {
+      FilePickerWindows.registerWith();
+      expect(FilePickerPlatform.instance, isA<FilePickerWindows>());
+    });
+
+    test('WindowsPlatformFile parses path correctly', () {
+      final file = WindowsPlatformFile.fromPath(r'C:\Users\Test\file.txt');
+      expect(file.name, equals('file.txt'));
+      expect(file.uri.path, equals('/C:/Users/Test/file.txt'));
+    });
+
+    test('FilePickerWindowsOptions contains expected properties', () {
+      const options = FilePickerWindowsOptions(
+        parentWindowHandle: 12345,
+        lockParentWindow: true,
+      );
+      expect(options.parentWindowHandle, equals(12345));
+      expect(options.lockParentWindow, isTrue);
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - packages/file_picker_android
   - packages/file_picker_darwin
   - packages/file_picker_linux
+  - packages/file_picker_windows
 
 melos:
   packages:


### PR DESCRIPTION
## Description

This PR extracts the Windows platform implementation from the monolithic `file_picker` package into a dedicated federated platform package: `packages/file_picker_windows`.

Part of the plugin federation effort, [issue related](https://github.com/miguelpruivo/flutter_file_picker/issues/2050).

## Summary of Changes

- **Created Package**: `packages/file_picker_windows` implementing `file_picker` for Windows using pure Dart FFI (`win32` and `ffi` packages).
- **Platform Class**: Implemented `FilePickerWindows` extending `FilePickerPlatform` with support for `pickFile`, `pickFiles`, `getDirectoryPath`, and `saveFile`.
- **Platform File**: Implemented `WindowsPlatformFile` extending `PlatformFile`, using `p.windows.basename` to reliably extract filenames from Windows file paths across all operating systems.
- **Options**: Created `FilePickerWindowsOptions` extending `WindowsOptions` for window locking and parent HWND handle parameters.
- **Workspace Integration**: Registered `packages/file_picker_windows` in root `pubspec.yaml` `workspace:`.
- **Testing**: Added unit tests in `packages/file_picker_windows/test/file_picker_windows_test.dart` verifying instance registration, Windows path parsing, and options.

## Verification

- `melos bootstrap` (5 packages bootstrapped successfully)
- `melos run analyze` (0 issues across all packages)
- `melos run test` (All tests passed 100%)