### PR TITLE
fix(file_picker_android): remove Apache Tika dependency for MIME type detection

### DIFF
--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)
+
 ## 1.0.0
 
 - Initial release of Android implementation package for `file_picker`.

--- a/packages/file_picker_android/CHANGELOG.md
+++ b/packages/file_picker_android/CHANGELOG.md
@@ -1,7 +1,4 @@
-## 1.0.1
-
-- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)
-
 ## 1.0.0
 
 - Initial release of Android implementation package for `file_picker`.
+- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)

--- a/packages/file_picker_android/android/build.gradle.kts
+++ b/packages/file_picker_android/android/build.gradle.kts
@@ -83,6 +83,5 @@ dependencies {
     add("implementation", "androidx.core:core-ktx:1.18.0")
     add("implementation", "androidx.annotation:annotation:1.10.0")
     add("implementation", "androidx.lifecycle:lifecycle-runtime:2.10.0")
-    add("implementation", "org.apache.tika:tika-core:3.3.0")
 }
 

--- a/packages/file_picker_android/android/proguard-rules.pro
+++ b/packages/file_picker_android/android/proguard-rules.pro
@@ -1,8 +1,0 @@
-#TIKA PROGUARD RULES
--keep class org.apache.tika.** { *; }
--keep class javax.xml.stream.XMLResolver.** { *; }
--dontwarn javax.xml.stream.XMLInputFactory
--dontwarn javax.xml.stream.XMLResolver
--dontwarn javax.xml.stream.XMLStreamException
--dontwarn org.osgi.**
--dontwarn aQute.bnd.annotation.**

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -48,7 +48,7 @@ object FileUtils {
     private const val CSV_MIME_TYPE = "text/csv"
     // Fallback MIME type used when neither the file name extension nor
     // content sniffing can determine a type, matching the value used by
-    // most content-detection libraries (and previously Apache Tika) for
+    // most content-detection libraries for
     // unrecognized binary content.
     private const val DEFAULT_MIME_TYPE = "application/octet-stream"
     // Maximum dimension (width or height) allowed when decoding an image for
@@ -332,7 +332,7 @@ object FileUtils {
 
     // Sniffs [bytes] for a MIME type using URLConnection's built-in magic-number
     // detection. This is a best-effort fallback for when the file name has no
-    // usable extension, without pulling in a full content-detection dependency.
+    // usable extension.
     private fun guessMimeTypeFromBytes(bytes: ByteArray?): String? {
         if (bytes == null || bytes.isEmpty()) {
             return null

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -22,18 +22,16 @@ import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.apache.tika.Tika
-import org.apache.tika.io.TikaInputStream
-import org.apache.tika.metadata.Metadata
-import org.apache.tika.metadata.TikaCoreProperties
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
+import java.net.URLConnection
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -48,6 +46,11 @@ object FileUtils {
     // (see https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java#439)
     private const val CSV_EXTENSION = "csv"
     private const val CSV_MIME_TYPE = "text/csv"
+    // Fallback MIME type used when neither the file name extension nor
+    // content sniffing can determine a type, matching the value used by
+    // most content-detection libraries (and previously Apache Tika) for
+    // unrecognized binary content.
+    private const val DEFAULT_MIME_TYPE = "application/octet-stream"
     // Maximum dimension (width or height) allowed when decoding an image for
     // compression. Images larger than this are subsampled via
     // BitmapFactory.Options.inSampleSize to avoid excessive memory usage
@@ -303,28 +306,41 @@ object FileUtils {
     }
 
     fun getFileExtension(bytes: ByteArray?): String {
-        val tika = Tika()
-        val mimeType = tika.detect(bytes)
-        return mimeType.substringAfter("/")
+        val mimeType = guessMimeTypeFromBytes(bytes) ?: DEFAULT_MIME_TYPE
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+            ?: mimeType.substringAfter("/")
     }
 
     private fun getMimeTypeForBytes(fileName: String?, bytes: ByteArray?): String {
-        val tika = Tika()
-
-        val detectedType = if (fileName.isNullOrEmpty()) {
-            tika.detect(bytes)
-        } else {
-            val detector = tika.detector
-
-            val stream = TikaInputStream.get(bytes)
-            val metadata = Metadata()
-            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fileName)
-            detector.detect(stream, metadata).toString()
+        val extension = fileName?.substringAfterLast('.', "")
+        if (!extension.isNullOrEmpty()) {
+            if (extension.equals(CSV_EXTENSION, ignoreCase = true)) {
+                return CSV_MIME_TYPE
+            }
+            MimeTypeMap.getSingleton()
+                .getMimeTypeFromExtension(extension.lowercase(Locale.getDefault()))
+                ?.let { return it }
         }
-        return if (detectedType == "text/plain") {
+
+        val detectedType = guessMimeTypeFromBytes(bytes)
+        return if (detectedType == null || detectedType == "text/plain") {
             "*/*"
         } else {
             detectedType
+        }
+    }
+
+    // Sniffs [bytes] for a MIME type using URLConnection's built-in magic-number
+    // detection. This is a best-effort fallback for when the file name has no
+    // usable extension, without pulling in a full content-detection dependency.
+    private fun guessMimeTypeFromBytes(bytes: ByteArray?): String? {
+        if (bytes == null || bytes.isEmpty()) {
+            return null
+        }
+        return try {
+            ByteArrayInputStream(bytes).use { URLConnection.guessContentTypeFromStream(it) }
+        } catch (e: IOException) {
+            null
         }
     }
 

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_android
 description: Android implementation of the file_picker plugin.
-version: 1.0.1
+version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_android
 description: Android implementation of the file_picker plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 


### PR DESCRIPTION
## Summary
- Removes the Apache Tika dependency (~300 KB) from the federated `file_picker_android` package, used only to detect a MIME type for `saveFile()`.
- MIME types are now resolved from the file name extension via `MimeTypeMap` (with the existing CSV special-case preserved), falling back to `URLConnection.guessContentTypeFromStream` content sniffing only when the file name has no usable extension.
- Removes the now-unused Tika proguard rules and the `tika-core` dependency from `build.gradle.kts`.
- Bumps `file_picker_android` to `1.0.1` with a CHANGELOG entry.

This is the `file_picker_android`-specific PR requested in #2101, as a companion to:
- The equivalent fix for the still-bundled legacy `android/` implementation on `master`.
- A backport of the same fix targeting the `11.0.x` line (based on `v11.0.2`).

Fixes #2101

## Test plan
- [x] The Kotlin change mirrors the identical fix already verified to compile cleanly in the legacy `android/` implementation (same imports, same dependency versions).
- This package has no example app of its own in the repo, so the change wasn't independently exercised through a full Gradle build here — it's textually identical to the already-verified fix.