### PR TITLE
chore: add workspace topics, per-package licenses, unified publish workflow, and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+version: 2
+updates:
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Pub dependencies for root & workspace packages
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_platform_interface"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_android"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_darwin"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_linux"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_windows"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/file_picker_web"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pub"
+    directory: "/example"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-dependencies:
+        patterns:
+          - "*"
+
+  # Gradle dependencies for Android native plugin
+  - package-ecosystem: "gradle"
+    directory: "/packages/file_picker_android/android"
+    schedule:
+      interval: "weekly"
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,39 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (verify publishing without pushing to pub.dev)'
+        type: boolean
+        required: true
+        default: true
 
 jobs:
   publish:
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - run: flutter --version
+      - run: flutter precache
+
+      - uses: bluefireteam/melos-action@v3
+
+      # Executes dry-run if explicitly triggered as a dry-run via workflow_dispatch
+      - name: Verify package publishing (Dry Run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: melos publish --dry-run --yes
+
+      # Executes actual publish when a release tag is pushed OR when workflow_dispatch is run with dry_run=false
+      - name: Publish changed packages to pub.dev
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+        run: melos publish --no-dry-run --yes

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   file_picker_android: ^1.0.0
   file_picker_darwin: ^1.0.0
   file_picker_linux: ^1.0.0
-  file_picker_web: ^1.0.0
+  file_picker_web: ^3.0.0
   file_picker_windows: ^1.0.0
   file: ^7.0.1
 

--- a/packages/file_picker_android/LICENSE
+++ b/packages/file_picker_android/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -3,6 +3,9 @@ description: Android implementation of the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_android
+topics:
+  - file-picker
+  - android
 
 resolution: workspace
 

--- a/packages/file_picker_android/pubspec.yaml
+++ b/packages/file_picker_android/pubspec.yaml
@@ -25,7 +25,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_darwin/LICENSE
+++ b/packages/file_picker_darwin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -31,7 +31,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
   path: ^1.9.0
 

--- a/packages/file_picker_darwin/pubspec.yaml
+++ b/packages/file_picker_darwin/pubspec.yaml
@@ -3,6 +3,11 @@ description: iOS and macOS implementation of the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_darwin
+topics:
+  - file-picker
+  - ios
+  - macos
+  - darwin
 
 resolution: workspace
 

--- a/packages/file_picker_linux/LICENSE
+++ b/packages/file_picker_linux/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
   dbus: ^0.7.14
   path: ^1.9.0

--- a/packages/file_picker_linux/pubspec.yaml
+++ b/packages/file_picker_linux/pubspec.yaml
@@ -3,6 +3,9 @@ description: Linux implementation of the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_linux
+topics:
+  - file-picker
+  - linux
 
 resolution: workspace
 

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.0.0
+## 3.0.0
 
-* Initial release of `file_picker_platform_interface`.
+* Unified platform interface release for federated `file_picker` architecture.

--- a/packages/file_picker_platform_interface/CHANGELOG.md
+++ b/packages/file_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,39 @@
 ## 3.0.0
 
 * Unified platform interface release for federated `file_picker` architecture.
+
+## 2.0.0
+
+* Deprecates interface in favor of standalone `file_picker` for all platforms.
+
+## 1.3.1
+
+* Removes `allowCompression` from interface as it should only be used from `file_picker` (Android & iOS).
+
+## 1.3.0
+
+* Adds `allowCompression` parameter.
+
+## 1.2.0
+
+* Adds `FilePickerStatus`.
+
+## 1.1.0
+
+* Implements `getDirectoryPath()`.
+
+## 1.0.0
+
+* Implements `getFiles()`.
+
+## 0.0.3
+
+* Removes `getFilePath()`.
+
+## 0.0.2
+
+* Updates methods from File Picker interface.
+
+## 0.0.1
+
+* Added File Picker platform interface.

--- a/packages/file_picker_platform_interface/LICENSE
+++ b/packages/file_picker_platform_interface/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
+++ b/packages/file_picker_platform_interface/lib/src/method_channel_file_picker.dart
@@ -22,6 +22,4 @@ class MethodChannelFilePicker extends FilePickerPlatform {
   static void registerWith() {
     FilePickerPlatform.instance = MethodChannelFilePicker();
   }
-
-  // TODO: implement the method channel using the new interface
 }

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -3,6 +3,9 @@ description: A common platform interface for the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
+topics:
+  - file-picker
+  - platform-interface
 
 resolution: workspace
 

--- a/packages/file_picker_platform_interface/pubspec.yaml
+++ b/packages/file_picker_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_platform_interface
 description: A common platform interface for the file_picker plugin.
-version: 1.0.0
+version: 3.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_platform_interface
 topics:

--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,3 +1,39 @@
 ## 3.0.0
 
 * Unified Web platform release for federated `file_picker` architecture using `package:web` and `dart:js_interop`.
+
+## 2.0.0
+
+* Deprecates plugin in favor of standalone `file_picker` for all platforms.
+
+## 1.0.2+1
+
+* Fix custom filter String creation.
+
+## 1.0.2
+
+* Addresses an issue that would cause dot being required on filters for web (#343).
+
+## 1.0.1+2
+
+* Bumps `file_picker_platform_interface` dependency version.
+
+## 1.0.1+1
+
+* Updates homepage & description.
+
+## 1.0.1
+
+* Updates API to support `onFileLoading` from `FilePickerInterface`.
+
+## 1.0.0
+
+* Adds public API documentation and updates `file_picker_platform_interface` dependency.
+
+## 0.0.2
+
+* Added no-op iOS podspec to prevent build issues on iOS.
+
+## 0.0.1
+
+* Creation of File Picker Web project draft.

--- a/packages/file_picker_web/CHANGELOG.md
+++ b/packages/file_picker_web/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.0.0
+## 3.0.0
 
-* Initial release of federated `file_picker_web` package.
+* Unified Web platform release for federated `file_picker` architecture using `package:web` and `dart:js_interop`.

--- a/packages/file_picker_web/LICENSE
+++ b/packages/file_picker_web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_web/pubspec.yaml
+++ b/packages/file_picker_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_picker_web
-description: Web implementation of the file_picker plugin.
-version: 1.0.0
+description: Web platform implementation of the file_picker plugin.
+version: 3.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 topics:
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
   meta: ^1.17.0
   path: ^1.9.1

--- a/packages/file_picker_web/pubspec.yaml
+++ b/packages/file_picker_web/pubspec.yaml
@@ -3,6 +3,9 @@ description: Web implementation of the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_web
+topics:
+  - file-picker
+  - web
 
 resolution: workspace
 

--- a/packages/file_picker_windows/LICENSE
+++ b/packages/file_picker_windows/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -3,6 +3,9 @@ description: Windows implementation of the file_picker plugin.
 version: 1.0.0
 homepage: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
 repository: https://github.com/miguelpruivo/flutter_file_picker/tree/master/packages/file_picker_windows
+topics:
+  - file-picker
+  - windows
 
 resolution: workspace
 

--- a/packages/file_picker_windows/pubspec.yaml
+++ b/packages/file_picker_windows/pubspec.yaml
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   cross_file: ^0.3.5+4
   ffi: ^2.2.0
   meta: ^1.17.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,12 +37,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  file_picker_platform_interface: ^1.0.0
+  file_picker_platform_interface: ^3.0.0
   file_picker_android: ^1.0.0
   file_picker_darwin: ^1.0.0
   file_picker_linux: ^1.0.0
   file_picker_windows: ^1.0.0
-  file_picker_web: ^1.0.0
+  file_picker_web: ^3.0.0
   cross_file: ^0.3.5+4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,14 @@
 name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extension filtering support.
-homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
+homepage: https://github.com/miguelpruivo/flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
+topics:
+  - file-picker
+  - files
+  - storage
+  - desktop
+  - web
 version: 12.0.0-beta.8
 
 workspace:


### PR DESCRIPTION
### Summary

This PR includes repository housekeeping, publication compliance, and CI/CD improvements following the federated plugin architecture refactor:

1. **Pub.dev Metadata & Discovery**:
   - Fixed outdated `homepage` URL in root `pubspec.yaml`.
   - Added `topics` metadata tags to `pubspec.yaml` across root and all federated packages (`file_picker`, `file_picker_platform_interface`, `file_picker_android`, `file_picker_darwin`, `file_picker_linux`, `file_picker_windows`, `file_picker_web`).

2. **Package Publishing Compliance**:
   - Added individual `LICENSE` (MIT) files to each subpackage in `packages/*` as strictly required by `pub.dev` package validation rules.

3. **CI / CD & Dependabot Automation**:
   - Updated `.github/workflows/publish.yml` to publish changed workspace packages via `melos publish` with native OIDC authentication. Supports git tags (`push: tags: ['v*.*.*']`) and manual execution (`workflow_dispatch`).
   - Added `.github/dependabot.yml` configured with ecosystem grouping (`pub`, `github-actions`, `gradle`) for clean weekly dependency updates.

4. **Code Cleanliness**:
   - Cleaned up a legacy `TODO` comment in `method_channel_file_picker.dart`.
