### PR TITLE
fix(android): remove Apache Tika dependency for MIME type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Android
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
+- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)
 
 ### Desktop & Web
 - Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `parentWindow` and `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -83,6 +83,5 @@ dependencies {
     add("implementation", "androidx.core:core-ktx:1.18.0")
     add("implementation", "androidx.annotation:annotation:1.10.0")
     add("implementation", "androidx.lifecycle:lifecycle-runtime:2.10.0")
-    add("implementation", "org.apache.tika:tika-core:3.3.0")
 }
 

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,8 +1,0 @@
-#TIKA PROGUARD RULES
--keep class org.apache.tika.** { *; }
--keep class javax.xml.stream.XMLResolver.** { *; }
--dontwarn javax.xml.stream.XMLInputFactory
--dontwarn javax.xml.stream.XMLResolver
--dontwarn javax.xml.stream.XMLStreamException
--dontwarn org.osgi.**
--dontwarn aQute.bnd.annotation.**

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -48,7 +48,7 @@ object FileUtils {
     private const val CSV_MIME_TYPE = "text/csv"
     // Fallback MIME type used when neither the file name extension nor
     // content sniffing can determine a type, matching the value used by
-    // most content-detection libraries (and previously Apache Tika) for
+    // most content-detection libraries for
     // unrecognized binary content.
     private const val DEFAULT_MIME_TYPE = "application/octet-stream"
     // Maximum dimension (width or height) allowed when decoding an image for
@@ -332,7 +332,7 @@ object FileUtils {
 
     // Sniffs [bytes] for a MIME type using URLConnection's built-in magic-number
     // detection. This is a best-effort fallback for when the file name has no
-    // usable extension, without pulling in a full content-detection dependency.
+    // usable extension.
     private fun guessMimeTypeFromBytes(bytes: ByteArray?): String? {
         if (bytes == null || bytes.isEmpty()) {
             return null

--- a/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -22,18 +22,16 @@ import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.apache.tika.Tika
-import org.apache.tika.io.TikaInputStream
-import org.apache.tika.metadata.Metadata
-import org.apache.tika.metadata.TikaCoreProperties
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
+import java.net.URLConnection
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -48,6 +46,11 @@ object FileUtils {
     // (see https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java#439)
     private const val CSV_EXTENSION = "csv"
     private const val CSV_MIME_TYPE = "text/csv"
+    // Fallback MIME type used when neither the file name extension nor
+    // content sniffing can determine a type, matching the value used by
+    // most content-detection libraries (and previously Apache Tika) for
+    // unrecognized binary content.
+    private const val DEFAULT_MIME_TYPE = "application/octet-stream"
     // Maximum dimension (width or height) allowed when decoding an image for
     // compression. Images larger than this are subsampled via
     // BitmapFactory.Options.inSampleSize to avoid excessive memory usage
@@ -303,28 +306,41 @@ object FileUtils {
     }
 
     fun getFileExtension(bytes: ByteArray?): String {
-        val tika = Tika()
-        val mimeType = tika.detect(bytes)
-        return mimeType.substringAfter("/")
+        val mimeType = guessMimeTypeFromBytes(bytes) ?: DEFAULT_MIME_TYPE
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+            ?: mimeType.substringAfter("/")
     }
 
     private fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
-        val tika = Tika()
-
-        val detectedType = if (fileName.isNullOrEmpty()) {
-            tika.detect(bytes)
-        } else {
-            val detector = tika.detector
-
-            val stream = TikaInputStream.get(bytes)
-            val metadata = Metadata()
-            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
-            detector.detect(stream, metadata).toString()
+        val extension = fileName?.substringAfterLast('.', "")
+        if (!extension.isNullOrEmpty()) {
+            if (extension.equals(CSV_EXTENSION, ignoreCase = true)) {
+                return CSV_MIME_TYPE
+            }
+            MimeTypeMap.getSingleton()
+                .getMimeTypeFromExtension(extension.lowercase(Locale.getDefault()))
+                ?.let { return it }
         }
-        return if (detectedType == "text/plain") {
+
+        val detectedType = guessMimeTypeFromBytes(bytes)
+        return if (detectedType == null || detectedType == "text/plain") {
             "*/*"
         } else {
             detectedType
+        }
+    }
+
+    // Sniffs [bytes] for a MIME type using URLConnection's built-in magic-number
+    // detection. This is a best-effort fallback for when the file name has no
+    // usable extension, without pulling in a full content-detection dependency.
+    private fun guessMimeTypeFromBytes(bytes: ByteArray?): String? {
+        if (bytes == null || bytes.isEmpty()) {
+            return null
+        }
+        return try {
+            ByteArrayInputStream(bytes).use { URLConnection.guessContentTypeFromStream(it) }
+        } catch (e: IOException) {
+            null
         }
     }
 


### PR DESCRIPTION
## Summary
- Removes the Apache Tika dependency (~300 KB) from the legacy `android/` implementation, used only to detect a MIME type for `saveFile()`.
- MIME types are now resolved from the file name extension via `MimeTypeMap` (with the existing CSV special-case preserved), falling back to `URLConnection.guessContentTypeFromStream` content sniffing only when the file name has no usable extension.
- Removes the now-unused Tika proguard rules and the `tika-core` dependency from `build.gradle.kts`.

Companion PRs:
- Backport of this same fix targeting the `11.0.x` line (based on `v11.0.2`).
- A separate PR applying the same fix to `file_picker_android` specifically.

Fixes #2101

## Test plan
- [x] `flutter build apk --debug` in `example/` compiles cleanly against this change.
- Java/Kotlin code in this plugin has no existing unit test harness (per `CONTRIBUTING.md`, native platform code is not currently unit tested), so verification was via compilation and manual review of the MIME-mapping logic against the previous Tika-based behavior.