### PR TITLE
Refactor federated plugin

### DIFF
--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FilePickerPlugin.kt
@@ -123,7 +123,8 @@ class FilePickerPlugin : MethodCallHandler, FlutterPlugin,
 
         when (method) {
             "clear" -> {
-                result.success(activity?.applicationContext?.let { clearCache(it) })
+                activity?.applicationContext?.let { clearCache(it) }
+                result.success(null)
             }
 
             "releaseSafGrant" -> {

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -204,55 +204,43 @@ object FileUtils {
         if (type == "dir") {
             intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
         } else {
-            if (type == "image/*") {
-                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
-                    type = this@startFileExplorer.type
-                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
-                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
+            intent = when (type) {
+                "image/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
+                    this.type = this@startFileExplorer.type
                     if (!allowedExtensions.isNullOrEmpty()) {
                         putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
                     }
                 }
-            }
-            else if (type == "audio/*" ){
-                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                "audio/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
                     this.type = this@startFileExplorer.type
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
-                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         val authority = "com.android.providers.media.documents"
                         val audioRootUri = DocumentsContract.buildRootUri(authority, "audio_root")
                         putExtra(DocumentsContract.EXTRA_INITIAL_URI, audioRootUri)
                     }
                 }
-            } else if(type == "video/*"){
-                intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                "video/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
                     this.type = this@startFileExplorer.type
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this@startFileExplorer.isMultipleSelection)
-                    putExtra("multi-pick", this@startFileExplorer.isMultipleSelection)
                 }
-            }
-            else if (type == "media") {
-                intent = Intent(Intent.ACTION_GET_CONTENT)
-                intent.type = "*/*"
-                val mimeTypes = arrayOf("image/*", "video/*", "audio/*")
-                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
-                intent.addCategory(Intent.CATEGORY_OPENABLE)
-                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, this.isMultipleSelection)
-            } else {
-                intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                "media" -> Intent(Intent.ACTION_GET_CONTENT).apply {
+                    this.type = "*/*"
+                    putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("image/*", "video/*", "audio/*"))
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    type = this@startFileExplorer.type
+                }
+                else -> Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    this.type = this@startFileExplorer.type
                     if (!allowedExtensions.isNullOrEmpty()) {
                         putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
                     } else {
                         putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(type))
                     }
-                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection)
-                    putExtra("multi-pick", isMultipleSelection)
                 }
+            }.apply {
+                putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultipleSelection)
+                putExtra("multi-pick", isMultipleSelection)
             }
         }
         if (intent.resolveActivity(activity.packageManager) != null) {

--- a/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
+++ b/packages/file_picker_android/android/src/main/kotlin/com/mr/flutter/plugin/filepicker/FileUtils.kt
@@ -206,13 +206,13 @@ object FileUtils {
         } else {
             intent = when (type) {
                 "image/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = this@startFileExplorer.type
+                    type = this@startFileExplorer.type
                     if (!allowedExtensions.isNullOrEmpty()) {
                         putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
                     }
                 }
                 "audio/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = this@startFileExplorer.type
+                    type = this@startFileExplorer.type
                     addCategory(Intent.CATEGORY_OPENABLE)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         val authority = "com.android.providers.media.documents"
@@ -221,17 +221,17 @@ object FileUtils {
                     }
                 }
                 "video/*" -> Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = this@startFileExplorer.type
+                    type = this@startFileExplorer.type
                     addCategory(Intent.CATEGORY_OPENABLE)
                 }
                 "media" -> Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = "*/*"
+                    type = "*/*"
                     putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("image/*", "video/*", "audio/*"))
                     addCategory(Intent.CATEGORY_OPENABLE)
                 }
                 else -> Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    this.type = this@startFileExplorer.type
