### PR TITLE
docs: attribute Tika removal to the 11.0.3 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Android
 - Decodes images with `inSampleSize` in `compressImage` to prevent excessive memory usage and `OutOfMemoryError` on large images. [#2083](https://github.com/miguelpruivo/flutter_file_picker/pull/2083)
-- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)
 
 ### Desktop & Web
 - Added `WindowsOptions` (with `parentWindowHandle` and `lockParentWindow`), `LinuxOptions` (with `parentWindow` and `lockParentWindow`), and `WebOptions` (with `cancelUploadOnWindowBlur`). [#2079](https://github.com/miguelpruivo/flutter_file_picker/pull/2079)
@@ -98,6 +97,10 @@
 
 ### Web
 - Fixed `pickFiles()` default `withData` behavior in the public API to correctly default to `true` on web when not explicitly provided. [#1987](https://github.com/miguelpruivo/flutter_file_picker/issues/1987)
+
+## 11.0.3
+### Android
+- Removed the Apache Tika dependency (~300 KB) used for MIME type detection in `saveFile()`. MIME types are now resolved from the file name extension via `MimeTypeMap`, with `URLConnection.guessContentTypeFromStream` as a content-sniffing fallback when no extension is available. [#2101](https://github.com/miguelpruivo/flutter_file_picker/issues/2101)
 
 ## 11.0.2
 ### Android


### PR DESCRIPTION
## Summary
Follow-up to #2104, which merged before this correction landed on that branch.

The Tika-removal fix targets the v11.x hotfix release (per discussion on #2104), so its CHANGELOG entry should sit under its own `11.0.3` heading rather than the unreleased `12.0.0-beta.8` bucket. This moves it there, positioned above `11.0.2` to match release chronology.

No code changes — `CHANGELOG.md` only.