+                    type = this@startFileExplorer.type
                     if (!allowedExtensions.isNullOrEmpty()) {
                         putExtra(Intent.EXTRA_MIME_TYPES, allowedExtensions!!.toTypedArray())
                     } else {

--- a/packages/file_picker_android/lib/src/android_platform_file.dart
+++ b/packages/file_picker_android/lib/src/android_platform_file.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:path/path.dart' as p;
 
 import 'android_saf_handle.dart';
 
@@ -18,9 +19,26 @@ base class AndroidPlatformFile extends PlatformFile {
        _bytesLength = bytesLength;
 
   factory AndroidPlatformFile.fromMap(Map<Object?, Object?> data) {
-    final String name = data['name'] as String? ?? '';
     final String path = data['path'] as String? ?? '';
-    final Uri uri = Uri.tryParse(path) ?? Uri.file(path);
+    final String rawName = data['name'] as String? ?? '';
+    final String name = rawName.isNotEmpty
+        ? rawName
+        : (path.isNotEmpty ? p.basename(path) : '');
+
+    if (path.isEmpty && data['uri'] == null) {
+      throw ArgumentError(
+        'path or uri cannot be empty when creating AndroidPlatformFile',
+      );
+    }
+    if (name.isEmpty) {
+      throw ArgumentError(
+        'name cannot be empty when creating AndroidPlatformFile',
+      );
+    }
+
+    final Uri uri = path.contains('://')
+        ? (Uri.tryParse(path) ?? Uri.file(path))
+        : Uri.file(path);
 
     AndroidSAFHandle? safHandle;
     if (data case {'safHandle': final Map<Object?, Object?> safMap}) {
@@ -84,15 +102,14 @@ base class AndroidPlatformFile extends PlatformFile {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    if (other is! AndroidPlatformFile) return false;
-    return super == other &&
+    return other is AndroidPlatformFile &&
         other.name == name &&
         other.uri == uri &&
         other.safHandle == safHandle;
   }
 
   @override
-  int get hashCode => Object.hash(super.hashCode, name, uri, safHandle);
+  int get hashCode => Object.hash(name, uri, safHandle);
 
   @override
   String toString() {

--- a/packages/file_picker_android/lib/src/file_picker_android.dart
+++ b/packages/file_picker_android/lib/src/file_picker_android.dart
@@ -44,7 +44,8 @@ class FilePickerAndroid extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
-    final files = await pickFiles(
+    final files = await _pickFilesInternal(
+      allowMultiple: false,
       dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,
@@ -69,6 +70,28 @@ class FilePickerAndroid extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
+    return _pickFilesInternal(
+      allowMultiple: true,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      androidOptions: androidOptions,
+    );
+  }
+
+  Future<List<PlatformFile>> _pickFilesInternal({
+    required bool allowMultiple,
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const FilePickerAndroidOptions(),
+  }) async {
     final String typeName = type.name;
 
     try {
@@ -89,11 +112,10 @@ class FilePickerAndroid extends FilePickerPlatform {
       };
 
       final List<Map>? result = await methodChannel.invokeListMethod(typeName, {
-        'allowMultipleSelection': true,
+        'allowMultipleSelection': allowMultiple,
         'allowedExtensions': allowedExtensions,
-        'withData': false,
         'compressionQuality': compressionQuality,
-        'androidSafOptions': ?safOptionsMap,
+        'androidSafOptions': safOptionsMap,
       });
 
       if (result == null) {
@@ -146,7 +168,7 @@ class FilePickerAndroid extends FilePickerPlatform {
       };
 
       return await methodChannel.invokeMethod<String>('dir', {
-        'androidSafOptions': ?safOptionsMap,
+        'androidSafOptions': safOptionsMap,
       });
     } on PlatformException catch (ex) {
       if (ex.code == "unknown_path") {

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
     sdk: flutter
   file_picker_platform_interface: ^1.0.0
   cross_file: ^0.3.5+4
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_picker_android/test/file_picker_android_test.dart
+++ b/packages/file_picker_android/test/file_picker_android_test.dart
@@ -35,5 +35,28 @@ void main() {
       );
       expect(handle.accessMode, equals(AndroidSAFAccessMode.readWrite));
     });
+
+    test('AndroidPlatformFile derives name from path if name is empty', () {
+      final file = AndroidPlatformFile.fromMap({'path': '/tmp/test_file.txt'});
+      expect(file.name, equals('test_file.txt'));
+      expect(file.path, equals('/tmp/test_file.txt'));
+    });
+
+    test('AndroidPlatformFile throws ArgumentError on empty path and uri', () {
+      expect(() => AndroidPlatformFile.fromMap({}), throwsArgumentError);
+    });
+
+    test('AndroidPlatformFile equality and hashCode work correctly', () {
+      final file1 = AndroidPlatformFile(
+        name: 'test.txt',
+        uri: Uri.file('/tmp/test.txt'),
+      );
+      final file2 = AndroidPlatformFile(
+        name: 'test.txt',
+        uri: Uri.file('/tmp/test.txt'),
+      );
+      expect(file1, equals(file2));
+      expect(file1.hashCode, equals(file2.hashCode));
+    });
   });
 }

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
@@ -20,6 +20,12 @@ final class IOSFilePickerHandler: NSObject,
     private var isSaveFile = false
 
     func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if call.method == "clear" {
+            _ = clearTemporaryFiles()
+            result(nil)
+            return
+        }
+
         if self.result != nil {
             result(
                 FlutterError(
@@ -30,12 +36,6 @@ final class IOSFilePickerHandler: NSObject,
         }
 
         self.result = result
-
-        if call.method == "clear" {
-            _ = clearTemporaryFiles()
-            result(nil)
-            return
-        }
 
         if call.method == "dir" {
             isDirectoryPicker = true

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/IOSFilePickerHandler.swift
@@ -32,8 +32,8 @@ final class IOSFilePickerHandler: NSObject,
         self.result = result
 
         if call.method == "clear" {
-            self.result?(clearTemporaryFiles())
-            self.result = nil
+            _ = clearTemporaryFiles()
+            result(nil)
             return
         }
 

--- a/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
+++ b/packages/file_picker_darwin/darwin/file_picker_darwin/Sources/file_picker_darwin/MacOSFilePickerHandler.swift
@@ -37,6 +37,9 @@ final class MacOSFilePickerHandler {
         case "saveFile":
             handleSaveFile(call, result: result)
 
+        case "clear":
+            result(nil)
+
         case "skipEntitlementsChecks":
             skipEntitlementsChecks = true
             result(nil)

--- a/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
+++ b/packages/file_picker_darwin/lib/src/darwin_platform_file.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:path/path.dart' as p;
 
 /// A [PlatformFile] implementation for Apple platforms (iOS and macOS).
 base class DarwinPlatformFile extends PlatformFile {
@@ -15,9 +16,26 @@ base class DarwinPlatformFile extends PlatformFile {
        _bytesLength = bytesLength;
 
   factory DarwinPlatformFile.fromMap(Map<Object?, Object?> data) {
-    final String name = data['name'] as String? ?? '';
     final String path = data['path'] as String? ?? '';
-    final Uri uri = Uri.tryParse(path) ?? Uri.file(path);
+    final String rawName = data['name'] as String? ?? '';
+    final String name = rawName.isNotEmpty
+        ? rawName
+        : (path.isNotEmpty ? p.basename(path) : '');
+
+    if (path.isEmpty && data['uri'] == null) {
+      throw ArgumentError(
+        'path or uri cannot be empty when creating DarwinPlatformFile',
+      );
+    }
+    if (name.isEmpty) {
+      throw ArgumentError(
+        'name cannot be empty when creating DarwinPlatformFile',
+      );
+    }
+
+    final Uri uri = path.contains('://')
+        ? (Uri.tryParse(path) ?? Uri.file(path))
+        : Uri.file(path);
     final Uint8List? bytes = data['bytes'] as Uint8List?;
 
     return DarwinPlatformFile(
@@ -71,12 +89,13 @@ base class DarwinPlatformFile extends PlatformFile {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    if (other is! DarwinPlatformFile) return false;
-    return super == other && other.name == name && other.uri == uri;
+    return other is DarwinPlatformFile &&
+        other.name == name &&
+        other.uri == uri;
   }
 
   @override
-  int get hashCode => Object.hash(super.hashCode, name, uri);
+  int get hashCode => Object.hash(name, uri);
 
   @override
   String toString() {

--- a/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
+++ b/packages/file_picker_darwin/lib/src/file_picker_darwin.dart
@@ -43,7 +43,8 @@ class FilePickerDarwin extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
-    final files = await pickFiles(
+    final files = await _pickFilesInternal(
+      allowMultiple: false,
       dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,
@@ -67,6 +68,26 @@ class FilePickerDarwin extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
+    return _pickFilesInternal(
+      allowMultiple: true,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+    );
+  }
+
+  Future<List<PlatformFile>> _pickFilesInternal({
+    required bool allowMultiple,
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+  }) async {
     final String typeName = type.name;
 
     try {
@@ -83,9 +104,8 @@ class FilePickerDarwin extends FilePickerPlatform {
 
       final List<Map<Object?, Object?>>? result = await methodChannel
           .invokeListMethod<Map<Object?, Object?>>(typeName, {
-            'allowMultipleSelection': true,
+            'allowMultipleSelection': allowMultiple,
             'allowedExtensions': allowedExtensions,
-            'withData': false,
             'compressionQuality': compressionQuality,
           });
 
@@ -142,7 +162,7 @@ class FilePickerDarwin extends FilePickerPlatform {
 
   @override
   Future<void> clearTemporaryFiles() async {
-    await methodChannel.invokeMethod<bool>('clear');
+    await methodChannel.invokeMethod<void>('clear');
   }
 
   @override

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
     sdk: flutter
   file_picker_platform_interface: ^1.0.0
   cross_file: ^0.3.5+4
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_picker_linux/lib/src/file_picker_linux.dart
+++ b/packages/file_picker_linux/lib/src/file_picker_linux.dart
@@ -53,7 +53,8 @@ class FilePickerLinux extends FilePickerPlatform {
     LinuxOptions linuxOptions = const FilePickerLinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
-    final files = await pickFiles(
+    final files = await _pickFilesInternal(
+      allowMultiple: false,
       dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,
@@ -78,6 +79,28 @@ class FilePickerLinux extends FilePickerPlatform {
     LinuxOptions linuxOptions = const FilePickerLinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
+    return _pickFilesInternal(
+      allowMultiple: true,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      linuxOptions: linuxOptions,
+    );
+  }
+
+  Future<List<PlatformFile>> _pickFilesInternal({
+    required bool allowMultiple,
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    LinuxOptions linuxOptions = const FilePickerLinuxOptions(),
+  }) async {
     final FilePickerLinuxOptions options = switch (linuxOptions) {
       FilePickerLinuxOptions opts => opts,
       _ => const FilePickerLinuxOptions(),
@@ -86,7 +109,7 @@ class FilePickerLinux extends FilePickerPlatform {
     final filter = Filter(type, allowedExtensions);
     Map<String, DBusValue> xdpOption = {
       'handle_token': DBusString('flutter_picker'),
-      'multiple': DBusBoolean(true),
+      'multiple': DBusBoolean(allowMultiple),
       'modal': DBusBoolean(options.lockParentWindow),
       'filters': filter.toDBusArray(),
     };

--- a/packages/file_picker_linux/lib/src/linux_platform_file.dart
+++ b/packages/file_picker_linux/lib/src/linux_platform_file.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+import 'package:path/path.dart' as p;
 
 /// A [PlatformFile] implementation for Linux.
 base class LinuxPlatformFile extends PlatformFile {
@@ -15,8 +16,13 @@ base class LinuxPlatformFile extends PlatformFile {
        _bytesLength = bytesLength;
 
   factory LinuxPlatformFile.fromPath(String path, {Uint8List? bytes}) {
+    if (path.isEmpty) {
+      throw ArgumentError(
+        'path cannot be empty when creating LinuxPlatformFile',
+      );
+    }
     final uri = Uri.file(path);
-    final name = uri.pathSegments.lastOrNull ?? path;
+    final name = p.posix.basename(path);
     return LinuxPlatformFile(
       name: name,
       uri: uri,

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   file_picker_platform_interface: ^1.0.0
   cross_file: ^0.3.5+4
   dbus: ^0.7.14
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
+++ b/packages/file_picker_platform_interface/lib/src/file_picker_platform_interface.dart
@@ -133,10 +133,10 @@ abstract class FilePickerPlatform extends PlatformInterface {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
 
-  /// Clear the temporary files created by the underlying file picker.
-  Future<void> clearTemporaryFiles() async {
-    throw UnimplementedError('clearTemporaryFiles() has not been implemented.');
-  }
+  /// Asks the underlying platform to remove any temporary files created by this plugin.
+  ///
+  /// Default implementation is a no-op for platforms that do not create temporary files.
+  Future<void> clearTemporaryFiles() async {}
 
   /// Save the given [bytes] to a file with the given [fileName], using the native save file dialog.
   ///

--- a/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
+++ b/packages/file_picker_platform_interface/test/file_picker_platform_interface_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(FilePickerPlatform.instance, instance);
     });
 
-    test('Default implementations throw UnimplementedError', () async {
+    test('Default implementations throw UnimplementedError or no-op', () async {
       final ExtendsFilePickerPlatform instance = ExtendsFilePickerPlatform();
       expect(() => instance.pickFile(), throwsUnimplementedError);
       expect(() => instance.pickFiles(), throwsUnimplementedError);
@@ -32,7 +32,7 @@ void main() {
         () => instance.pickFileAndDirectoryPaths(),
         throwsUnimplementedError,
       );
-      expect(() => instance.clearTemporaryFiles(), throwsUnimplementedError);
+      expect(instance.clearTemporaryFiles(), completes);
       expect(() => instance.getDirectoryPath(), throwsUnimplementedError);
       expect(
         () => instance.saveFile(

--- a/packages/file_picker_web/lib/src/web_platform_file.dart
+++ b/packages/file_picker_web/lib/src/web_platform_file.dart
@@ -23,7 +23,8 @@ base class WebPlatformFile extends PlatformFile {
     int? bytesLength,
     Uint8List? bytes,
     Stream<Uint8List>? readStream,
-  }) : _xFile = xFile,
+  }) : assert(name.isNotEmpty, 'name cannot be empty'),
+       _xFile = xFile,
        _bytesLength = bytesLength,
        _bytes = bytes,
        _readStream = readStream;

--- a/packages/file_picker_web/lib/src/web_platform_file.dart
+++ b/packages/file_picker_web/lib/src/web_platform_file.dart
@@ -23,11 +23,14 @@ base class WebPlatformFile extends PlatformFile {
     int? bytesLength,
     Uint8List? bytes,
     Stream<Uint8List>? readStream,
-  }) : assert(name.isNotEmpty, 'name cannot be empty'),
-       _xFile = xFile,
+  }) : _xFile = xFile,
        _bytesLength = bytesLength,
        _bytes = bytes,
-       _readStream = readStream;
+       _readStream = readStream {
+    if (name.isEmpty) {
+      throw ArgumentError('name cannot be empty');
+    }
+  }
 
   /// The name of the file including extension.
   @override

--- a/packages/file_picker_windows/lib/src/file_picker_windows.dart
+++ b/packages/file_picker_windows/lib/src/file_picker_windows.dart
@@ -63,7 +63,8 @@ class FilePickerWindows extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
-    final files = await pickFiles(
+    final files = await _pickFilesInternal(
+      allowMultiple: false,
       dialogTitle: dialogTitle,
       initialDirectory: initialDirectory,
       type: type,
@@ -88,6 +89,28 @@ class FilePickerWindows extends FilePickerPlatform {
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),
   }) async {
+    return _pickFilesInternal(
+      allowMultiple: true,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+      type: type,
+      allowedExtensions: allowedExtensions,
+      onFileLoading: onFileLoading,
+      compressionQuality: compressionQuality,
+      windowsOptions: windowsOptions,
+    );
+  }
+
+  Future<List<PlatformFile>> _pickFilesInternal({
+    required bool allowMultiple,
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    WindowsOptions windowsOptions = const FilePickerWindowsOptions(),
+  }) async {
     final FilePickerWindowsOptions options = switch (windowsOptions) {
       FilePickerWindowsOptions opts => opts,
       _ => const FilePickerWindowsOptions(),
@@ -102,7 +125,7 @@ class FilePickerWindows extends FilePickerPlatform {
         initialDirectory: initialDirectory,
         type: type,
         allowedExtensions: allowedExtensions,
-        allowMultiple: true,
+        allowMultiple: allowMultiple,
         lockParentWindow: options.lockParentWindow,
         parentWindowHandle: options.parentWindowHandle,
       ),

--- a/packages/file_picker_windows/lib/src/windows_platform_file.dart
+++ b/packages/file_picker_windows/lib/src/windows_platform_file.dart
@@ -16,6 +16,11 @@ base class WindowsPlatformFile extends PlatformFile {
        _bytesLength = bytesLength;
 
   factory WindowsPlatformFile.fromPath(String path, {Uint8List? bytes}) {
+    if (path.isEmpty) {
+      throw ArgumentError(
+        'path cannot be empty when creating WindowsPlatformFile',
+      );
+    }
     final uri = Uri.file(path, windows: true);
     final name = p.windows.basename(path);
     return WindowsPlatformFile(


### PR DESCRIPTION
## Description

This PR addresses [all items noted](https://github.com/miguelpruivo/flutter_file_picker/issues/1932#issuecomment-5128017014) in @navaronbracke's checklist for the federated plugin refactoring:

### 1. `file_picker_platform_interface` & `PlatformFile` Subclasses
- Made `FilePickerPlatform.clearTemporaryFiles()` a no-op by default.
- Removed dead parameters (`withData`, `withReadStream`) from native platform invocations.
- Removed `super == other` and `super.hashCode` in `operator ==` and `hashCode` across all `PlatformFile` subclasses (`AndroidPlatformFile`, `DarwinPlatformFile`, `LinuxPlatformFile`, `WindowsPlatformFile`, `WebPlatformFile`).
- Added validation throwing `ArgumentError` when constructing `PlatformFile` subclasses with empty `name`/`path`.
- Used `package:path`'s `basename()` to derive `name` when `name` is omitted but `path` is present.

### 2. Isolated `allowMultiple` Handling
- Updated `pickFile()` across all platform implementations (`FilePickerAndroid`, `FilePickerDarwin`, `FilePickerLinux`, `FilePickerWindows`, `FilePickerWeb`) so it no longer implicitly passes `allowMultiple: true` via delegation to `pickFiles()`. Instead, a private helper is reused with explicit `allowMultiple` flags.

### 3. `file_picker_android` (Kotlin)
- Cleaned up `Intent` creation logic for `allowMultiple`.
- Updated `clear` method in `FilePickerPlugin.kt` to return `result.success(null)`.

### 4. `file_picker_darwin` (Swift)
- Updated `clear` method in `IOSFilePickerHandler.swift` and `MacOSFilePickerHandler.swift` to invoke `result(nil)`.